### PR TITLE
[INS-216] Fix activity type filter for the contributor leaderboard data

### DIFF
--- a/frontend/server/api/project/[slug]/contributors/contributor-leaderboard.get.ts
+++ b/frontend/server/api/project/[slug]/contributors/contributor-leaderboard.get.ts
@@ -1,7 +1,8 @@
 import {DateTime} from "luxon";
 import {createDataSource} from "~~/server/data/data-sources";
 import type {ContributorsLeaderboardFilter} from "~~/server/data/types";
-import {FilterActivityMetric} from "~~/server/data/types";
+import {ActivityTypes} from "~~/types/shared/activity-types";
+import {ActivityPlatforms} from "~~/types/shared/activity-platforms";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -37,9 +38,13 @@ export default defineEventHandler(async (event) => {
 
   const project = (event.context.params as { slug: string }).slug;
 
+  const activityPlatform = query.platform as ActivityPlatforms;
+  const activityType = query.activityType as ActivityTypes;
+
   const filter: ContributorsLeaderboardFilter = {
     project,
-    metric: (query.metric as FilterActivityMetric) || FilterActivityMetric.ALL,
+    platform: activityPlatform !== ActivityPlatforms.ALL ? activityPlatform : undefined,
+    activity_type: activityType !== ActivityTypes.ALL ? activityType : undefined,
     repository: query.repository as string,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/data/tinybird/contributors-leaderboard-source.ts
+++ b/frontend/server/data/tinybird/contributors-leaderboard-source.ts
@@ -31,17 +31,9 @@ export async function fetchContributorsLeaderboard(
   // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
   //  We need to ensure this doesn't pose a security risk.
 
-  const contributorsLeaderboardQuery = {
-    project: filter.project,
-    repository: filter.repository,
-    limit: filter.limit,
-    startDate: filter.startDate,
-    endDate: filter.endDate,
-  };
-
   const data = await fetchFromTinybird<TinybirdContributorsLeaderboardData>(
     '/v0/pipes/contributors_leaderboard.json',
-    contributorsLeaderboardQuery
+    filter
   );
 
   let processedData: ContributorsLeaderboardData = [];

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -40,7 +40,8 @@ export type ActiveOrganizationsFilter = {
 
 export type ContributorsLeaderboardFilter = {
   project: string;
-  metric: FilterActivityMetric;
+  platform?: ActivityPlatforms;
+  activity_type?: ActivityTypes;
   repository?: string;
   limit?: number;
   startDate?: DateTime;


### PR DESCRIPTION
[Linear ticket](https://linear.app/lfx/issue/INS-216/picking-different-activities-shows-the-same-numbers-on-the-contributor).

## :information_source: This PR is part of a stack
Please review them in order, as some of the first ones set the foundation for the later ones.
* main branch
    * PR #109 
        * PR #110
            * PR #111 
                * PR #112 
                    * PR #113  :point_left: You are here
                        * PR #114
                            * PR #115 
                              *  PR #116 
                                 * PR #117