### PR TITLE
changed the default for widgets with new and cumulative tabs

### DIFF
--- a/frontend/app/components/modules/project/components/popularity/forks.vue
+++ b/frontend/app/components/modules/project/components/popularity/forks.vue
@@ -87,7 +87,7 @@ const {
   startDate, endDate, selectedRepository, selectedTimeRangeKey, customRangeGranularity
 } = storeToRefs(useProjectStore())
 
-const activeTab = ref('cumulative');
+const activeTab = ref('new');
 const route = useRoute();
 
 const barGranularity = computed(() => (selectedTimeRangeKey.value === dateOptKeys.custom
@@ -126,8 +126,8 @@ const chartData = computed<ChartData[]>(
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 
 const tabs = [
+  { label: 'New', value: 'new' },
   { label: 'Cumulative', value: 'cumulative' },
-  { label: 'New', value: 'new' }
 ];
 
 const chartSeries = computed<ChartSeries[]>(() => [

--- a/frontend/app/components/modules/project/components/popularity/github-mentions.vue
+++ b/frontend/app/components/modules/project/components/popularity/github-mentions.vue
@@ -91,7 +91,7 @@ const {
   customRangeGranularity
 } = storeToRefs(useProjectStore())
 
-const activeTab = ref('cumulative');
+const activeTab = ref('new-mentions');
 const route = useRoute();
 const keyword = computed(() => project.value?.name);
 
@@ -130,8 +130,8 @@ const chartData = computed<ChartData[]>(
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 
 const tabs = [
+  { label: 'New Mentions', value: 'new-mentions' },
   { label: 'Cumulative', value: 'cumulative' },
-  { label: 'New Mentions', value: 'new-mentions' }
 ];
 
 const chartSeries = computed<ChartSeries[]>(() => [

--- a/frontend/app/components/modules/project/components/popularity/package-downloads.vue
+++ b/frontend/app/components/modules/project/components/popularity/package-downloads.vue
@@ -84,7 +84,7 @@ const {
   customRangeGranularity
 } = storeToRefs(useProjectStore())
 
-const activeTab = ref('cumulative');
+const activeTab = ref('new-downloads');
 const route = useRoute();
 
 const barGranularity = computed(() => (selectedTimeRangeKey.value === dateOptKeys.custom
@@ -122,8 +122,8 @@ const chartData = computed<ChartData[]>(
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 
 const tabs = [
+  { label: 'New Downloads', value: 'new-downloads' },
   { label: 'Cumulative', value: 'cumulative' },
-  { label: 'New Downloads', value: 'new-downloads' }
 ];
 
 const chartSeries = computed<ChartSeries[]>(() => [

--- a/frontend/app/components/modules/project/components/popularity/social-mentions.vue
+++ b/frontend/app/components/modules/project/components/popularity/social-mentions.vue
@@ -113,7 +113,7 @@ const {
 } = storeToRefs(useProjectStore())
 const keyword = computed(() => project.value?.name);
 
-const activeTab = ref('cumulative');
+const activeTab = ref('new-mentions');
 const route = useRoute();
 
 const barGranularity = computed(() => (selectedTimeRangeKey.value === dateOptKeys.custom
@@ -155,8 +155,8 @@ const chartData = computed<ChartData[]>(
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 
 const tabs = [
+  { label: 'New mentions by platform', value: 'new-mentions' },
   { label: 'Mentions by platform', value: 'cumulative' },
-  { label: 'New mentions by platform', value: 'new-mentions' }
 ];
 
 const chartSeries = computed<ChartSeries[]>(() => [

--- a/frontend/app/components/modules/project/components/popularity/stars.vue
+++ b/frontend/app/components/modules/project/components/popularity/stars.vue
@@ -87,7 +87,7 @@ const {
   startDate, endDate, selectedRepository, selectedTimeRangeKey, customRangeGranularity
 } = storeToRefs(useProjectStore())
 
-const activeTab = ref('cumulative');
+const activeTab = ref('new');
 const route = useRoute();
 
 const barGranularity = computed(() => (selectedTimeRangeKey.value === dateOptKeys.custom
@@ -126,8 +126,8 @@ const chartData = computed<ChartData[]>(
 const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
 
 const tabs = [
+  { label: 'New', value: 'new' },
   { label: 'Cumulative', value: 'cumulative' },
-  { label: 'New', value: 'new' }
 ];
 
 const chartSeries = computed<ChartSeries[]>(() => [


### PR DESCRIPTION
## In this PR

Changed the default view for widgets that have new and cumulative tabs:
- Forks
- Stars
- Github Mentions
- Social Mentions
- Package Downloads

## Ticket
[INS-354](https://linear.app/lfx/issue/INS-354/make-new-the-default-option-for-all-charts-instead-of-cumulative)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Updated default views in several project popularity modules so that the initial tab now showcases the most recent data.
  - Streamlined tab options by removing duplicate entries, ensuring a clearer and more consistent user experience across forks, GitHub mentions, package downloads, social mentions, and stars.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->