### PR TITLE
Fix getting the collections and projects count from TinyBird

### DIFF
--- a/frontend/server/api/collection/index.ts
+++ b/frontend/server/api/collection/index.ts
@@ -41,16 +41,21 @@ export default defineEventHandler(async (event): Promise<Pagination<Collection> 
             orderByDirection,
         });
 
+        type CollectionCount = {'count(id)': number};
+        const collectionCountResult = await fetchFromTinybird<CollectionCount[]>('/v0/pipes/collections_list.json', {
+            count: true,
+        });
+
         const data: Pagination<Collection> = {
             page,
             pageSize,
-            total: res.rows,
+            total: collectionCountResult.data[0]?.['count(id)'] || 0,
             data: res.data,
         }
 
         return data
     } catch (error) {
-        console.error('Error collection list:', error);
+        console.error('Error fetching collection list from TinyBird:', error);
         throw createError({statusCode: 500, statusMessage: 'Internal Server Error'});
     }
 });

--- a/frontend/server/api/project/index.ts
+++ b/frontend/server/api/project/index.ts
@@ -56,16 +56,21 @@ export default defineEventHandler(async (event): Promise<Pagination<Project> | E
             orderByDirection,
         });
 
+        type ProjectCount = {'count(id)': number};
+        const projectCountResult = await fetchFromTinybird<ProjectCount[]>('/v0/pipes/projects_list.json', {
+            count: true,
+        });
+
         const data: Pagination<Project> = {
             page,
             pageSize,
-            total: res.rows,
+            total: projectCountResult.data[0]?.['count(id)'] || 0,
             data: res.data,
         }
 
         return data;
     } catch (error) {
-        console.error('Error fetching project list:', error);
+        console.error('Error fetching project list from TinyBird:', error);
         throw createError({statusCode: 500, statusMessage: 'Internal Server Error'});
     }
 });


### PR DESCRIPTION
The TinyBird endpoint for the collections and projects list require a separate query to get the total count but our backend API is only making one request for the data, so the total it returns to the frontend is the total number of values in the query result, not the total available in TinyBird.

The ticket in Linear is [here](https://linear.app/lfx/issue/INS-225/[collections]-total-number-returned-in-the-api-is-not-correct).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Total collections are now calculated more accurately by retrieving count data directly from an external data source.
	- Total projects are now calculated more accurately by fetching project count data from an external source.
- **Bug Fixes**
	- Improved error logging messages for clarity when fetching collection and project lists from TinyBird.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->