### PR TITLE
[INS-216] Fix activity type filter for the organizations  dependency data

### DIFF
--- a/frontend/server/api/project/[slug]/contributors/organization-dependency.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/organization-dependency.get.ts
@@ -1,6 +1,8 @@
 import {DateTime} from "luxon";
-import {FilterActivityMetric, FilterGranularity} from "~~/server/data/types";
+import {FilterGranularity} from "~~/server/data/types";
 import {createDataSource} from "~~/server/data/data-sources";
+import {ActivityTypes} from "~~/types/shared/activity-types";
+import {ActivityPlatforms} from "~~/types/shared/activity-platforms";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -36,10 +38,14 @@ export default defineEventHandler(async (event) => {
 
   const project = (event.context.params as { slug: string }).slug;
 
+  const activityPlatform = query.platform as ActivityPlatforms;
+  const activityType = query.activityType as ActivityTypes;
+
   const filter = {
     project,
     granularity: (query.granularity as FilterGranularity) || FilterGranularity.QUARTERLY,
-    metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
+    platform: activityPlatform !== ActivityPlatforms.ALL ? activityPlatform : undefined,
+    activity_type: activityType !== ActivityTypes.ALL ? activityType : undefined,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/data/tinybird/organizations-dependency-data-source.ts
+++ b/frontend/server/data/tinybird/organizations-dependency-data-source.ts
@@ -2,7 +2,6 @@ import type {
   OrganizationDependencyFilter,
   OrganizationsLeaderboardFilter,
 } from "../types";
-import {FilterActivityMetric} from "../types";
 import {fetchFromTinybird} from './tinybird'
 import type {OrganizationsLeaderboardDataPoint} from "~~/server/data/tinybird/organizations-leaderboard-source";
 import {fetchOrganizationsLeaderboard} from "~~/server/data/tinybird/organizations-leaderboard-source";
@@ -38,12 +37,8 @@ export async function fetchOrganizationDependency(filter: OrganizationDependency
   //  We need to ensure this doesn't pose a security risk.
 
   const leaderboardFilter: OrganizationsLeaderboardFilter = {
-    project: filter.project,
-    metric: (filter.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
-    repository: filter.repository,
+    ...filter,
     limit: 5,
-    startDate: filter.startDate,
-    endDate: filter.endDate,
   };
 
   const [tinybirdTopOrganizationsResponse, tinybirdLeaderboardResponse] = await Promise.all([

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -68,7 +68,8 @@ export type ContributorDependencyFilter = {
 export type OrganizationDependencyFilter = {
   project: string;
   repository?: string;
-  metric?: FilterActivityMetric;
+  platform?: ActivityPlatforms;
+  activity_type?: ActivityTypes;
   startDate?: DateTime;
   endDate?: DateTime;
 }


### PR DESCRIPTION
[Linear ticket](https://linear.app/lfx/issue/INS-216/picking-different-activities-shows-the-same-numbers-on-the-contributor).

## :information_source: This PR is part of a stack
Please review them in order, as some of the first ones set the foundation for the later ones.
* main branch
    * PR #109 
        * PR #110
            * PR #111 
                * PR #112  :point_left: You are here
                    * PR #113 
                        * PR #114
                            * PR #115 
                              *  PR #116 
                                 * PR #117

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced filtering options now allow you to refine results by activity platform and activity type for organization dependency data.
  
- **Refactor**
  - Streamlined the filter processing to simplify parameter handling and improve overall consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->