### PR TITLE
Add data endpoints for the popularity forks and stars widgets

### DIFF
--- a/frontend/app/components/modules/project/components/popularity/forks.vue
+++ b/frontend/app/components/modules/project/components/popularity/forks.vue
@@ -105,6 +105,8 @@ const { data, status, error } = useFetch(
     params: {
       granularity,
       type: activeTab,
+      countType: activeTab,
+      activityType: 'fork',
       repository: selectedRepository,
       startDate,
       endDate,
@@ -117,9 +119,9 @@ const forks = computed<ForksData | undefined>(() => data.value as ForksData);
 const summary = computed<Summary | undefined>(() => forks.value?.summary);
 const chartData = computed<ChartData[]>(
   // convert the data to chart data
-  () => convertToChartData(forks.value?.data as RawChartData[], 'dateFrom', [
+  () => convertToChartData(forks.value?.data as RawChartData[], 'startDate', [
     'forks'
-  ], undefined, 'dateTo')
+  ], undefined, 'endDate')
 );
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 

--- a/frontend/app/components/modules/project/components/popularity/stars.vue
+++ b/frontend/app/components/modules/project/components/popularity/stars.vue
@@ -105,6 +105,8 @@ const { data, status, error } = useFetch(
     params: {
       granularity,
       type: activeTab,
+      countType: activeTab,
+      activityType: 'star',
       repository: selectedRepository,
       startDate,
       endDate,
@@ -117,9 +119,9 @@ const stars = computed<StarsData | undefined>(() => data.value as StarsData);
 const summary = computed<Summary | undefined>(() => stars.value?.summary);
 const chartData = computed<ChartData[]>(
   // convert the data to chart data
-  () => convertToChartData(stars.value?.data as RawChartData[], 'dateFrom', [
+  () => convertToChartData(stars.value?.data as RawChartData[], 'startDate', [
     'stars'
-  ], undefined, 'dateTo')
+  ], undefined, 'endDate')
 );
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 

--- a/frontend/server/api/project/[slug]/contributors/contributor-dependency.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/contributor-dependency.get.ts
@@ -1,6 +1,6 @@
 import {DateTime} from "luxon";
 import {createDataSource} from "~~/server/data/data-sources";
-import {FilterActivityMetric} from "~~/server/data/types";
+import {FilterActivityMetric, FilterGranularity} from "~~/server/data/types";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -34,9 +34,12 @@ import {FilterActivityMetric} from "~~/server/data/types";
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
 
+  const project = (event.context.params as { slug: string }).slug;
+
   const filter = {
+    project,
+    granularity: (query.granularity as FilterGranularity) || FilterGranularity.QUARTERLY,
     metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
-    project: query.project as string,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/api/project/[slug]/contributors/contributor-leaderboard.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/contributor-leaderboard.get.ts
@@ -35,7 +35,10 @@ import {FilterActivityMetric} from "~~/server/data/types";
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
 
+  const project = (event.context.params as { slug: string }).slug;
+
   const filter: ContributorsLeaderboardFilter = {
+    project,
     metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,

--- a/frontend/server/api/project/[slug]/contributors/organization-dependency.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/organization-dependency.get.ts
@@ -1,5 +1,5 @@
 import {DateTime} from "luxon";
-import {FilterActivityMetric} from "~~/server/data/types";
+import {FilterActivityMetric, FilterGranularity} from "~~/server/data/types";
 import {createDataSource} from "~~/server/data/data-sources";
 
 /**
@@ -34,9 +34,12 @@ import {createDataSource} from "~~/server/data/data-sources";
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
 
+  const project = (event.context.params as { slug: string }).slug;
+
   const filter = {
+    project,
+    granularity: (query.granularity as FilterGranularity) || FilterGranularity.QUARTERLY,
     metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
-    project: query.project as string,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/api/project/[slug]/contributors/organization-leaderboard.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/organization-leaderboard.get.ts
@@ -34,6 +34,8 @@ import {FilterActivityMetric} from "~~/server/data/types";
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
 
+  const project = (event.context.params as { slug: string }).slug;
+
   const meta = {
     offset: 0,
     limit: 10,
@@ -41,6 +43,7 @@ export default defineEventHandler(async (event) => {
   };
 
   const filter: OrganizationsLeaderboardFilter = {
+    project,
     metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,

--- a/frontend/server/api/project/[slug]/popularity/stars.get.ts
+++ b/frontend/server/api/project/[slug]/popularity/stars.get.ts
@@ -1,4 +1,7 @@
-import { cumulative, newStars } from '~~/server/mocks/stars.mock';
+import {DateTime} from "luxon";
+import type {ActivityCountFilter, FilterGranularity} from "~~/server/data/types";
+import {ActivityFilterActivityType, ActivityFilterCountType} from "~~/server/data/types";
+import {createDataSource} from "~~/server/data/data-sources";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -27,13 +30,21 @@ import { cumulative, newStars } from '~~/server/mocks/stars.mock';
  */
 export default defineEventHandler(async (event) => {
   const query = getQuery(event);
-  let data;
 
-  if (query.type === 'cumulative') {
-    data = cumulative;
-  } else {
-    data = newStars;
+  const project = (event.context.params as { slug: string }).slug;
+
+  const filter: ActivityCountFilter = {
+    project,
+    granularity: query.granularity as FilterGranularity,
+    repository: query.repository as string,
+    countType: (query.countType as ActivityFilterCountType) || ActivityFilterCountType.NEW,
+    activityType: (query.activityType as ActivityFilterActivityType) || ActivityFilterActivityType.STARS,
+    onlyContributions: false, // forks and stars are non-contribution activities, but we want to count them.
+    startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
+    endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,
   }
 
-  return data;
+  const dataSource = createDataSource();
+
+  return await dataSource.fetchStarsActivities(filter);
 });

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -10,6 +10,7 @@ import type {
   OrganizationDependencyFilter,
   GeographicDistributionFilter,
   RetentionFilter,
+  ActivityCountFilter,
 } from "~~/server/data/types";
 import type {ActiveContributorsResponse} from "~~/server/data/tinybird/active-contributors-data-source";
 import type {ActiveOrganizationsResponse} from "~~/server/data/tinybird/active-organizations-data-source";
@@ -27,6 +28,9 @@ import {fetchContributorDependency} from "~~/server/data/tinybird/contributors-d
 import {fetchOrganizationDependency} from "~~/server/data/tinybird/organizations-dependency-data-source";
 import {fetchGeographicDistribution} from "~~/server/data/tinybird/geographic-distribution-data-source";
 import {fetchRetention} from "~~/server/data/tinybird/retention-data-source";
+import {fetchForksActivities} from "~~/server/data/tinybird/forks-data-source";
+import {fetchStarsActivities} from "~~/server/data/tinybird/stars-data-source";
+import type {ForksData, StarsData} from "~~/types/popularity/responses.types";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
@@ -39,6 +43,8 @@ export interface DataSource {
     fetchOrganizationDependency: (filter: OrganizationDependencyFilter) => Promise<OrganizationDependencyResponse>;
     fetchGeographicDistribution: (filter: GeographicDistributionFilter) => Promise<GeographicDistributionResponse>;
     fetchRetention: (filter: RetentionFilter) => Promise<RetentionResponse>;
+    fetchForksActivities: (filter: ActivityCountFilter) => Promise<ForksData>;
+    fetchStarsActivities: (filter: ActivityCountFilter) => Promise<StarsData>;
 }
 
 export function createDataSource(): DataSource {
@@ -51,5 +57,7 @@ export function createDataSource(): DataSource {
         fetchOrganizationDependency,
         fetchGeographicDistribution,
         fetchRetention,
+        fetchForksActivities,
+        fetchStarsActivities,
     };
 }

--- a/frontend/server/data/tinybird/contributors-dependency-data-source.ts
+++ b/frontend/server/data/tinybird/contributors-dependency-data-source.ts
@@ -37,6 +37,7 @@ export async function fetchContributorDependency(filter: ContributorDependencyFi
   //  We need to ensure this doesn't pose a security risk.
 
   const leaderboardFilter: ContributorsLeaderboardFilter = {
+    project: filter.project,
     metric: (filter.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
     repository: filter.repository,
     limit: 5,
@@ -50,9 +51,9 @@ export async function fetchContributorDependency(filter: ContributorDependencyFi
   ]);
 
   const topContributorsCount = tinybirdTopContributorsResponse.data.length;
-  const lastContributor = tinybirdTopContributorsResponse.data[topContributorsCount - 1];
-  const topContributorsPercentage = lastContributor.contributionPercentageRunningTotal;
-  const {totalContributorCount} = tinybirdTopContributorsResponse.data[0];
+  const lastContributor = tinybirdTopContributorsResponse.data.at(-1);
+  const topContributorsPercentage = lastContributor?.contributionPercentageRunningTotal || 0;
+  const totalContributorCount = tinybirdTopContributorsResponse.data[0]?.totalContributorCount || 0;
 
   const response: ContributorDependencyResponse = {
     topContributors: {
@@ -60,7 +61,7 @@ export async function fetchContributorDependency(filter: ContributorDependencyFi
       percentage: topContributorsPercentage
     },
     otherContributors: {
-      count: totalContributorCount - topContributorsCount,
+      count: Math.max(0, (totalContributorCount || 0) - topContributorsCount),
       percentage: 100 - topContributorsPercentage
     },
     list: convertLeaderboardData(tinybirdLeaderboardResponse.data)

--- a/frontend/server/data/tinybird/contributors-leaderboard-source.ts
+++ b/frontend/server/data/tinybird/contributors-leaderboard-source.ts
@@ -32,6 +32,7 @@ export async function fetchContributorsLeaderboard(
   //  We need to ensure this doesn't pose a security risk.
 
   const contributorsLeaderboardQuery = {
+    project: filter.project,
     repository: filter.repository,
     limit: filter.limit,
     startDate: filter.startDate,
@@ -60,7 +61,7 @@ export async function fetchContributorsLeaderboard(
     meta: {
       offset: 0,
       limit: 10,
-      total: data.rows
+      total: data?.rows || 0
     },
     data: processedData
   };

--- a/frontend/server/data/tinybird/forks-data-source.ts
+++ b/frontend/server/data/tinybird/forks-data-source.ts
@@ -1,0 +1,93 @@
+import type {ActivityCountFilter} from "../types";
+import {ActivityFilterCountType} from "../types";
+import {fetchFromTinybird} from './tinybird'
+import type {ForksData} from "~~/types/popularity/responses.types";
+import {calculatePercentageChange, getPreviousDates} from "~~/server/data/util";
+
+// This is the data part of the response from Tinybird
+type TinybirdActivityCountData = {
+  startDate: string,
+  endDate: string,
+  activityCount?: number
+  cumulativeActivityCount?: number
+};
+
+type TinybirdActivityCountSummary = {
+  activityCount: number;
+};
+
+function getTinybirdQueries(filter: ActivityCountFilter) {
+  const dates = getPreviousDates(filter.startDate, filter.endDate);
+
+  return {
+    currentSummaryQuery: {
+      ...filter,
+      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      repo: filter.repository, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+    },
+    previousSummaryQuery: {
+      ...filter,
+      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      repo: filter.repository, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      startDate: dates.previous.from,
+      endDate: dates.previous.to
+    },
+    dataQuery: {
+      ...filter,
+      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      repo: filter.repository,
+    }
+  }
+}
+export async function fetchForksActivities(filter: ActivityCountFilter): Promise<ForksData> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  const {currentSummaryQuery, previousSummaryQuery, dataQuery} = getTinybirdQueries(filter);
+
+  const summariesPath = 'activities_count.json'; // Tinybird uses this one for the summaries
+  let dataPath = 'activities_cumulative_count.json';
+  if (filter.countType === ActivityFilterCountType.NEW) {
+    dataPath = 'activities_count.json';
+  }
+
+  const [currentSummaryData, previousSummaryData, currentData] = await Promise.all([
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(`/v0/pipes/${summariesPath}`, currentSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(`/v0/pipes/${summariesPath}`, previousSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountData[]>(`/v0/pipes/${dataPath}`, dataQuery)
+  ]);
+
+  const currentCumulativeCount = currentSummaryData.data[0]?.activityCount || 0;
+  const previousCumulativeCount = previousSummaryData.data[0]?.activityCount || 0;
+  const percentageChange = calculatePercentageChange(currentCumulativeCount, previousCumulativeCount);
+
+  let data;
+
+  if (filter.countType === ActivityFilterCountType.CUMULATIVE) {
+    data = currentData.data.map((item) => ({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      forks: item.cumulativeActivityCount || 0,
+    }))
+  } else {
+    data = currentData.data.map((item) => ({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      forks: item.activityCount || 0,
+    }))
+  }
+
+  return {
+    summary: {
+      current: currentCumulativeCount,
+      previous: previousCumulativeCount,
+      percentageChange,
+      changeValue: currentCumulativeCount - previousCumulativeCount,
+      periodFrom: filter.startDate?.toString() || '',
+      periodTo: filter.endDate?.toString() || '',
+    },
+    data
+  };
+}

--- a/frontend/server/data/tinybird/organizations-dependency-data-source.ts
+++ b/frontend/server/data/tinybird/organizations-dependency-data-source.ts
@@ -38,6 +38,7 @@ export async function fetchOrganizationDependency(filter: OrganizationDependency
   //  We need to ensure this doesn't pose a security risk.
 
   const leaderboardFilter: OrganizationsLeaderboardFilter = {
+    project: filter.project,
     metric: (filter.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
     repository: filter.repository,
     limit: 5,
@@ -51,9 +52,9 @@ export async function fetchOrganizationDependency(filter: OrganizationDependency
   ]);
 
   const topOrganizationsCount = tinybirdTopOrganizationsResponse.data.length;
-  const topOrganizationsPercentage = tinybirdTopOrganizationsResponse.data[topOrganizationsCount - 1]
-      .contributionPercentageRunningTotal;
-  const {totalOrganizationCount} = tinybirdTopOrganizationsResponse.data[0];
+  const lastOrganization = tinybirdTopOrganizationsResponse.data.at(-1);
+  const topOrganizationsPercentage = lastOrganization?.contributionPercentageRunningTotal || 0;
+  const totalOrganizationCount = tinybirdTopOrganizationsResponse.data[0]?.totalOrganizationCount || 0;
 
   const response: OrganizationDependencyResponse = {
     topOrganizations: {
@@ -61,7 +62,7 @@ export async function fetchOrganizationDependency(filter: OrganizationDependency
       percentage: topOrganizationsPercentage
     },
     otherOrganizations: {
-      count: totalOrganizationCount - topOrganizationsCount,
+      count: Math.max(0, (totalOrganizationCount || 0) - topOrganizationsCount),
       percentage: 100 - topOrganizationsPercentage
     },
     list: convertLeaderboardData(tinybirdLeaderboardResponse.data)

--- a/frontend/server/data/tinybird/organizations-leaderboard-source.ts
+++ b/frontend/server/data/tinybird/organizations-leaderboard-source.ts
@@ -33,6 +33,7 @@ export async function fetchOrganizationsLeaderboard(
   //  We need to ensure this doesn't pose a security risk.
 
   const organizationsLeaderboardQuery = {
+    project: filter.project,
     repository: filter.repository,
     startDate: filter.startDate,
     endDate: filter.endDate,

--- a/frontend/server/data/tinybird/stars-data-source.ts
+++ b/frontend/server/data/tinybird/stars-data-source.ts
@@ -1,0 +1,93 @@
+import type {ActivityCountFilter} from "../types";
+import {ActivityFilterCountType} from "../types";
+import {fetchFromTinybird} from './tinybird'
+import type {StarsData} from "~~/types/popularity/responses.types";
+import {calculatePercentageChange, getPreviousDates} from "~~/server/data/util";
+
+// This is the data part of the response from Tinybird
+type TinybirdActivityCountData = {
+  startDate: string,
+  endDate: string,
+  activityCount?: number
+  cumulativeActivityCount?: number
+};
+
+type TinybirdActivityCountSummary = {
+  activityCount: number;
+};
+
+function getTinybirdQueries(filter: ActivityCountFilter) {
+  const dates = getPreviousDates(filter.startDate, filter.endDate);
+
+  return {
+    currentSummaryQuery: {
+      ...filter,
+      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      repo: filter.repository, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+    },
+    previousSummaryQuery: {
+      ...filter,
+      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      repo: filter.repository, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      startDate: dates.previous.from,
+      endDate: dates.previous.to
+    },
+    dataQuery: {
+      ...filter,
+      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      repo: filter.repository,
+    }
+  }
+}
+export async function fetchStarsActivities(filter: ActivityCountFilter): Promise<StarsData> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  const {currentSummaryQuery, previousSummaryQuery, dataQuery} = getTinybirdQueries(filter);
+
+  const summariesPath = 'activities_count.json'; // Tinybird uses this one for the summaries
+  let dataPath = 'activities_cumulative_count.json';
+  if (filter.countType === ActivityFilterCountType.NEW) {
+    dataPath = 'activities_count.json';
+  }
+
+  const [currentSummaryData, previousSummaryData, currentData] = await Promise.all([
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(`/v0/pipes/${summariesPath}`, currentSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(`/v0/pipes/${summariesPath}`, previousSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountData[]>(`/v0/pipes/${dataPath}`, dataQuery)
+  ]);
+
+  const currentCumulativeCount = currentSummaryData.data[0]?.activityCount || 0;
+  const previousCumulativeCount = previousSummaryData.data[0]?.activityCount || 0;
+  const percentageChange = calculatePercentageChange(currentCumulativeCount, previousCumulativeCount);
+
+  let data;
+
+  if (filter.countType === ActivityFilterCountType.CUMULATIVE) {
+    data = currentData.data.map((item) => ({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      stars: item.cumulativeActivityCount || 0,
+    }))
+  } else {
+    data = currentData.data.map((item) => ({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      stars: item.activityCount || 0,
+    }))
+  }
+
+  return {
+    summary: {
+      current: currentCumulativeCount,
+      previous: previousCumulativeCount,
+      percentageChange,
+      changeValue: currentCumulativeCount - previousCumulativeCount,
+      periodFrom: filter.startDate?.toString() || '',
+      periodTo: filter.endDate?.toString() || '',
+    },
+    data
+  };
+}

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -37,6 +37,7 @@ export type ActiveOrganizationsFilter = {
 };
 
 export type ContributorsLeaderboardFilter = {
+  project: string;
   metric: FilterActivityMetric;
   repository?: string;
   limit?: number;
@@ -45,6 +46,7 @@ export type ContributorsLeaderboardFilter = {
 }
 
 export type OrganizationsLeaderboardFilter = {
+  project: string;
   metric: FilterActivityMetric;
   repository?: string;
   limit?: number;
@@ -91,4 +93,23 @@ export type RetentionFilter = {
   onlyContributions: boolean;
   startDate?: DateTime;
   endDate?: DateTime;
+}
+
+export enum ActivityFilterCountType {
+  CUMULATIVE = 'cumulative',
+  NEW = 'new'
+}
+export enum ActivityFilterActivityType {
+  FORKS = 'fork',
+  STARS = 'star'
+}
+export type ActivityCountFilter = {
+  project: string;
+  granularity: FilterGranularity;
+  countType: ActivityFilterCountType;
+  activityType: ActivityFilterActivityType,
+  onlyContributions: boolean;
+  repository?: string,
+  startDate?: DateTime,
+  endDate?: DateTime,
 }

--- a/frontend/server/data/util.ts
+++ b/frontend/server/data/util.ts
@@ -34,3 +34,11 @@ export function getPreviousDates(currentStartDate?: DateTime, currentEndDate?: D
     }
   };
 }
+
+export function calculatePercentageChange(current: number, previous: number): number {
+  if (previous !== 0) {
+    return ((current * 100) / previous) - 100;
+  }
+
+  return 0;
+}

--- a/frontend/types/popularity/responses.types.ts
+++ b/frontend/types/popularity/responses.types.ts
@@ -3,8 +3,8 @@ import type { Summary } from '../shared/summary.types';
 export interface StarsData {
   summary: Summary;
   data: {
-    dateFrom: string;
-    dateTo: string;
+    startDate: string;
+    endDate: string;
     stars: number;
   }[];
 }
@@ -12,8 +12,8 @@ export interface StarsData {
 export interface ForksData {
   summary: Summary;
   data: {
-    dateFrom: string;
-    dateTo: string;
+    startDate: string;
+    endDate: string;
     forks: number;
   }[];
 }


### PR DESCRIPTION
[Ticket in Linear
](https://linear.app/lfx/issue/INS-150/popularity-activity-counts)

Adds the data endpoints for the forks and stars widgets on the popularity page.

I had to rename a couple of things along the way for compatibility with TinyBird, namely the query parameter `activityType` -> `activity_type` and the `stars` and `forks` having to be `star` and `fork` when talking to TinyBird.

The stars and forks code to fetch data from TinyBird is pretty much the same. The difference is only because of the variable names in the results the frontend expects. Because of that, I did not unify the two but [I want to revisit this](https://linear.app/lfx/issue/INS-175/refactor-stars-and-forks-logic).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added enhanced filtering options for fork and star activities, supporting dynamic data retrieval for more accurate analytics.
  
- **Refactor**
  - Standardized chart date fields by renaming parameters to “startDate” and “endDate.”
  - Improved leaderboard filtering by incorporating project context and default granularity.
  
- **Chores**
  - Upgraded underlying data handling and type definitions to ensure robust, real-time insights.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->