### PR TITLE
[INS 329] Create tests for organizations dependency

### DIFF
--- a/frontend/server/data/tinybird/organizations-dependency-data-source.test.ts
+++ b/frontend/server/data/tinybird/organizations-dependency-data-source.test.ts
@@ -1,0 +1,84 @@
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import {DateTime} from "luxon";
+import {mockTimeseries} from '../../mocks/tinybird-organizations-dependency-response.mock';
+import {
+  mockTimeseries as mockLeaderboardTimeseries
+} from '../../mocks/tinybird-organizations-leaderboard-response.mock';
+import type {OrganizationDependencyResponse} from "~~/server/data/tinybird/organizations-dependency-data-source";
+
+const mockFetchFromTinybird = vi.fn();
+
+describe('Organizations Dependency Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // Here be dragons! vi.doMock is not hoisted, and thus it is executed after the original import statement.
+    // This means that the import for tinybird.ts inside active-organizations-data-source.ts would still be used,
+    // and thus not mocked. This means we need to import the module again after the mock is set, whenever we want to
+    // use it.
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  })
+
+  test('should fetch organizations dependency data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchOrganizationDependency} = await import("~~/server/data/tinybird/organizations-dependency-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockTimeseries).mockResolvedValueOnce(mockLeaderboardTimeseries);
+
+    const startDate = DateTime.utc(2024, 3, 20);
+    const endDate = DateTime.utc(2025, 3, 20);
+
+    const filter = {
+      project: 'the-linux-kernel-organization',
+      startDate,
+      endDate
+    };
+
+    const result = await fetchOrganizationDependency(filter);
+
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(
+      1,
+      '/v0/pipes/organization_dependency.json',
+      filter
+    )
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(
+      2,
+      '/v0/pipes/organizations_leaderboard.json',
+      {
+        ...filter,
+        limit: 5
+      }
+    );
+
+    const topOrganizationsCount = mockTimeseries.data.length;
+    const lastOrganization = mockTimeseries.data.at(-1);
+    const topOrganizationsPercentage = lastOrganization?.contributionPercentageRunningTotal || 0;
+    const totalOrganizationCount = mockTimeseries.data[0]?.totalOrganizationCount || 0;
+
+    const expectedResult: OrganizationDependencyResponse = {
+      topOrganizations: {
+        count: topOrganizationsCount,
+        percentage: topOrganizationsPercentage
+      },
+      otherOrganizations: {
+        count: Math.max(0, (totalOrganizationCount || 0) - topOrganizationsCount),
+        percentage: 100 - topOrganizationsPercentage
+      },
+      list: mockLeaderboardTimeseries.data.map((item) => ({
+        logo: item.logo,
+        name: item.displayName,
+        contributions: item.contributionCount,
+        percentage: item.contributionPercentage,
+        website: ''
+      }))
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  // TODO: Add checks for invalid dates, invalid data, sql injections, and other edge cases.
+});

--- a/frontend/server/mocks/tinybird-organizations-dependency-response.mock.ts
+++ b/frontend/server/mocks/tinybird-organizations-dependency-response.mock.ts
@@ -1,0 +1,84 @@
+// https://api.us-west-2.aws.tinybird.co/v0/pipes/organization_dependency.json?startDate=2024-03-20 00:00:00&endDate=2025-03-20 00:00:00&project=the-linux-kernel-organization
+
+export const mockTimeseries = {
+  meta: [
+    {
+      name: "id",
+      type: "String"
+    },
+    {
+      name: "displayName",
+      type: "String"
+    },
+    {
+      name: "contributionPercentage",
+      type: "Float64"
+    },
+    {
+      name: "contributionPercentageRunningTotal",
+      type: "Float64"
+    },
+    {
+      name: "totalOrganizationCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      id: "d7bf07d9-780b-4279-bfbc-d83f85950353",
+      displayName: "Red Hat, Inc.",
+      contributionPercentage: 13,
+      contributionPercentageRunningTotal: 13,
+      totalOrganizationCount: 952
+    },
+    {
+      id: "9f7f73b0-95d6-49c2-bffe-8300c03852ef",
+      displayName: "Linaro Limited",
+      contributionPercentage: 10,
+      contributionPercentageRunningTotal: 23,
+      totalOrganizationCount: 952
+    },
+    {
+      id: "0c562f29-ab29-4383-b4ca-85457367ee39",
+      displayName: "Arm Limited",
+      contributionPercentage: 7,
+      contributionPercentageRunningTotal: 30,
+      totalOrganizationCount: 952
+    },
+    {
+      id: "987a49ec-31c9-4611-a5f0-a0ce52a999b2",
+      displayName: "SUSE",
+      contributionPercentage: 7,
+      contributionPercentageRunningTotal: 37,
+      totalOrganizationCount: 952
+    },
+    {
+      id: "543dd100-3a92-4a9d-ba5a-d629f452681a",
+      displayName: "Advanced Micro Devices (AMD)",
+      contributionPercentage: 6,
+      contributionPercentageRunningTotal: 43,
+      totalOrganizationCount: 952
+    },
+    {
+      id: "51fde723-67df-4e0e-91c6-936d01d59559",
+      displayName: "The Linux Foundation",
+      contributionPercentage: 5,
+      contributionPercentageRunningTotal: 48,
+      totalOrganizationCount: 952
+    },
+    {
+      id: "522278e4-d0dc-4ddb-a7bc-739253b760cf",
+      displayName: "Qualcomm, Inc.",
+      contributionPercentage: 3,
+      contributionPercentageRunningTotal: 51,
+      totalOrganizationCount: 952
+    }
+  ],
+  rows: 7,
+  rows_before_limit_at_least: 926,
+  statistics: {
+    elapsed: 0.840925162,
+    rows_read: 1345215,
+    bytes_read: 140177381
+  }
+};


### PR DESCRIPTION
This fixes the tests for the Organizations Dependency data source.

It just takes care of the most basic test. The goal is simply to have a basic security harness so we can refactor things without fear of breaking stuff.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Introduced an automated workflow that validates pull requests, strengthening overall system reliability.
- **Tests**
	- Expanded testing coverage with new unit tests for organization data processes.
	- Streamlined contributor data tests to maintain smooth pipeline execution.
	- Improved simulated responses for external service interactions to enhance quality assurance.
- **Refactor**
	- Simplified the configuration retrieval approach for external integration, ensuring consistent operation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->