### PR TITLE
[INS 335] Create tests for retention

### DIFF
--- a/frontend/server/data/tinybird/retention-data-source.test.ts
+++ b/frontend/server/data/tinybird/retention-data-source.test.ts
@@ -1,0 +1,103 @@
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import {DateTime} from "luxon";
+import {
+  mockContributorRetentionData,
+  mockOrganizationRetentionData
+} from '../../mocks/tinybird-retention-response.mock';
+import {DemographicType, FilterGranularity} from "~~/server/data/types";
+import type {RetentionDataPoint, RetentionResponse} from "~~/server/data/tinybird/retention-data-source";
+
+const mockFetchFromTinybird = vi.fn();
+
+describe('Retention Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // Here be dragons! vi.doMock is not hoisted, and thus it is executed after the original import statement.
+    // This means that the import for tinybird.ts inside active-organizations-data-source.ts would still be used,
+    // and thus not mocked. This means we need to import the module again after the mock is set, whenever we want to
+    // use it.
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  })
+
+  test('should fetch contributors retention data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchRetention} = await import("~~/server/data/tinybird/retention-data-source");
+
+    mockFetchFromTinybird.mockResolvedValue(mockContributorRetentionData);
+
+    const startDate = DateTime.utc(2024, 3, 20);
+    const endDate = DateTime.utc(2025, 3, 20);
+
+    const filter = {
+      project: 'the-linux-kernel-organization',
+      granularity: FilterGranularity.MONTHLY,
+      onlyContributions: false,
+      demographicType: DemographicType.CONTRIBUTORS,
+      startDate,
+      endDate
+    };
+
+    const result = await fetchRetention(filter);
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/contributor_retention.json',
+      filter
+    );
+
+    const expectedResult: RetentionResponse = mockContributorRetentionData.data.map(
+      (item): RetentionDataPoint => ({
+        startDate: item.startDate,
+        endDate: item.endDate,
+        percentage: item.retentionRate,
+      })
+    );
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  // Ideally, this second scenario should be done with a test matrix, so we don't have to repeat so much code.
+  // After a bried search, I couldn't find documentation on how to do this with Vitest, so I'm opting for leaving it
+  // like this for now.
+  test('should fetch organization retention data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchRetention} = await import("~~/server/data/tinybird/retention-data-source");
+
+    mockFetchFromTinybird.mockResolvedValue(mockOrganizationRetentionData);
+
+    const startDate = DateTime.utc(2024, 3, 20);
+    const endDate = DateTime.utc(2025, 3, 20);
+
+    const filter = {
+      project: 'the-linux-kernel-organization',
+      granularity: FilterGranularity.MONTHLY,
+      onlyContributions: false,
+      demographicType: DemographicType.ORGANIZATIONS,
+      startDate,
+      endDate
+    };
+
+    const result = await fetchRetention(filter);
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/organization_retention.json',
+      filter
+    );
+
+    const expectedResult: RetentionResponse = mockOrganizationRetentionData.data.map(
+      (item): RetentionDataPoint => ({
+        startDate: item.startDate,
+        endDate: item.endDate,
+        percentage: item.retentionRate,
+      })
+    );
+
+    expect(result).toEqual(expectedResult);
+  });
+
+  // TODO: Add checks for invalid dates, invalid data, sql injections, and other edge cases.
+});

