### PR TITLE
[INS-189] Add the pull requests data endpoint

### DIFF
--- a/frontend/app/components/modules/project/components/development/pull-requests.vue
+++ b/frontend/app/components/modules/project/components/development/pull-requests.vue
@@ -67,7 +67,7 @@
         <div class="flex flex-col gap-4">
           <lfx-project-pull-request-legend-item
             title="Open"
-            :delta="openSummary!"
+            :delta="openedSummary!"
             :color="chartSeries[0]!.color!"
           />
           <lfx-project-pull-request-legend-item
@@ -141,14 +141,14 @@ const pullRequests = computed<PullRequests>(() => data.value as PullRequests);
 const summary = computed<Summary>(() => pullRequests.value.summary);
 const chartData = computed<ChartData[]>(
   // convert the data to chart data
-  () => convertToChartData((pullRequests.value?.data || []) as RawChartData[], 'dateFrom', [
+  () => convertToChartData((pullRequests.value?.data || []) as RawChartData[], 'startDate', [
     'open',
     'merged',
     'closed'
-  ], undefined, 'dateTo')
+  ], undefined, 'endDate')
 );
 
-const openSummary = computed<Summary | undefined>(() => pullRequests.value?.openSummary);
+const openedSummary = computed<Summary | undefined>(() => pullRequests.value?.openedSummary);
 const mergedSummary = computed<Summary | undefined>(() => pullRequests.value?.mergedSummary);
 const closedSummary = computed<Summary | undefined>(() => pullRequests.value?.closedSummary);
 

--- a/frontend/server/api/project/[slug]/development/pull-requests.get.ts
+++ b/frontend/server/api/project/[slug]/development/pull-requests.get.ts
@@ -1,4 +1,7 @@
-import { pullRequests } from '~~/server/mocks/pull-requests.mock';
+import {DateTime} from "luxon";
+import type {ActivityCountFilter, FilterGranularity} from "~~/server/data/types";
+import {ActivityFilterActivityType, ActivityFilterCountType} from "~~/server/data/types";
+import {createDataSource} from "~~/server/data/data-sources";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -11,7 +14,7 @@ import { pullRequests } from '~~/server/mocks/pull-requests.mock';
  *     periodFrom: string; // period from
  *     periodTo: string; // period to
  *   },
- *   openSummary: {
+ *   openedSummary: {
  *     current: number; // current value
  *     previous: number; // previous value
  *     percentageChange: number; // percentage change (return as actual percentage ex: 2.3 percent)
@@ -37,8 +40,8 @@ import { pullRequests } from '~~/server/mocks/pull-requests.mock';
  *   },
  *   avgVelocityInDays: number;
  *   data: {
- *     dateFrom: string; // ISO 8601 date string - start of the bucket. Based on the interval
- *     dateTo: string; // ISO 8601 date string - end of the bucket. Based on the interval
+ *     startDate: string; // ISO 8601 date string - start of the bucket. Based on the interval
+ *     endDate: string; // ISO 8601 date string - end of the bucket. Based on the interval
  *     open: number; // count of open pull requests
  *     merged: number; // count of merged pull requests
  *     closed: number; // count of closed pull requests
@@ -51,4 +54,23 @@ import { pullRequests } from '~~/server/mocks/pull-requests.mock';
  * - repository: string
  * - time-period: string // This is isn't defined yet, but we'll add '90d', '1y', '5y' for now
  */
-export default defineEventHandler(async () => pullRequests);
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+
+  const project = (event.context.params as { slug: string }).slug;
+
+  const filter: ActivityCountFilter = {
+    project,
+    granularity: query.granularity as FilterGranularity,
+    repo: query.repository as string,
+    countType: ActivityFilterCountType.NEW, // TODO: This isn't used but I'm keeping it here for now to satisfy the interface
+    activity_type: ActivityFilterActivityType.ISSUES_CLOSED, // TODO: This isn't used but I'm keeping it here for now to satisfy the interface
+    onlyContributions: false,
+    startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
+    endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,
+  }
+
+  const dataSource = createDataSource();
+
+  return await dataSource.fetchPullRequests(filter);
+});

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -30,7 +30,9 @@ import {fetchGeographicDistribution} from "~~/server/data/tinybird/geographic-di
 import {fetchRetention} from "~~/server/data/tinybird/retention-data-source";
 import {fetchForksActivities} from "~~/server/data/tinybird/forks-data-source";
 import {fetchStarsActivities} from "~~/server/data/tinybird/stars-data-source";
