### PR TITLE
Better pre-commit hook

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,7 +1,9 @@
 #run husky pre-commit hook only if frontend changed
-if git diff --name-only --cached | grep 'frontend/';
+if git diff --diff-filter=d --name-only --cached | grep 'frontend/';
   then
     echo "FRONTEND FOLDER CHANGED --> starting husky..."
-    cd frontend && pnpm lint:fix && pnpm tsc-check
-    git add -u
+    cd frontend && \
+    pnpm exec eslint --fix $(git diff --diff-filter=d --name-only --cached --relative) && \
+    pnpm tsc-check
+    git add -u $(git diff --diff-filter=d --name-only --cached --relative)
 fi


### PR DESCRIPTION
This is related to #118 

In it, I forgot that even though `git add -u` doesn't add new files, it still adds all the changed files that were already tracked (i.e. that had previously been `git add`ed). In other words, it didn't fully fix the problem.

This PR introduces a few more changes to overcome the issue, while not disrupting the team's preferred workflow of having the pre-commit hook modify the files about to be committed, but at the same time preventing adding files that were not explicitly added to the commit, as was the goal of the other PR.

This one also adds a couple of minor changes that should speed things up a bit.

* Added the `--diff-filter=d` in the initial check so that the hook doesn't run if the only changes are deleted files.
* Only run eslint for files that were added for this commit - this makes it much faster than running linting for the whole codebase, and also doesn't make even more unexpected changes. I had to run eslint directly instead of relying on the `lint:fix` script from package.json because that one already specifies the `.` path, meaning ESLint would run for the whole codebase.
* Only run `git add` after linting for files that were explicitly added for this commit, as opposed to adding everything, so that we don't have unexpected surprises.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

- **Chores**
  - Enhanced pre-commit hook to improve handling of changes in the frontend directory by targeting only modified files for automated code quality fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->