### PR TITLE
Organizations leaderboard widget endpoint

### DIFF
--- a/frontend/server/api/project/[slug]/contributors/organization-leaderboard.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/organization-leaderboard.get.ts
@@ -1,4 +1,7 @@
-import { allMetrics, commits } from '~~/server/mocks/organization-leaderboard.mock';
+import {DateTime} from "luxon";
+import {createDataSource} from "~~/server/data/data-sources";
+import type {OrganizationsLeaderboardFilter} from "~~/server/data/types";
+import {OrganizationsLeaderboardFilterMetric} from "~~/server/data/types";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -30,22 +33,25 @@ import { allMetrics, commits } from '~~/server/mocks/organization-leaderboard.mo
  */
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
-  const { metric } = query;
+
   const meta = {
     offset: 0,
     limit: 10,
     total: 100
   };
 
-  if (metric === 'all') {
-    return {
-      meta,
-      data: allMetrics
-    };
-  }
+  const filter: OrganizationsLeaderboardFilter = {
+    metric: (query.metric as OrganizationsLeaderboardFilterMetric) || OrganizationsLeaderboardFilterMetric.ALL,
+    repository: query.repository as string,
+    startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
+    endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,
+  };
+
+  const dataSource = createDataSource();
+  const result = await dataSource.fetchOrganizationsLeaderboard(filter);
 
   return {
     meta,
-    data: commits
+    data: result.data
   };
 });

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -2,28 +2,32 @@
 // If we ever need to change the data source, we can do it here, and we won't have to change the API code.
 
 import type {
-    ActiveContributorsFilter,
-    ActiveOrganizationsFilter,
-    ContributorsLeaderboardFilter
+  ActiveContributorsFilter,
+  ActiveOrganizationsFilter,
+  ContributorsLeaderboardFilter,
+  OrganizationsLeaderboardFilter
 } from "~~/server/data/types";
 import type {ActiveContributorsResponse} from "~~/server/data/tinybird/active-contributors-data-source";
-import type {ContributorsLeaderboardResponse} from "~~/server/data/tinybird/contributors-leaderboard-source";
-
-import {fetchActiveContributors} from "~~/server/data/tinybird/active-contributors-data-source";
 import type {ActiveOrganizationsResponse} from "~~/server/data/tinybird/active-organizations-data-source";
+import type {ContributorsLeaderboardResponse} from "~~/server/data/tinybird/contributors-leaderboard-source";
+import type {OrganizationsLeaderboardResponse} from "~~/server/data/tinybird/organizations-leaderboard-source";
+import {fetchActiveContributors} from "~~/server/data/tinybird/active-contributors-data-source";
 import {fetchActiveOrganizations} from "~~/server/data/tinybird/active-organizations-data-source";
 import {fetchContributorsLeaderboard} from "~~/server/data/tinybird/contributors-leaderboard-source";
+import {fetchOrganizationsLeaderboard} from "~~/server/data/tinybird/organizations-leaderboard-source";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
     fetchActiveOrganizations: (filter: ActiveOrganizationsFilter) => Promise<ActiveOrganizationsResponse>;
     fetchContributorsLeaderboard: (filter: ContributorsLeaderboardFilter) => Promise<ContributorsLeaderboardResponse>;
+    fetchOrganizationsLeaderboard: (filter: OrganizationsLeaderboardFilter) => Promise<OrganizationsLeaderboardResponse>;
 }
 
 export function createDataSource(): DataSource {
     return {
         fetchActiveContributors,
         fetchContributorsLeaderboard,
-        fetchActiveOrganizations
+        fetchActiveOrganizations,
+        fetchOrganizationsLeaderboard
     };
 }

--- a/frontend/server/data/tinybird/organizations-leaderboard-source.ts
+++ b/frontend/server/data/tinybird/organizations-leaderboard-source.ts
@@ -1,0 +1,61 @@
+import type {OrganizationsLeaderboardFilter} from "~~/server/data/types";
+import {fetchFromTinybird, type TinybirdResponse} from "~~/server/data/tinybird/tinybird";
+
+export type OrganizationsLeaderboardDataPoint = {
+  logo: string | undefined; // URL of the user's profile pic or avatar.
+  name: string; // Full name of the organization
+  contributions: number; // Total number of contributions
+  contributionValue: number; // Value of the contribution
+  website: string; // We don't seem to have this at the moment
+}
+export type OrganizationsLeaderboardData = OrganizationsLeaderboardDataPoint[];
+export type OrganizationsLeaderboardResponse = {
+  meta: {
+    offset: number;
+    limit: number;
+    total: number;
+  },
+  data: OrganizationsLeaderboardData
+}
+
+type TinybirdOrganizationsLeaderboardData = {
+  logo: string,
+  displayName: string,
+  contributionCount: number,
+  contributionPercentage: number
+}[];
+
+export async function fetchOrganizationsLeaderboard(filter: OrganizationsLeaderboardFilter): Promise<OrganizationsLeaderboardResponse> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  const organizationsLeaderboardQuery = {
+    repository: filter.repository,
+    startDate: filter.startDate,
+    endDate: filter.endDate,
+  };
+
+  const data = await fetchFromTinybird<TinybirdOrganizationsLeaderboardData>('/v0/pipes/organizations_leaderboard.json', organizationsLeaderboardQuery);
+
+  let processedData: OrganizationsLeaderboardData = [];
+  if (data !== undefined) {
+    processedData = (data as TinybirdResponse<TinybirdOrganizationsLeaderboardData>)?.data.map(
+      (item): OrganizationsLeaderboardDataPoint => ({
+        logo: item.logo,
+        name: item.displayName,
+        contributions: item.contributionCount,
+        contributionValue: 0,
+        website: '' // We don't seem to have this at the moment
+      })
+    );
+  }
+
+  return {
+    meta: {
+      offset: 0,
+      limit: 10,
+      total: data.rows
+    },
+    data: processedData
+  };
+}

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -38,3 +38,14 @@ export type ContributorsLeaderboardFilter = {
   startDate?: DateTime;
   endDate?: DateTime;
 }
+
+export enum OrganizationsLeaderboardFilterMetric {
+  ALL = 'all',
+  COMMITS = 'commits'
+}
+export type OrganizationsLeaderboardFilter = {
+  metric: OrganizationsLeaderboardFilterMetric;
+  repository: string;
+  startDate?: DateTime;
+  endDate?: DateTime;
+}


### PR DESCRIPTION
This adds the necessary endpoint for the organizations leaderboard widget.

This PR is built on the changes from https://github.com/LF-Engineering/insights/pull/78, and it shouldn't be merged until after that one is merged and this one is rebase onto main. Even reviewing should be held back until the rebase, because right now this shows changes that belong to the previous PR in the chain.

* main branch
    * PR #76 
        * PR #77
            * PR #78
                * **PR #79 :point_left: You are here**
                    * PR #84
                        * PR #85
                            * PR #86


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- The organization leaderboard now supports dynamic filtering for metric, repository, and date range, enabling more tailored results.
	- Leaderboard data is fetched in real time, replacing the previous static approach for improved accuracy and responsiveness.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->