### PR TITLE
[INS-195] Add the endpoint for the "Average time to merge" widget data

### DIFF
--- a/frontend/app/components/modules/project/components/development/average-time-to-merge.vue
+++ b/frontend/app/components/modules/project/components/development/average-time-to-merge.vue
@@ -101,9 +101,9 @@ const averageTimeMerge = computed<AverageTimeMerge>(() => data.value as AverageT
 const summary = computed<Summary>(() => averageTimeMerge.value.summary);
 const chartData = computed<ChartData[]>(
   // convert the data to chart data
-  () => convertToChartData((averageTimeMerge.value?.data || []) as RawChartData[], 'dateFrom', [
+  () => convertToChartData((averageTimeMerge.value?.data || []) as RawChartData[], 'startDate', [
     'averageTime'
-  ], undefined, 'dateTo')
+  ], undefined, 'endDate')
 );
 
 const chartSeries = ref<ChartSeries[]>([

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -12,6 +12,7 @@ import type {
   RetentionFilter,
   ActivityCountFilter,
   WaitTimeFor1stReviewFilter,
+  AverageTimeToMergeFilter,
 } from "~~/server/data/types";
 import type {ActiveContributorsResponse} from "~~/server/data/tinybird/active-contributors-data-source";
 import type {ActiveOrganizationsResponse} from "~~/server/data/tinybird/active-organizations-data-source";
@@ -33,9 +34,12 @@ import {fetchForksActivities} from "~~/server/data/tinybird/forks-data-source";
 import {fetchStarsActivities} from "~~/server/data/tinybird/stars-data-source";
 import {fetchIssuesResolution} from "~~/server/data/tinybird/issues-resolution-data-source";
 import {fetchPullRequests} from "~~/server/data/tinybird/pull-requests-data-source";
-import type {ForksData, StarsData} from "~~/types/popularity/responses.types";
+import {fetchAverageTimeToMerge} from "~~/server/data/tinybird/average-time-to-merge-data-source";
 import {fetchWaitTimeFor1stReview} from "~~/server/data/tinybird/wait-time-for-1st-review-data-source";
-import type {IssuesResolution, PullRequests, WaitTime1stReview} from "~~/types/development/responses.types";
+import type {ForksData, StarsData} from "~~/types/popularity/responses.types";
+import type {
+  IssuesResolution, PullRequests, AverageTimeMerge, WaitTime1stReview
+} from "~~/types/development/responses.types";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
@@ -52,6 +56,7 @@ export interface DataSource {
     fetchStarsActivities: (filter: ActivityCountFilter) => Promise<StarsData>;
     fetchIssuesResolution: (filter: ActivityCountFilter) => Promise<IssuesResolution>;
     fetchPullRequests: (filter: ActivityCountFilter) => Promise<PullRequests>;
+    fetchAverageTimeToMerge: (filter: AverageTimeToMergeFilter) => Promise<AverageTimeMerge>;
     fetchWaitTimeFor1stReview: (filter: WaitTimeFor1stReviewFilter) => Promise<WaitTime1stReview>;
 }
 
@@ -69,6 +74,7 @@ export function createDataSource(): DataSource {
         fetchStarsActivities,
         fetchIssuesResolution,
         fetchPullRequests,
+        fetchAverageTimeToMerge,
         fetchWaitTimeFor1stReview
     };
 }

--- a/frontend/server/data/tinybird/average-time-to-merge-data-source.test.ts
+++ b/frontend/server/data/tinybird/average-time-to-merge-data-source.test.ts
@@ -1,0 +1,87 @@
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import { DateTime } from "luxon";
+import {
+  mockCurrentSummary,
+  mockPreviousSummary,
+  mockAverageTimeToMerge
+} from '../../mocks/tinybird-average-time-to-merge-response.mock';
+import type { AverageTimeMerge } from "~~/types/development/responses.types";
+import type {AverageTimeToMergeFilter} from "~~/server/data/types";
+import {FilterGranularity} from "~~/server/data/types";
+
+const mockFetchFromTinybird = vi.fn();
+
+describe('Average Time to Merge Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // Here be dragons! vi.doMock is not hoisted, and thus it is executed after the original import statement.
+    // This means that the import for tinybird.ts inside the data source module would still be used,
+    // and thus not mocked. This means we need to import the module again after the mock is set, whenever we want to
+    // use it.
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  })
+
+  test('should fetch average time to merge data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchAverageTimeToMerge} = await import("~~/server/data/tinybird/average-time-to-merge-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockCurrentSummary)
+      .mockResolvedValueOnce(mockPreviousSummary)
+      .mockResolvedValueOnce(mockAverageTimeToMerge);
+
+    const startDate = DateTime.utc(2024, 3, 20);
+    const endDate = DateTime.utc(2025, 3, 20);
+
+    const filter: AverageTimeToMergeFilter = {
+      granularity: FilterGranularity.WEEKLY,
+      project: 'the-linux-kernel-organization',
+      startDate,
+      endDate
+    };
+
+    const result = await fetchAverageTimeToMerge(filter);
+
+    const expectedTinybirdPath = '/v0/pipes/pull_requests_average_time_to_merge.json';
+
+    const expectedCurrentSummaryQuery = {
+      project: filter.project,
+      startDate: filter.startDate,
+      endDate: filter.endDate,
+    };
+    const expectedPreviousSummaryQuery = {
+      project: filter.project,
+      startDate: DateTime.utc(2023, 3, 19),
+      endDate: DateTime.utc(2024, 3, 19),
+    };
+
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(1, expectedTinybirdPath, expectedCurrentSummaryQuery);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(2, expectedTinybirdPath, expectedPreviousSummaryQuery);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(3, expectedTinybirdPath, filter);
+
+    const currentAverageTime = mockCurrentSummary.data[0]?.averageTimeToMergeSeconds || 0;
+    const previousAverageTime = mockPreviousSummary.data[0]?.averageTimeToMergeSeconds || 0;
+
+    const expectedResult: AverageTimeMerge = {
+      summary: {
+        current: currentAverageTime,
+        previous: previousAverageTime,
+        percentageChange: 100,
+        changeValue: currentAverageTime - previousAverageTime,
+        periodFrom: filter.startDate?.toISO() || '',
+        periodTo: filter.endDate?.toISO() || '',
+      },
+      data: mockAverageTimeToMerge.data.map((item) => ({
+        startDate: item.startDate,
+        endDate: item.endDate,
+        averageTime: item.averageTimeToMergeSeconds,
+      }))
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/frontend/server/data/tinybird/average-time-to-merge-data-source.ts
+++ b/frontend/server/data/tinybird/average-time-to-merge-data-source.ts
@@ -1,0 +1,65 @@
+import type { AverageTimeToMergeFilter } from "../types";
+import { fetchFromTinybird } from './tinybird'
+import { calculatePercentageChange, getPreviousDates } from "~~/server/data/util";
+import type { AverageTimeMerge } from "~~/types/development/responses.types";
+
+// This is the data part of the response from Tinybird
+type TinybirdAverageTimeToMergeData = {
+  startDate: string,
+  endDate: string,
+  averageTimeToMergeSeconds: number
+};
+
+type TinybirdAverageTimeToMergeSummary = {
+  averageTimeToMergeSeconds: number;
+};
+
+export async function fetchAverageTimeToMerge(filter: AverageTimeToMergeFilter): Promise<AverageTimeMerge> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  const dates = getPreviousDates(filter.startDate, filter.endDate);
+  const currentSummaryQuery = {
+    ...filter,
+    granularity: undefined, // This tells TinyBird to return a summary instead of time series
+  };
+  const previousSummaryQuery = {
+    ...filter,
+    granularity: undefined, // This tells TinyBird to return a summary instead of time series
+    startDate: dates.previous.from,
+    endDate: dates.previous.to
+  };
+
+  const path = '/v0/pipes/pull_requests_average_time_to_merge.json';
+
+  const [
+    currentSummary,
+    previousSummary,
+    averageTimeToMergeData
+  ] = await Promise.all([
+    fetchFromTinybird<TinybirdAverageTimeToMergeSummary[]>(path, currentSummaryQuery),
+    fetchFromTinybird<TinybirdAverageTimeToMergeSummary[]>(path, previousSummaryQuery),
+    fetchFromTinybird<TinybirdAverageTimeToMergeData[]>(path, filter),
+  ]);
+
+  const currentAverageTime = currentSummary.data[0]?.averageTimeToMergeSeconds || 0;
+  const previousAverageTime = previousSummary.data[0]?.averageTimeToMergeSeconds || 0;
+  const changeValue = currentAverageTime - previousAverageTime;
+  const percentageChange = calculatePercentageChange(currentAverageTime, previousAverageTime);
+
+  return {
+    summary: {
+      current: currentAverageTime,
+      previous: previousAverageTime,
+      percentageChange,
+      changeValue,
+      periodFrom: filter.startDate?.toISO() || '',
+      periodTo: filter.endDate?.toISO() || '',
+    },
+    data: averageTimeToMergeData.data.map((item) => ({
+      startDate: item.startDate,
+      endDate: item.endDate,
+      averageTime: item.averageTimeToMergeSeconds
+    }))
+  };
+}

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -129,6 +129,14 @@ export type ActivityCountFilter = {
   endDate?: DateTime,
 }
 
+export type AverageTimeToMergeFilter = {
+  project: string;
+  granularity?: FilterGranularity;
+  repo?: string,
+  startDate?: DateTime,
+  endDate?: DateTime,
+};
+
 export type WaitTimeFor1stReviewFilter = {
   project: string;
   granularity?: FilterGranularity;

--- a/frontend/server/mocks/tinybird-average-time-to-merge-response.mock.ts
+++ b/frontend/server/mocks/tinybird-average-time-to-merge-response.mock.ts
@@ -1,0 +1,79 @@
+export const mockCurrentSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      averageTimeToMergeSeconds: 100
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.320078864,
+    rows_read: 357628,
+    bytes_read: 18362864
+  }
+};
+
+export const mockPreviousSummary = {
+  meta: [
+    {
+      name: "activityCount",
+      type: "UInt64"
+    }
+  ],
+  data: [
+    {
+      averageTimeToMergeSeconds: 50
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.279353225,
+    rows_read: 474679,
+    bytes_read: 24215414
+  }
+};
+
+export const mockAverageTimeToMerge = {
+  meta: [
+    {
+      name: "startDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "endDate",
+      type: "Nullable(Date)"
+    },
+    {
+      name: "averageTimeToMergeSeconds",
+      type: "Nullable(Float64)"
+    }
+  ],
+  data: [
+    {
+      startDate: "2025-01-01",
+      endDate: "2025-01-31",
+      averageTimeToMergeSeconds: 674461
+    },
+    {
+      startDate: "2025-02-01",
+      endDate: "2025-02-28",
+      averageTimeToMergeSeconds: 1236134
+    },
+    {
+      startDate: "2025-03-01",
+      endDate: "2025-03-31",
+      averageTimeToMergeSeconds: 531463
+    }
+  ],
+  rows: 3,
+  statistics: {
+    elapsed: 0.031928949,
+    rows_read: 475680,
+    bytes_read: 24223415
+  }
+};

--- a/frontend/types/development/responses.types.ts
+++ b/frontend/types/development/responses.types.ts
@@ -17,8 +17,8 @@ export interface ActiveDays {
 export interface AverageTimeMerge {
   summary: Summary;
   data: {
-    dateFrom: string;
-    dateTo: string;
+    startDate: string;
+    endDate: string;
     averageTime: number;
   }[];
 }


### PR DESCRIPTION
[Ticket in Linear](https://linear.app/lfx/issue/INS-195/[nuxt-api]-average-time-to-merge)

Besides adding the API endpoint, this also changes the `dateFrom` and `dateTo` variable names to `startDate` and `endDate` to conform with the rest of the code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Rolled out enhanced average merge time metrics with dynamic data retrieval and flexible date range filtering.

- **Refactor**
  - Standardized date parameter naming for improved clarity and consistency.
  - Updated type definitions to allow optional filtering properties.

- **Tests**
  - Introduced comprehensive tests to validate average merge time calculations and data integration with external data sources.
  
- **Chores**
  - Added mock data for testing average time to merge scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->