### PR TITLE
Active organizations widget endpoint

### DIFF
--- a/frontend/app/components/modules/project/components/contributors/active-organizations.vue
+++ b/frontend/app/components/modules/project/components/contributors/active-organizations.vue
@@ -77,7 +77,7 @@ const { data, status, error } = useFetch(
   `/api/project/${route.params.slug}/contributors/active-organizations`,
   {
     params: {
-      interval: activeTab.value,
+      granularity: activeTab.value,
       repository: selectedRepository,
       startDate,
       endDate,

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -1,21 +1,29 @@
 // This creates a Tinybird data source for fetching active contributors' data.
 // If we ever need to change the data source, we can do it here, and we won't have to change the API code.
 
-import type {ActiveContributorsFilter, ContributorsLeaderboardFilter} from "~~/server/data/types";
+import type {
+    ActiveContributorsFilter,
+    ActiveOrganizationsFilter,
+    ContributorsLeaderboardFilter
+} from "~~/server/data/types";
 import type {ActiveContributorsResponse} from "~~/server/data/tinybird/active-contributors-data-source";
 import type {ContributorsLeaderboardResponse} from "~~/server/data/tinybird/contributors-leaderboard-source";
 
 import {fetchActiveContributors} from "~~/server/data/tinybird/active-contributors-data-source";
+import type {ActiveOrganizationsResponse} from "~~/server/data/tinybird/active-organizations-data-source";
+import {fetchActiveOrganizations} from "~~/server/data/tinybird/active-organizations-data-source";
 import {fetchContributorsLeaderboard} from "~~/server/data/tinybird/contributors-leaderboard-source";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
+    fetchActiveOrganizations: (filter: ActiveOrganizationsFilter) => Promise<ActiveOrganizationsResponse>;
     fetchContributorsLeaderboard: (filter: ContributorsLeaderboardFilter) => Promise<ContributorsLeaderboardResponse>;
 }
 
 export function createDataSource(): DataSource {
     return {
         fetchActiveContributors,
-        fetchContributorsLeaderboard
+        fetchContributorsLeaderboard,
+        fetchActiveOrganizations
     };
 }

--- a/frontend/server/data/tinybird/active-organizations-data-source.ts
+++ b/frontend/server/data/tinybird/active-organizations-data-source.ts
@@ -1,0 +1,112 @@
+/*
+This is responsible for fetching the active organizations data from Tinybird.
+The goal is to make the API endpoint oblivious to where the data comes from, since it's a separate service.
+There's a bit of an overlap in responsibility between the API and this service because this returns the data
+in the format the API will return to the client, which isn't ideal. If we ever need to use this for something else,
+let's refactor it to return the data in a more generic format.
+ */
+
+import type {DateTime} from "luxon";
+import type {ActiveOrganizationsFilter} from "../types";
+import {getPreviousDates} from "../util";
+import type {TinybirdResponse} from './tinybird';
+import {fetchFromTinybird} from './tinybird'
+
+export type ActiveOrganizationsDataPoint = {
+  startDate: string;
+  endDate: string;
+  organizations: number;
+};
+export type ActiveOrganizationsResponseData = ActiveOrganizationsDataPoint[];
+export type ActiveOrganizationsResponse = {
+  summary: {
+    current: number; // Current number of active organizations
+    previous: number; // Previous number of active organizations
+    percentageChange: number; // Percentage change in active organizations
+    changeValue: number; // Change in the number of active organizations
+    periodFrom: DateTime; // Start of the period (e.g. last 90 days)
+    periodTo: DateTime; // End of the period (e.g. last 90 days)
+  };
+  data: ActiveOrganizationsResponseData
+};
+
+type TinybirdActiveOrganizationsSummary = {
+  organizationCount: number;
+}[];
+
+type TinybirdActiveOrganizationsData = {
+  startDate: string;
+  endDate: string;
+  organizationCount: number;
+}[];
+
+export async function fetchActiveOrganizations(filter: ActiveOrganizationsFilter) {
+  const dates = getPreviousDates(filter.startDate, filter.endDate);
+
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+  const currentSummaryQuery = {
+    project: filter.project,
+    repo: filter.repository,
+    startDate: dates.current.from,
+    endDate: dates.current.to
+  };
+
+  const previousSummaryQuery = {
+    project: filter.project,
+    repo: filter.repository,
+    startDate: dates.previous.from,
+    endDate: dates.previous.to
+  };
+
+  const dataQuery = {
+    project: filter.project,
+    granularity: filter.granularity,
+    repo: filter.repository,
+    startDate: dates.current.from,
+    endDate: dates.current.to
+  };
+
+  const [currentSummary, previousSummary, data] = await Promise.all([
+    fetchFromTinybird<TinybirdActiveOrganizationsSummary>('/v0/pipes/active_organizations.json', currentSummaryQuery),
+    fetchFromTinybird<TinybirdActiveOrganizationsSummary>('/v0/pipes/active_organizations.json', previousSummaryQuery),
+    fetchFromTinybird<TinybirdActiveOrganizationsData>('/v0/pipes/active_organizations.json', dataQuery)
+  ]);
+
+  let processedData: ActiveOrganizationsResponseData = [];
+  if (data !== undefined) {
+    processedData = (data as TinybirdResponse<TinybirdActiveOrganizationsData>)?.data.map(
+      (item): ActiveOrganizationsDataPoint => ({
+        startDate: item.startDate,
+        endDate: item.endDate,
+        organizations: item.organizationCount
+      })
+    );
+  }
+
+  const currentOrganizationCount = currentSummary.data[0].organizationCount;
+  const previousOrganizationCount = previousSummary.data[0].organizationCount;
+  const changeValue = currentOrganizationCount - previousOrganizationCount;
+  let percentageChange = 0;
+  if (previousOrganizationCount === 0 && currentOrganizationCount > 0) {
+    percentageChange = 100;
+  } else if (previousOrganizationCount === 0 && currentOrganizationCount === 0) {
+    percentageChange = 0;
+  } else if (previousOrganizationCount !== 0) {
+    percentageChange = ((currentOrganizationCount - previousOrganizationCount) / previousOrganizationCount) * 100;
+  }
+
+  const response: ActiveOrganizationsResponse = {
+    summary: {
+      current: currentOrganizationCount,
+      previous: previousOrganizationCount,
+      percentageChange,
+      changeValue,
+      periodFrom: dates.current.from,
+      periodTo: dates.current.to,
+    },
+    data: processedData,
+  };
+
+  return response;
+}

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -15,6 +15,19 @@ export type ActiveContributorsFilter = {
   endDate?: DateTime;
 };
 
+export enum ActiveOrganizationsFilterGranularity {
+  WEEKLY = 'weekly',
+  MONTHLY = 'monthly',
+  QUARTERLY = 'quarterly'
+}
+export type ActiveOrganizationsFilter = {
+  project: string;
+  repository?: string;
+  granularity?: ActiveOrganizationsFilterGranularity;
+  startDate?: DateTime;
+  endDate?: DateTime;
+};
+
 export enum ContributorsLeaderboardFilterMetric {
   ALL = 'all',
   COMMITS = 'commits'


### PR DESCRIPTION
This adds the necessary endpoint for the active organizations widget.

This PR is built on the changes from https://github.com/LF-Engineering/insights/pull/77, and it shouldn't be merged until after that one is merged and this one is rebase onto main. Even reviewing should be held back until the rebase, because right now this shows changes that belong to the previous PR in the chain.

* main branch
    * PR #76
        * PR #77
            * **PR #78 :point_left: You are here**
                * PR #79
                    * PR #84
                        * PR #85
                            * PR #86

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Active organization metrics now allow filtering by time periods, offering more tailored insights.
  - Contributor leaderboard functionality has been enhanced to deliver more accurate contribution data.

- **Refactor**
  - Replaced static sample data with dynamic, query-driven data retrieval for improved reliability.
  - Improved query validation and sanitization for cleaner and more robust data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->