### PR TITLE
[INS 328] Create tests for contributors dependency

### DIFF
--- a/frontend/server/data/tinybird/contributors-dependency-data-source.test.ts
+++ b/frontend/server/data/tinybird/contributors-dependency-data-source.test.ts
@@ -1,0 +1,81 @@
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import {DateTime} from "luxon";
+import {mockTimeseries} from '../../mocks/tinybird-contributors-dependency-response.mock';
+import {mockTimeseries as mockLeaderboardTimeseries} from '../../mocks/tinybird-contributors-leaderboard-response.mock';
+import type {ContributorDependencyResponse} from "~~/server/data/tinybird/contributors-dependency-data-source";
+
+const mockFetchFromTinybird = vi.fn();
+
+describe('Contributors Dependency Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // Here be dragons! vi.doMock is not hoisted, and thus it is executed after the original import statement.
+    // This means that the import for tinybird.ts inside active-contributors-data-source.ts would still be used,
+    // and thus not mocked. This means we need to import the module again after the mock is set, whenever we want to
+    // use it.
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  })
+
+  test('should fetch contributors dependency data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchContributorDependency} = await import("~~/server/data/tinybird/contributors-dependency-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockTimeseries).mockResolvedValueOnce(mockLeaderboardTimeseries);
+
+    const startDate = DateTime.utc(2024, 3, 20);
+    const endDate = DateTime.utc(2025, 3, 20);
+
+    const filter = {
+      project: 'the-linux-kernel-organization',
+      startDate,
+      endDate
+    };
+
+    const result = await fetchContributorDependency(filter);
+
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(
+      1,
+      '/v0/pipes/contributor_dependency.json',
+      filter
+    )
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(
+      2,
+      '/v0/pipes/contributors_leaderboard.json',
+      {
+        ...filter,
+        limit: 5
+      }
+    );
+
+    const topContributorsCount = mockTimeseries.data.length;
+    const lastContributor = mockTimeseries.data.at(-1);
+    const topContributorsPercentage = lastContributor?.contributionPercentageRunningTotal || 0;
+    const totalContributorCount = mockTimeseries.data[0]?.totalContributorCount || 0;
+
+    const expectedResult: ContributorDependencyResponse = {
+      topContributors: {
+        count: topContributorsCount,
+        percentage: topContributorsPercentage
+      },
+      otherContributors: {
+        count: Math.max(0, (totalContributorCount || 0) - topContributorsCount),
+        percentage: 100 - topContributorsPercentage
+      },
+      list: mockLeaderboardTimeseries.data.map((item) => ({
+        avatar: item.avatar,
+        name: item.displayName,
+        contributions: item.contributionCount,
+        percentage: item.contributionPercentage
+      }))
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  // TODO: Add checks for invalid dates, invalid data, sql injections, and other edge cases.
+});

--- a/frontend/server/mocks/tinybird-contributors-dependency-response.mock.ts
+++ b/frontend/server/mocks/tinybird-contributors-dependency-response.mock.ts
@@ -1,0 +1,103 @@
+export const mockTimeseries = {
+  meta: [
+    {
+      name: "id",
+      type: "String"
+    },
+    {
+      name: "displayName",
+      type: "String"
+    },
+    {
+      name: "contributionPercentage",
+      type: "Float64"
+    },
+    {
+      name: "contributionPercentageRunningTotal",
+      type: "Float64"
+    },
+    {
+      name: "totalContributorCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      id: "7f65feb0-589b-11ee-bf26-d732180a3416",
+      displayName: "Mark Brown",
+      contributionPercentage: 2,
+      contributionPercentageRunningTotal: 7,
+      totalContributorCount: 6754
+    },
+    {
+      id: "a3bbff07-7cec-4885-b688-d8b377a580c6",
+      displayName: "Alex Deucher",
+      contributionPercentage: 2,
+      contributionPercentageRunningTotal: 9,
+      totalContributorCount: 6754
+    },
+    {
+      id: "b17e3beb-09e2-447f-a12d-00c716dd00db",
+      displayName: "Jakub Kicinski",
+      contributionPercentage: 3,
+      contributionPercentageRunningTotal: 3,
+      totalContributorCount: 6754
+    },
+    {
+      id: "6ac1a927-efc8-4b42-9cd4-683f7ec2e4c8",
+      displayName: "Len Brown",
+      contributionPercentage: 2,
+      contributionPercentageRunningTotal: 5,
+      totalContributorCount: 6754
+    },
+    {
+      id: "d47386a6-3890-42c3-8c26-6872a8e38c2c",
+      displayName: "Linus Torvalds",
+      contributionPercentage: 2,
+      contributionPercentageRunningTotal: 11,
+      totalContributorCount: 6754
+    },
+    {
+      id: "eb7fc260-77d6-11ef-b115-a7c57b0467ff",
+      displayName: "Greg Kroah-Hartman",
+      contributionPercentage: 2,
+      contributionPercentageRunningTotal: 13,
+      totalContributorCount: 6754
+    },
+    {
+      id: "03a88390-f8f7-11ee-9733-23f194e8fceb",
+      displayName: "Kent Overstreet",
+      contributionPercentage: 1,
+      contributionPercentageRunningTotal: 14,
+      totalContributorCount: 6754
+    },
+    {
+      id: "e068c75f-716e-4248-b8fa-4e97aaa76fc9",
+      displayName: "Christian Brauner",
+      contributionPercentage: 1,
+      contributionPercentageRunningTotal: 16,
+      totalContributorCount: 6754
+    },
+    {
+      id: "7b2a3b66-d42a-442c-99c0-5cdc4f0c5a56",
+      displayName: "Krzysztof Kozlowski",
+      contributionPercentage: 1,
+      contributionPercentageRunningTotal: 15,
+      totalContributorCount: 6754
+    },
+    {
+      id: "f215f342-dd22-4f08-b70a-f2cb589b9f41",
+      displayName: "Bjorn Andersson",
+      contributionPercentage: 1,
+      contributionPercentageRunningTotal: 17,
+      totalContributorCount: 6754
+    }
+  ],
+  rows: 10,
+  rows_before_limit_at_least: 6754,
+  statistics: {
+    elapsed: 1.899921774,
+    rows_read: 2301274,
+    bytes_read: 189901864
+  }
+};


### PR DESCRIPTION
This fixes the tests for the Contributors Dependency data source.

It just takes care of the most basic test. The goal is simply to have a basic security harness so we can refactor things without fear of breaking stuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
	- Introduced new unit tests to verify the proper handling of contributor dependency data under simulated API responses.
	- Added a comprehensive mock data set to emulate realistic contributor metrics, ensuring robust verification of counts, percentages, and performance details. 

<!-- end of auto-generated comment: release notes by coderabbit.ai -->