+import {fetchPullRequests} from "~~/server/data/tinybird/pull-requests-data-source";
 import type {ForksData, StarsData} from "~~/types/popularity/responses.types";
+import type {PullRequests} from "~~/types/development/responses.types";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
@@ -45,6 +47,7 @@ export interface DataSource {
     fetchRetention: (filter: RetentionFilter) => Promise<RetentionResponse>;
     fetchForksActivities: (filter: ActivityCountFilter) => Promise<ForksData>;
     fetchStarsActivities: (filter: ActivityCountFilter) => Promise<StarsData>;
+    fetchPullRequests: (filter: ActivityCountFilter) => Promise<PullRequests>;
 }
 
 export function createDataSource(): DataSource {
@@ -59,5 +62,6 @@ export function createDataSource(): DataSource {
         fetchRetention,
         fetchForksActivities,
         fetchStarsActivities,
+        fetchPullRequests,
     };
 }

--- a/frontend/server/data/tinybird/pull-requests-data-source.test.ts
+++ b/frontend/server/data/tinybird/pull-requests-data-source.test.ts
@@ -1,0 +1,186 @@
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import {DateTime} from "luxon";
+import {
+  mockCurrentOpenedPRsSummary,
+  mockPreviousOpenedPRsSummary,
+  mockCurrentMergedPRsSummary,
+  mockPreviousMergedPRsSummary,
+  mockCurrentClosedPRsSummary,
+  mockPreviousClosedPRsSummary,
+  mockOpenedPullRequests,
+  mockMergedPullRequests,
+  mockClosedPullRequests,
+  mockPullRequestsVelocity
+} from '../../mocks/tinybird-pull-requests-response.mock';
+import {
+  type ActivityCountFilter,
+  ActivityFilterActivityType,
+  FilterGranularity
+} from "../types";
+import type {PullRequests} from "~~/types/development/responses.types";
+import type { DateRange} from "~~/server/data/util";
+import {calculatePercentageChange, getPreviousDates} from "~~/server/data/util";
+
+const mockFetchFromTinybird = vi.fn();
+
+describe('Pull Requests Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // Here be dragons! vi.doMock is not hoisted, and thus it is executed after the original import statement.
+    // This means that the import for tinybird.ts inside the data source module would still be used,
+    // and thus not mocked. This means we need to import the module again after the mock is set, whenever we want to
+    // use it.
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  })
+
+  /*
+   * This is a long test because this data source has to send a lot of queries to Tinybird.
+   */
+  test('should fetch pull requests data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchPullRequests} = await import("~~/server/data/tinybird/pull-requests-data-source");
+
+    mockFetchFromTinybird
+      .mockResolvedValueOnce(mockCurrentOpenedPRsSummary)
+      .mockResolvedValueOnce(mockPreviousOpenedPRsSummary)
+      .mockResolvedValueOnce(mockCurrentMergedPRsSummary)
+      .mockResolvedValueOnce(mockPreviousMergedPRsSummary)
+      .mockResolvedValueOnce(mockCurrentClosedPRsSummary)
+      .mockResolvedValueOnce(mockPreviousClosedPRsSummary)
+      .mockResolvedValueOnce(mockOpenedPullRequests)
+      .mockResolvedValueOnce(mockMergedPullRequests)
+      .mockResolvedValueOnce(mockClosedPullRequests)
+      .mockResolvedValueOnce(mockPullRequestsVelocity);
+
+    const startDate = DateTime.utc(2025, 1, 1);
+    const endDate = DateTime.utc(2025, 3, 31);
+
+    const dates = getPreviousDates(startDate, endDate);
+
+    const filter: ActivityCountFilter = {
+      project: 'the-linux-kernel-organization',
+      granularity: FilterGranularity.WEEKLY,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_OPENED,
+      onlyContributions: false,
+      startDate,
+      endDate
+    };
+
+    const result = await fetchPullRequests(filter);
+
+    // The granularity should not be sent in the summary queries, so we remove it here and add it when necessary in
+    // the generateQuery function.
+    delete filter.granularity;
+    const generateQuery = (activityType: ActivityFilterActivityType, isSummary: boolean, dates: DateRange) => ({
+      ...filter,
+      activity_type: activityType,
+      startDate: dates.from,
+      endDate: dates.to,
+      ...(!isSummary && {granularity: FilterGranularity.WEEKLY})
+    });
+
+    // These are the queries the data source should send to Tinybird, in this order.
+    const expectedQueries = [
+      // Summaries
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_OPENED, true, dates.current),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_OPENED, true, dates.previous),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_MERGED, true, dates.current),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_MERGED, true, dates.previous),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_CLOSED, true, dates.current),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_CLOSED, true, dates.previous),
+
+      // Time series data
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_OPENED, false, dates.current),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_MERGED, false, dates.current),
+      generateQuery(ActivityFilterActivityType.PULL_REQUESTS_CLOSED, false, dates.current),
+
+      // Pull request resolution velocity
+      {
+        project: 'the-linux-kernel-organization',
+        onlyContributions: false,
+        startDate,
+        endDate
+      },
+    ];
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledTimes(expectedQueries.length);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(1, '/v0/pipes/activities_count.json', expectedQueries[0]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(2, '/v0/pipes/activities_count.json', expectedQueries[1]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(3, '/v0/pipes/activities_count.json', expectedQueries[2]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(4, '/v0/pipes/activities_count.json', expectedQueries[3]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(5, '/v0/pipes/activities_count.json', expectedQueries[4]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(6, '/v0/pipes/activities_count.json', expectedQueries[5]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(7, '/v0/pipes/activities_count.json', expectedQueries[6]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(8, '/v0/pipes/activities_count.json', expectedQueries[7]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(9, '/v0/pipes/activities_count.json', expectedQueries[8]);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(
+      10,
+      '/v0/pipes/pull_requests_average_resolve_velocity.json',
+      expectedQueries[9]
+    );
+
+    const currentOpenedCount = mockCurrentOpenedPRsSummary.data[0]?.activityCount || 0;
+    const previousOpenedCount = mockPreviousOpenedPRsSummary.data[0]?.activityCount || 0;
+    const currentMergedCount = mockCurrentMergedPRsSummary.data[0]?.activityCount || 0;
+    const previousMergedCount = mockPreviousMergedPRsSummary.data[0]?.activityCount || 0;
+    const currentClosedCount = mockCurrentClosedPRsSummary.data[0]?.activityCount || 0;
+    const previousClosedCount = mockPreviousClosedPRsSummary.data[0]?.activityCount || 0;
+    const currentTotalCount = currentOpenedCount + currentMergedCount + currentClosedCount;
+    const previousTotalCount = previousOpenedCount + previousMergedCount + previousClosedCount;
+    const totalPercentageChange = calculatePercentageChange(currentTotalCount, previousTotalCount);
+    const openedPercentageChange = calculatePercentageChange(currentOpenedCount, previousOpenedCount);
+    const mergedPercentageChange = calculatePercentageChange(currentMergedCount, previousMergedCount);
+    const closedPercentageChange = calculatePercentageChange(currentClosedCount, previousClosedCount);
+
+    const expectedResult: PullRequests = {
+      // TODO: If this is still here, don't approve the PR because I forgot to confirm what should be counted here.
+      summary: {
+        current: currentTotalCount,
+        previous: previousTotalCount,
+        percentageChange: totalPercentageChange,
+        changeValue: currentTotalCount - previousTotalCount,
+        periodFrom: filter.startDate?.toString() || '',
+        periodTo: filter.endDate?.toString() || '',
+      },
+      openedSummary: {
+        current: currentOpenedCount,
+        previous: previousOpenedCount,
+        percentageChange: openedPercentageChange,
+        changeValue: currentOpenedCount - previousOpenedCount,
+        periodFrom: filter.startDate?.toString() || '',
+        periodTo: filter.endDate?.toString() || '',
+      },
+      mergedSummary: {
+        current: currentMergedCount,
+        previous: previousMergedCount,
+        percentageChange: mergedPercentageChange,
+        changeValue: currentMergedCount - previousMergedCount,
+        periodFrom: filter.startDate?.toString() || '',
+        periodTo: filter.endDate?.toString() || '',
+      },
+      closedSummary: {
+        current: currentClosedCount,
+        previous: previousClosedCount,
+        percentageChange: closedPercentageChange,
+        changeValue: currentClosedCount - previousClosedCount,
+        periodFrom: filter.startDate?.toString() || '',
+        periodTo: filter.endDate?.toString() || '',
+      },
+      avgVelocityInDays: mockPullRequestsVelocity.data[0].averagePullRequestResolveVelocitySeconds,
+      data: mockOpenedPullRequests.data.map((item, index) => ({
+        startDate: item.startDate,
+        endDate: item.endDate,
+        open: item.activityCount,
+        merged: mockMergedPullRequests.data[index].activityCount,
+        closed: mockClosedPullRequests.data[index].activityCount,
+      }))
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/frontend/server/data/tinybird/pull-requests-data-source.ts
+++ b/frontend/server/data/tinybird/pull-requests-data-source.ts
@@ -1,0 +1,188 @@
+import type { ActivityCountFilter } from "../types";
+import { ActivityFilterActivityType } from "../types";
+import { fetchFromTinybird } from './tinybird'
+import { calculatePercentageChange, getPreviousDates } from "~~/server/data/util";
+import type { PullRequests } from "~~/types/development/responses.types";
+
+// This is the data part of the response from Tinybird
+type TinybirdActivityCountData = {
+  startDate: string,
+  endDate: string,
+  activityCount?: number
+  cumulativeActivityCount?: number
+};
+
+type TinybirdActivityCountSummary = {
+  activityCount: number;
+};
+
+type TinybirdPullRequestResolutionVelocityData = {
+  averagePullRequestResolveVelocitySeconds: number;
+};
+
+function getTinybirdQueries(filter: ActivityCountFilter) {
+  const dates = getPreviousDates(filter.startDate, filter.endDate);
+
+  return {
+    currentOpenedPRsSummaryQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_OPENED,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+    },
+    previousOpenedPRsSummaryQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_OPENED,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      startDate: dates.previous.from,
+      endDate: dates.previous.to
+    },
+
+    currentMergedPRsSummaryQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_MERGED,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+    },
+    previousMergedPRsSummaryQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_MERGED,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      startDate: dates.previous.from,
+      endDate: dates.previous.to
+    },
+
+    currentClosedPRsSummaryQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_CLOSED,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+    },
+    previousClosedPRsSummaryQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_CLOSED,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+      startDate: dates.previous.from,
+      endDate: dates.previous.to
+    },
+
+    openedPRsQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_OPENED,
+    },
+    mergedPRsQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_MERGED,
+    },
+    closedPRsQuery: {
+      ...filter,
+      activity_type: ActivityFilterActivityType.PULL_REQUESTS_CLOSED,
+    },
+    prResolutionVelocityQuery: {
+      ...filter,
+      activity_type: undefined,
+      granularity: undefined, // This tells TinyBird to return a summary instead of time series
+    }
+  }
+}
+
+export async function fetchPullRequests(filter: ActivityCountFilter): Promise<PullRequests> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  console.log('filter.granularity', filter.granularity);
+
+  const {
+    currentOpenedPRsSummaryQuery,
+    previousOpenedPRsSummaryQuery,
+    currentMergedPRsSummaryQuery,
+    previousMergedPRsSummaryQuery,
+    currentClosedPRsSummaryQuery,
+    previousClosedPRsSummaryQuery,
+    openedPRsQuery,
+    mergedPRsQuery,
+    closedPRsQuery,
+    prResolutionVelocityQuery
+  } = getTinybirdQueries(filter);
+
+  const summariesPath = '/v0/pipes/activities_count.json';
+  const dataPath = '/v0/pipes/activities_count.json';
+  const prResolutionVelocityPath = '/v0/pipes/pull_requests_average_resolve_velocity.json';
+
+  const [
+    currentOpenedPRsSummary,
+    previousOpenedPRsSummary,
+    currentMergedPRsSummary,
+    previousMergedPRsSummary,
+    currentClosedPRsSummary,
+    previousClosedPRsSummary,
+    openedPRs,
+    mergedPRs,
+    closedPRs,
+    prResolutionVelocity
+  ] = await Promise.all([
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(summariesPath, currentOpenedPRsSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(summariesPath, previousOpenedPRsSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(summariesPath, currentMergedPRsSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(summariesPath, previousMergedPRsSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(summariesPath, currentClosedPRsSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountSummary[]>(summariesPath, previousClosedPRsSummaryQuery),
+    fetchFromTinybird<TinybirdActivityCountData[]>(dataPath, openedPRsQuery),
+    fetchFromTinybird<TinybirdActivityCountData[]>(dataPath, mergedPRsQuery),
+    fetchFromTinybird<TinybirdActivityCountData[]>(dataPath, closedPRsQuery),
+    fetchFromTinybird<TinybirdPullRequestResolutionVelocityData[]>(prResolutionVelocityPath, prResolutionVelocityQuery)
+  ]);
+
+  const currentOpenedCount = currentOpenedPRsSummary.data[0]?.activityCount || 0;
+  const previousOpenedCount = previousOpenedPRsSummary.data[0]?.activityCount || 0;
+  const currentMergedCount = currentMergedPRsSummary.data[0]?.activityCount || 0;
+  const previousMergedCount = previousMergedPRsSummary.data[0]?.activityCount || 0;
+  const currentClosedCount = currentClosedPRsSummary.data[0]?.activityCount || 0;
+  const previousClosedCount = previousClosedPRsSummary.data[0]?.activityCount || 0;
+  const currentTotalCount = currentOpenedCount + currentMergedCount + currentClosedCount;
+  const previousTotalCount = previousOpenedCount + previousMergedCount + previousClosedCount;
+  const totalPercentageChange = calculatePercentageChange(currentTotalCount, previousTotalCount);
+  const openedPercentageChange = calculatePercentageChange(currentOpenedCount, previousOpenedCount);
+  const mergedPercentageChange = calculatePercentageChange(currentMergedCount, previousMergedCount);
+  const closedPercentageChange = calculatePercentageChange(currentClosedCount, previousClosedCount);
+
+  return {
+    summary: {
+      current: currentTotalCount,
+      previous: previousTotalCount,
+      percentageChange: totalPercentageChange,
+      changeValue: currentTotalCount - previousTotalCount,
+      periodFrom: filter.startDate?.toISO() || '',
+      periodTo: filter.endDate?.toISO() || '',
+    },
+    openedSummary: {
+      current: currentOpenedCount,
+      previous: previousOpenedCount,
+      percentageChange: openedPercentageChange,
+      changeValue: currentOpenedCount - previousOpenedCount,
+      periodFrom: filter.startDate?.toISO() || '',
+      periodTo: filter.endDate?.toISO() || '',
+    },
+    mergedSummary: {
+      current: currentMergedCount,
+      previous: previousMergedCount,
+      percentageChange: mergedPercentageChange,
+      changeValue: currentMergedCount - previousMergedCount,
+      periodFrom: filter.startDate?.toISO() || '',
+      periodTo: filter.endDate?.toISO() || '',
+    },
+    closedSummary: {
+      current: currentClosedCount,
+      previous: previousClosedCount,
+      percentageChange: closedPercentageChange,
+      changeValue: currentClosedCount - previousClosedCount,
+      periodFrom: filter.startDate?.toISO() || '',
+      periodTo: filter.endDate?.toISO() || '',
+    },
+    avgVelocityInDays: prResolutionVelocity.data[0].averagePullRequestResolveVelocitySeconds,
+    data: openedPRs.data.map((item, index) => ({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      open: item.activityCount || 0,
+      merged: mergedPRs.data[index].activityCount || 0,
+      closed: closedPRs.data[index].activityCount || 0,
+    }))
+  };
+}

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -114,11 +114,14 @@ export enum ActivityFilterActivityType {
   STARS = 'star',
   ISSUES_OPENED = 'issues-opened',
   ISSUES_CLOSED = 'issues-closed',
+  PULL_REQUESTS_OPENED = 'pull_request-opened',
+  PULL_REQUESTS_MERGED = 'pull_request-merged',
+  PULL_REQUESTS_CLOSED = 'pull_request-closed',
 }
 export type ActivityCountFilter = {
   project: string;
-  granularity: FilterGranularity;
-  countType: ActivityFilterCountType;
+  granularity?: FilterGranularity;
+  countType?: ActivityFilterCountType;
   activity_type: ActivityFilterActivityType,
   onlyContributions: boolean;
   repo?: string,

--- a/frontend/server/data/util.ts
+++ b/frontend/server/data/util.ts
@@ -1,5 +1,16 @@
 import {DateTime} from "luxon";
 
+// We should use Luxon's Interval type for this, but that would require a lot of changes in the codebase, so for now
+// we'll just use a custom type, just so we can satisfy Typescript's strict typing.
+export type DateRange = {
+  from: DateTime;
+  to: DateTime;
+};
+export type DateRangeSet = {
+  current: DateRange,
+  previous: DateRange,
+};
+
 // This sets how far back we want to go when no start date is provided.
 // TODO: What should we set this to? Is this even how we want to address this problem?
 export const earliestPossibleStartDate = DateTime.utc(2010, 1, 1);
@@ -10,7 +21,7 @@ export const earliestPossibleStartDate = DateTime.utc(2010, 1, 1);
  * and then subtract that from the current dates to get the previous ones.
  * It provides correct defaults for the current dates if they are not provided.
  */
-export function getPreviousDates(currentStartDate?: DateTime, currentEndDate?: DateTime) {
+export function getPreviousDates(currentStartDate?: DateTime, currentEndDate?: DateTime): DateRangeSet {
   const safeStartDate = currentStartDate || earliestPossibleStartDate;
   const safeEndDate = currentEndDate || DateTime.utc();
 

--- a/frontend/server/mocks/pull-requests.mock.ts
+++ b/frontend/server/mocks/pull-requests.mock.ts
@@ -7,7 +7,7 @@ export const pullRequests = {
     periodFrom: '2024-11-11T00:00:00Z',
     periodTo: '2025-02-12T00:00:00Z'
   },
-  openSummary: {
+  openedSummary: {
     current: 120,
     previous: 60,
     percentageChange: 100,

--- a/frontend/server/mocks/tinybird-pull-requests-response.mock.ts
+++ b/frontend/server/mocks/tinybird-pull-requests-response.mock.ts
@@ -1,0 +1,282 @@
+export const mockCurrentOpenedPRsSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      activityCount: 100
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.320078864,
+    rows_read: 357628,
+    bytes_read: 18362864
+  }
+};
+
+export const mockPreviousOpenedPRsSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      activityCount: 50
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.279353225,
+    rows_read: 474679,
+    bytes_read: 24215414
+  }
+};
+
+export const mockCurrentMergedPRsSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      activityCount: 25
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.320078864,
+    rows_read: 357628,
+    bytes_read: 18362864
+  }
+};
+
+export const mockPreviousMergedPRsSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      activityCount: 50
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.279353225,
+    rows_read: 474679,
+    bytes_read: 24215414
+  }
+};
+
+export const mockCurrentClosedPRsSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      activityCount: 10
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.320078864,
+    rows_read: 357628,
+    bytes_read: 18362864
+  }
+};
+
+export const mockPreviousClosedPRsSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      activityCount: 5
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.279353225,
+    rows_read: 474679,
+    bytes_read: 24215414
+  }
+};
+
+export const mockOpenedPullRequests = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      startDate: "2023-03-01",
+      endDate: "2023-03-31",
+      activityCount: 11
+    },
+    {
+      startDate: "2023-04-01",
+      endDate: "2023-04-30",
+      activityCount: 4
+    },
+    {
+      startDate: "2023-05-01",
+      endDate: "2023-05-31",
+      activityCount: 7
+    },
+    {
+      startDate: "2023-06-01",
+      endDate: "2023-06-30",
+      activityCount: 21
+    },
+  ],
+  rows: 13,
+  statistics: {
+    elapsed: 0.031928949,
+    rows_read: 475680,
+    bytes_read: 24223415
+  }
+};
+
+export const mockMergedPullRequests = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      startDate: "2023-03-01",
+      endDate: "2023-03-31",
+      activityCount: 8
+    },
+    {
+      startDate: "2023-04-01",
+      endDate: "2023-04-30",
+      activityCount: 1
+    },
+    {
+      startDate: "2023-05-01",
+      endDate: "2023-05-31",
+      activityCount: 6
+    },
+    {
+      startDate: "2023-06-01",
+      endDate: "2023-06-30",
+      activityCount: 6
+    },
+  ],
+  rows: 13,
+  statistics: {
+    elapsed: 0.031928949,
+    rows_read: 475680,
+    bytes_read: 24223415
+  }
+};
+
+export const mockClosedPullRequests = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      startDate: "2023-03-01",
+      endDate: "2023-03-31",
+      activityCount: 2
+    },
+    {
+      startDate: "2023-04-01",
+      endDate: "2023-04-30",
+      activityCount: 1
+    },
+    {
+      startDate: "2023-05-01",
+      endDate: "2023-05-31",
+      activityCount: 3
+    },
+    {
+      startDate: "2023-06-01",
+      endDate: "2023-06-30",
+      activityCount: 2
+    },
+  ],
+  rows: 13,
+  statistics: {
+    elapsed: 0.031928949,
+    rows_read: 475680,
+    bytes_read: 24223415
+  }
+};
+
+export const mockPullRequestsVelocity = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      averagePullRequestResolveVelocitySeconds: 7451999
+    },
+  ],
+  rows: 13,
+  statistics: {
+    elapsed: 0.031928949,
+    rows_read: 475680,
+    bytes_read: 24223415
+  }
+};

