### PR TITLE
Fix incorrect parameter name in one of Tinybird's queries

### DIFF
--- a/frontend/server/api/project/[slug]/popularity/forks.get.ts
+++ b/frontend/server/api/project/[slug]/popularity/forks.get.ts
@@ -38,7 +38,7 @@ export default defineEventHandler(async (event) => {
     granularity: query.granularity as FilterGranularity,
     repo: query.repository as string,
     countType: (query.countType as ActivityFilterCountType) || ActivityFilterCountType.NEW,
-    activityType: (query.activityType as ActivityFilterActivityType) || ActivityFilterActivityType.FORKS,
+    activity_type: (query.activityType as ActivityFilterActivityType) || ActivityFilterActivityType.FORKS,
     onlyContributions: false, // forks and stars are non-contribution activities, but we want to count them.
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/api/project/[slug]/popularity/stars.get.ts
+++ b/frontend/server/api/project/[slug]/popularity/stars.get.ts
@@ -38,7 +38,7 @@ export default defineEventHandler(async (event) => {
     granularity: query.granularity as FilterGranularity,
     repo: query.repository as string,
     countType: (query.countType as ActivityFilterCountType) || ActivityFilterCountType.NEW,
-    activityType: (query.activityType as ActivityFilterActivityType) || ActivityFilterActivityType.STARS,
+    activity_type: (query.activityType as ActivityFilterActivityType) || ActivityFilterActivityType.STARS,
     onlyContributions: false, // forks and stars are non-contribution activities, but we want to count them.
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,

--- a/frontend/server/data/tinybird/forks-data-source.ts
+++ b/frontend/server/data/tinybird/forks-data-source.ts
@@ -22,13 +22,13 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
   return {
     currentSummaryQuery: {
       ...filter,
-      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repo: filter.repo, // We need this due to a discrepancy between variable names in Tinybird and the frontend
     },
     previousSummaryQuery: {
       ...filter,
-      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repo: filter.repo, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       startDate: dates.previous.from,
@@ -36,7 +36,7 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
     },
     dataQuery: {
       ...filter,
-      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       repo: filter.repo,
     }
   }

--- a/frontend/server/data/tinybird/stars-data-source.ts
+++ b/frontend/server/data/tinybird/stars-data-source.ts
@@ -22,13 +22,13 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
   return {
     currentSummaryQuery: {
       ...filter,
-      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repo: filter.repo, // We need this due to a discrepancy between variable names in Tinybird and the frontend
     },
     previousSummaryQuery: {
       ...filter,
-      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repo: filter.repo, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       startDate: dates.previous.from,
@@ -36,7 +36,7 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
     },
     dataQuery: {
       ...filter,
-      activity_type: filter.activityType, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       repo: filter.repo,
     }
   }

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -111,13 +111,15 @@ export enum ActivityFilterCountType {
 }
 export enum ActivityFilterActivityType {
   FORKS = 'fork',
-  STARS = 'star'
+  STARS = 'star',
+  ISSUES_OPENED = 'issues-opened',
+  ISSUES_CLOSED = 'issues-closed',
 }
 export type ActivityCountFilter = {
   project: string;
   granularity: FilterGranularity;
   countType: ActivityFilterCountType;
-  activityType: ActivityFilterActivityType,
+  activity_type: ActivityFilterActivityType,
   onlyContributions: boolean;
   repo?: string,
   startDate?: DateTime,


### PR DESCRIPTION
The `activityType` property of the ActivityCountFilter had the wrong name, it should be `activity_type` instead.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Expanded project activity filters to include options for "issues opened" and "issues closed," offering enhanced insights into project activity.
- **Refactor**
  - Improved the consistency of activity filtering criteria to ensure more reliable data processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->