### PR TITLE
[INS-216] Fix activity type filter for the contributors dependency data

### DIFF
--- a/frontend/server/api/project/[slug]/contributors/contributor-dependency.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/contributor-dependency.get.ts
@@ -1,6 +1,8 @@
 import {DateTime} from "luxon";
 import {createDataSource} from "~~/server/data/data-sources";
-import {FilterActivityMetric, FilterGranularity} from "~~/server/data/types";
+import {FilterGranularity} from "~~/server/data/types";
+import {ActivityTypes} from "~~/types/shared/activity-types";
+import {ActivityPlatforms} from "~~/types/shared/activity-platforms";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -36,10 +38,14 @@ export default defineEventHandler(async (event) => {
 
   const project = (event.context.params as { slug: string }).slug;
 
+  const activityPlatform = query.platform as ActivityPlatforms;
+  const activityType = query.activityType as ActivityTypes;
+
   const filter = {
     project,
     granularity: (query.granularity as FilterGranularity) || FilterGranularity.QUARTERLY,
-    metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
+    platform: activityPlatform !== ActivityPlatforms.ALL ? activityPlatform : undefined,
+    activity_type: activityType !== ActivityTypes.ALL ? activityType : undefined,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/data/tinybird/contributors-dependency-data-source.ts
+++ b/frontend/server/data/tinybird/contributors-dependency-data-source.ts
@@ -37,12 +37,8 @@ export async function fetchContributorDependency(filter: ContributorDependencyFi
   //  We need to ensure this doesn't pose a security risk.
 
   const leaderboardFilter: ContributorsLeaderboardFilter = {
-    project: filter.project,
-    metric: (filter.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
-    repository: filter.repository,
-    limit: 5,
-    startDate: filter.startDate,
-    endDate: filter.endDate,
+    ...filter,
+    limit: 5
   };
 
   const [tinybirdTopContributorsResponse, tinybirdLeaderboardResponse] = await Promise.all([

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -1,4 +1,6 @@
 import type {DateTime} from "luxon";
+import type {ActivityTypes} from "~~/types/shared/activity-types";
+import type {ActivityPlatforms} from "~~/types/shared/activity-platforms";
 
 export type FetchFunction = typeof $fetch;
 
@@ -57,7 +59,8 @@ export type OrganizationsLeaderboardFilter = {
 export type ContributorDependencyFilter = {
   project: string;
   repository?: string;
-  metric?: FilterActivityMetric;
+  platform?: ActivityPlatforms;
+  activity_type?: ActivityTypes;
   startDate?: DateTime;
   endDate?: DateTime;
 }


### PR DESCRIPTION
[Linear ticket](https://linear.app/lfx/issue/INS-216/picking-different-activities-shows-the-same-numbers-on-the-contributor).

## :information_source: This PR is part of a stack
Please review them in order, as some of the first ones set the foundation for the later ones.
* main branch
    * PR #109 
        * PR #110 
            * PR #111  :point_left: You are here
                * PR #112 
                    * PR #113 
                        * PR #114
                            * PR #115 
                              *  PR #116 
                                 * PR #117