--- a/frontend/types/development/responses.types.ts
+++ b/frontend/types/development/responses.types.ts
@@ -1,3 +1,7 @@
+/**
+These are the types for the responses the frontend expects from the API for the development tab in the project page.
+ */
+
 import type { Summary } from '../shared/summary.types';
 
 export interface ActiveDays {
@@ -74,13 +78,13 @@ export interface MergeLeadTime {
 
 export interface PullRequests {
   summary: Summary;
-  openSummary: Summary;
+  openedSummary: Summary;
   mergedSummary: Summary;
   closedSummary: Summary;
   avgVelocityInDays: number;
   data: {
-    dateFrom: string;
-    dateTo: string;
+    startDate: string;
+    endDate: string;
     open: number;
     merged: number;
     closed: number;

--- a/frontend/types/popularity/responses.types.ts
+++ b/frontend/types/popularity/responses.types.ts
@@ -1,3 +1,7 @@
+/**
+ These are the types for the responses the frontend expects from the API for the popularity tab in the project page.
+ */
+
 import type { Summary } from '../shared/summary.types';
 
 export interface StarsData {


### PR DESCRIPTION
[Ticket in Linear](https://linear.app/lfx/issue/INS-189/[nuxt-api]-pull-requests).

This is a big one, sorry. Unfortunately the data source for the pull requests widget has to do a lot of requests to TinyBird, which makes the whole thing bigger.

A few notes:
* I renamed the API response property `openSummary` to `openedSummary` for consistency with TinyBird and the rest of the code - they are referred to as "opened" because it's the action of opening, as in, "how many pull requests were *opened* during this time". @emlimlf, please make sure there's nothing else that needs changing on the frontend side.
* A couple other API response properties that were renamed for consistency with the rest of the code: `dateFrom` => `startDate` and `dateTo` => `endDate`. @emlimlf, please make sure there's nothing else that needs changing on the frontend side.
* The `ResolutionSummary` type was also renamed to `IssuesResolutionSummary` to make it more explicit.
* As before, the number of days is returned as seconds, according to what has been decided. Frankly, this feels weirder each time I look at it :sweat_smile: In any case, don't forget to make the necessary adjustment.