### PR TITLE
[INS-243] Fix fetching collection projects count from TinyBird

### DIFF
--- a/frontend/server/api/project/index.ts
+++ b/frontend/server/api/project/index.ts
@@ -58,6 +58,8 @@ export default defineEventHandler(async (event): Promise<Pagination<Project> | E
 
         type ProjectCount = {'count(id)': number};
         const projectCountResult = await fetchFromTinybird<ProjectCount[]>('/v0/pipes/projects_list.json', {
+            collectionSlug,
+            isLf,
             count: true,
         });
 


### PR DESCRIPTION
The TinyBird query to fetch the total projects count was missing a couple of parameters.

[Linear ticket](https://linear.app/lfx/issue/INS-243/total-returned-in-the-api-is-not-correct).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
	- Enhanced project count filtering with additional options for more refined results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->