--- a/frontend/server/mocks/tinybird-retention-response.mock.ts
+++ b/frontend/server/mocks/tinybird-retention-response.mock.ts
@@ -1,0 +1,181 @@
+// https://api.us-west-2.aws.tinybird.co/v0/pipes/contributor_retention.json?startDate=2024-03-20 00:00:00&endDate=2025-03-20 00:00:00&project=the-linux-kernel-organization&granularity=monthly
+export const mockContributorRetentionData = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "retentionRate",
+      type: "Float64"
+    }
+  ],
+  data: [
+    {
+      startDate: "2024-03-01",
+      endDate: "2024-03-31",
+      retentionRate: 68.94
+    },
+    {
+      startDate: "2024-04-01",
+      endDate: "2024-04-30",
+      retentionRate: 64.67
+    },
+    {
+      startDate: "2024-05-01",
+      endDate: "2024-05-31",
+      retentionRate: 57.39
+    },
+    {
+      startDate: "2024-06-01",
+      endDate: "2024-06-30",
+      retentionRate: 60.57
+    },
+    {
+      startDate: "2024-07-01",
+      endDate: "2024-07-31",
+      retentionRate: 58.64
+    },
+    {
+      startDate: "2024-08-01",
+      endDate: "2024-08-31",
+      retentionRate: 59.72
+    },
+    {
+      startDate: "2024-09-01",
+      endDate: "2024-09-30",
+      retentionRate: 56.22
+    },
+    {
+      startDate: "2024-10-01",
+      endDate: "2024-10-31",
+      retentionRate: 58.57
+    },
+    {
+      startDate: "2024-11-01",
+      endDate: "2024-11-30",
+      retentionRate: 53.05
+    },
+    {
+      startDate: "2024-12-01",
+      endDate: "2024-12-31",
+      retentionRate: 58.64
+    },
+    {
+      startDate: "2025-01-01",
+      endDate: "2025-01-31",
+      retentionRate: 57.77
+    },
+    {
+      startDate: "2025-02-01",
+      endDate: "2025-02-28",
+      retentionRate: 27.87
+    },
+    {
+      startDate: "2025-03-01",
+      endDate: "2025-03-31",
+      retentionRate: 38.83
+    }
+  ],
+  rows: 13,
+  statistics: {
+    elapsed: 0.412489953,
+    rows_read: 795243,
+    bytes_read: 75444485
+  }
+};
+
+// https://api.us-west-2.aws.tinybird.co/v0/pipes/organization_retention.json?startDate=2024-03-20 00:00:00&endDate=2025-03-20 00:00:00&project=the-linux-kernel-organization&granularity=monthly
+export const mockOrganizationRetentionData = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "retentionRate",
+      type: "Float64"
+    }
+  ],
+  data: [
+    {
+      startDate: "2024-03-01",
+      endDate: "2024-03-31",
+      retentionRate: 77.74
+    },
+    {
+      startDate: "2024-04-01",
+      endDate: "2024-04-30",
+      retentionRate: 72.45
+    },
+    {
+      startDate: "2024-05-01",
+      endDate: "2024-05-31",
+      retentionRate: 67.73
+    },
+    {
+      startDate: "2024-06-01",
+      endDate: "2024-06-30",
+      retentionRate: 69.36
+    },
+    {
+      startDate: "2024-07-01",
+      endDate: "2024-07-31",
+      retentionRate: 68.42
+    },
+    {
+      startDate: "2024-08-01",
+      endDate: "2024-08-31",
+      retentionRate: 72
+    },
+    {
+      startDate: "2024-09-01",
+      endDate: "2024-09-30",
+      retentionRate: 66.43
+    },
+    {
+      startDate: "2024-10-01",
+      endDate: "2024-10-31",
+      retentionRate: 72.3
+    },
+    {
+      startDate: "2024-11-01",
+      endDate: "2024-11-30",
+      retentionRate: 59.8
+    },
+    {
+      startDate: "2024-12-01",
+      endDate: "2024-12-31",
+      retentionRate: 43.25
+    },
+    {
+      startDate: "2025-01-01",
+      endDate: "2025-01-31",
+      retentionRate: 52.55
+    },
+    {
+      startDate: "2025-02-01",
+      endDate: "2025-02-28",
+      retentionRate: 47.59
+    },
+    {
+      startDate: "2025-03-01",
+      endDate: "2025-03-31",
+      retentionRate: 63.79
+    }
+  ],
+  rows: 13,
+  statistics: {
+    elapsed: 0.068190336,
+    rows_read: 795243,
+    bytes_read: 66313517
+  }
+};


### PR DESCRIPTION
This fixes the tests for the Retention data source.

It just takes care of the most basic test. The goal is simply to have a basic security harness so we can refactor things without fear of breaking stuff.