### PR TITLE
Fix organizations leaderboard missing percentage

### DIFF
--- a/frontend/server/data/tinybird/organizations-dependency-data-source.ts
+++ b/frontend/server/data/tinybird/organizations-dependency-data-source.ts
@@ -75,7 +75,7 @@ function convertLeaderboardData(leaderboard: OrganizationsLeaderboardDataPoint[]
     logo: item.logo,
     name: item.name,
     contributions: item.contributions,
-    percentage: item.contributionPercentage,
+    percentage: item.percentage,
     website: item.website || '' // We don't seem to have this at the moment
   }));
 }

--- a/frontend/server/data/tinybird/organizations-leaderboard-source.ts
+++ b/frontend/server/data/tinybird/organizations-leaderboard-source.ts
@@ -6,7 +6,7 @@ export type OrganizationsLeaderboardDataPoint = {
   name: string; // Full name of the organization
   contributions: number; // Total number of contributions
   contributionValue: number; // Value of the contribution
-  contributionPercentage: number;
+  percentage: number;
   website: string; // We don't seem to have this at the moment
 }
 export type OrganizationsLeaderboardData = OrganizationsLeaderboardDataPoint[];
@@ -49,7 +49,7 @@ export async function fetchOrganizationsLeaderboard(
         name: item.displayName,
         contributions: item.contributionCount,
         contributionValue: 0,
-        contributionPercentage: item.contributionPercentage,
+        percentage: item.contributionPercentage,
         website: '' // We don't seem to have this at the moment
       })
     );


### PR DESCRIPTION
Just what the title says.

Ticket: https://linear.app/lfx/issue/INS-168/investigate-and-fix-organizations-leaderboard-missing-percentage


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Updated how leaderboard percentage values are sourced by renaming the `contributionPercentage` property to `percentage`, ensuring that the displayed data remains consistent and accurate for organizations’ contribution metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->