### PR TITLE
Fix git add . on pre-commit hook

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -3,5 +3,5 @@ if git diff --name-only --cached | grep 'frontend/';
   then
     echo "FRONTEND FOLDER CHANGED --> starting husky..."
     cd frontend && pnpm lint:fix && pnpm tsc-check
-    git add .
+    git add -u
 fi


### PR DESCRIPTION
We have git add . in our git pre-commit hook but this has a big problem: it adds ALL changes in the working directory into the commit, whether they had been staged or not. This means that when someone has multiple changed / new files in the working directory, the commits end up with all those files in the commit, even if the user only intended for a couple of them to be there.

Instead, only files that were already staged, meaning explicitly added by the user, should be added by the hook. Git add has the -u flag for that.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Updated the commit staging process to include only modifications and deletions of existing files, reducing the chance of inadvertently adding new untracked files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->