### PR TITLE
Contributors leaderboard widget endpoint

### DIFF
--- a/frontend/server/api/project/[slug]/contributors/contributor-leaderboard.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/contributor-leaderboard.get.ts
@@ -40,7 +40,6 @@ export default defineEventHandler(async (event) => {
     total: 100
   };
 
-  // Create filter from query params
   const filter: ContributorsLeaderboardFilter = {
     metric: (query.metric as ContributorsLeaderboardFilterMetric) || ContributorsLeaderboardFilterMetric.ALL,
     repository: query.repository as string,

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -1,17 +1,21 @@
 // This creates a Tinybird data source for fetching active contributors' data.
 // If we ever need to change the data source, we can do it here, and we won't have to change the API code.
 
-import type {ActiveContributorsFilter} from "~~/server/data/types";
+import type {ActiveContributorsFilter, ContributorsLeaderboardFilter} from "~~/server/data/types";
 import type {ActiveContributorsResponse} from "~~/server/data/tinybird/active-contributors-data-source";
+import type {ContributorsLeaderboardResponse} from "~~/server/data/tinybird/contributors-leaderboard-source";
 
 import {fetchActiveContributors} from "~~/server/data/tinybird/active-contributors-data-source";
+import {fetchContributorsLeaderboard} from "~~/server/data/tinybird/contributors-leaderboard-source";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
+    fetchContributorsLeaderboard: (filter: ContributorsLeaderboardFilter) => Promise<ContributorsLeaderboardResponse>;
 }
 
 export function createDataSource(): DataSource {
     return {
-        fetchActiveContributors
+        fetchActiveContributors,
+        fetchContributorsLeaderboard
     };
 }

--- a/frontend/server/data/tinybird/active-contributors-data-source.ts
+++ b/frontend/server/data/tinybird/active-contributors-data-source.ts
@@ -76,7 +76,7 @@ export async function fetchActiveContributors(filter: ActiveContributorsFilter) 
   let processedData: ActiveContributorsResponseData = [];
   if (data !== undefined) {
     processedData = (data as TinybirdResponse<TinybirdActiveContributorsData>)?.data.map(
-      (item): ActiveContributorsResponseData[0] => ({
+      (item): ActiveContributorsDataPoint => ({
         startDate: item.startDate,
         endDate: item.endDate,
         contributors: item.contributorCount

--- a/frontend/server/data/tinybird/contributors-leaderboard-source.ts
+++ b/frontend/server/data/tinybird/contributors-leaderboard-source.ts
@@ -1,0 +1,59 @@
+import type {ContributorsLeaderboardFilter} from "~~/server/data/types";
+import {fetchFromTinybird, type TinybirdResponse} from "~~/server/data/tinybird/tinybird";
+
+export type ContributorsLeaderboardDataPoint = {
+  avatar: string | undefined; // URL of the user's profile pic or avatar.
+  name: string; // Full name of the contributor
+  contributions: number; // Total number of contributions
+  contributionValue: number; // Value of the contribution
+}
+export type ContributorsLeaderboardData = ContributorsLeaderboardDataPoint[];
+export type ContributorsLeaderboardResponse = {
+  meta: {
+    offset: number;
+    limit: number;
+    total: number;
+  },
+  data: ContributorsLeaderboardData
+}
+
+type TinybirdContributorsLeaderboardData = {
+  avatar: string,
+  displayName: string,
+  contributionCount: number,
+  contributionPercentage: number
+}[];
+
+export async function fetchContributorsLeaderboard(filter: ContributorsLeaderboardFilter): Promise<ContributorsLeaderboardResponse> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  const contributorsLeaderboardQuery = {
+    repository: filter.repository,
+    startDate: filter.startDate,
+    endDate: filter.endDate,
+  };
+
+  const data = await fetchFromTinybird<TinybirdContributorsLeaderboardData>('/v0/pipes/contributors_leaderboard.json', contributorsLeaderboardQuery);
+
+  let processedData: ContributorsLeaderboardData = [];
+  if (data !== undefined) {
+    processedData = (data as TinybirdResponse<TinybirdContributorsLeaderboardData>)?.data.map(
+      (item): ContributorsLeaderboardDataPoint => ({
+        avatar: item.avatar,
+        name: item.displayName,
+        contributions: item.contributionCount,
+        contributionValue: 0
+      })
+    );
+  }
+
+  return {
+    meta: {
+      offset: 0,
+      limit: 10,
+      total: data.rows
+    },
+    data: processedData
+  };
+}

--- a/frontend/server/data/tinybird/tinybird.ts
+++ b/frontend/server/data/tinybird/tinybird.ts
@@ -38,7 +38,7 @@ export async function fetchFromTinybird<T>(
     // We don't want o send undefined values to TinyBird, so we remove those from the query. We also format DateTime objects for TinyBird
     const processedQuery = Object.fromEntries(
       Object.entries(query)
-        .filter(([_, value]) => value !== undefined)
+        .filter(([_, value]) => (value !== undefined) && (value !== '') && (value !== null))
         .map(([key, value]) => [
             key,
             value instanceof DateTime

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -14,3 +14,14 @@ export type ActiveContributorsFilter = {
   startDate?: DateTime;
   endDate?: DateTime;
 };
+
+export enum ContributorsLeaderboardFilterMetric {
+  ALL = 'all',
+  COMMITS = 'commits'
+}
+export type ContributorsLeaderboardFilter = {
+  metric: ContributorsLeaderboardFilterMetric;
+  repository: string;
+  startDate?: DateTime;
+  endDate?: DateTime;
+}


### PR DESCRIPTION
This adds the necessary endpoint for the contributors leaderboard widget.

This PR is built on the changes from #76, and it shouldn't be merged until after that one is merged and this one is rebase onto main. Even reviewing should be held back until the rebase, because right now this shows changes that belong to the previous PR in the chain.

* main branch
    * PR #76
        * **PR #77 :point_left: You are here**
            * PR #78
                * PR #79
                    * PR #84
                        * PR #85
                            * PR #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced contributor leaderboard functionality, allowing users to view and filter contributor statistics by metric, repository, and date range.
  
- **Refactor**
  - Improved data handling by refining the filtering process to ensure only valid values are used, enhancing the accuracy and reliability of leaderboard data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->