### PR TITLE
Extract some tinybird response types to make them reusable on other widgets

### DIFF
--- a/frontend/app/components/modules/project/components/development/merge-lead-time.vue
+++ b/frontend/app/components/modules/project/components/development/merge-lead-time.vue
@@ -44,25 +44,25 @@
               title="Pickup"
               description="Pull request raised"
               icon="code-pull-request"
-              :item-value="mergeLeadTime.data.pickup"
+              :item-value="pickup"
             />
             <lfx-merge-lead-item
               title="Review"
               description="Review started"
               icon="eye"
-              :item-value="mergeLeadTime.data.review"
+              :item-value="review"
             />
             <lfx-merge-lead-item
               title="Accepted"
               description="Pull request accepted"
               icon="check-circle"
-              :item-value="mergeLeadTime.data.accepted"
+              :item-value="accepted"
             />
             <lfx-merge-lead-item
               title="Merged"
               description=""
               icon="thumbs-up"
-              :item-value="mergeLeadTime.data.pickup"
+              :item-value="prMerged"
               is-last
             />
           </div>
@@ -77,10 +77,11 @@
 import { useFetch, useRoute } from 'nuxt/app';
 import { computed } from 'vue';
 import { storeToRefs } from "pinia";
+import { Duration } from 'luxon';
 import LfxProjectLoadState from '../shared/load-state.vue';
 import LfxSkeletonState from '../shared/skeleton-state.vue';
 import LfxMergeLeadItem from './fragments/merge-lead-item.vue';
-import type { MergeLeadTime } from '~~/types/development/responses.types';
+import type { MergeLeadTime, MergeLeadTimeItem } from '~~/types/development/responses.types';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxDeltaDisplay from '~/components/uikit/delta-display/delta-display.vue';
 import { formatNumber } from '~/components/shared/utils/formatter';
@@ -108,10 +109,55 @@ const { data, status, error } = useFetch(
 );
 
 const mergeLeadTime = computed<MergeLeadTime>(() => data.value as MergeLeadTime);
+const pickup = computed<MergeLeadTimeItem>(() => ({
+  ...mergeLeadTime.value.data.pickup,
+  ...formatDuration(mergeLeadTime.value.data.pickup.value)
+} as MergeLeadTimeItem));
+const review = computed<MergeLeadTimeItem>(() => ({
+  ...mergeLeadTime.value.data.review,
+  ...formatDuration(mergeLeadTime.value.data.review.value)
+} as MergeLeadTimeItem));
+const accepted = computed<MergeLeadTimeItem>(() => ({
+  ...mergeLeadTime.value.data.accepted,
+  ...formatDuration(mergeLeadTime.value.data.accepted.value)
+} as MergeLeadTimeItem));
+const prMerged = computed<MergeLeadTimeItem>(() => ({
+  ...mergeLeadTime.value.data.prMerged,
+  ...formatDuration(mergeLeadTime.value.data.prMerged.value)
+} as MergeLeadTimeItem));
 
 const summary = computed<Summary>(() => mergeLeadTime.value.summary);
 
 const isEmpty = computed(() => isEmptyData((mergeLeadTime.value?.data || []) as unknown as Record<string, unknown>[]));
+
+const formatDuration = (seconds: number): { value: number, unit: string } => {
+  const duration = Duration.fromObject({ seconds });
+  const value = duration.as('seconds');
+
+  switch (true) {
+    case seconds >= 86400:
+      return {
+        value: Number(duration.as('days').toFixed(2)),
+        unit: 'days'
+      };
+    case seconds >= 3600:
+      return {
+        value: Number(duration.as('hours').toFixed(2)),
+        unit: 'hours'
+      };
+    case seconds >= 60:
+      return {
+        value: Number(duration.as('minutes').toFixed(2)),
+        unit: 'minutes'
+      };
+    default:
+      return {
+        value: Number(value.toFixed(2)),
+        unit: 'seconds'
+      };
+  }
+};
+
 </script>
 
 <script lang="ts">

--- a/frontend/server/api/project/[slug]/development/merge-lead-time.get.ts
+++ b/frontend/server/api/project/[slug]/development/merge-lead-time.get.ts
@@ -1,4 +1,6 @@
-import { mergeLeadTime } from '~~/server/mocks/merge-lead-time.mock';
+import { DateTime } from "luxon";
+import type { MergeLeadTimeFilter } from "~~/server/data/types";
+import { createDataSource } from "~~/server/data/data-sources";
 
 /**
  * Frontend expects the data to be in the following format:
@@ -41,4 +43,19 @@ import { mergeLeadTime } from '~~/server/mocks/merge-lead-time.mock';
  * - repository: string
  * - time-period: string // This is isn't defined yet, but we'll add '90d', '1y', '5y' for now
  */
-export default defineEventHandler(async () => mergeLeadTime);
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+
+  const project = (event.context.params as { slug: string }).slug;
+
+  const filter: MergeLeadTimeFilter = {
+    project,
+    repo: query.repository as string,
+    startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
+    endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,
+  }
+
+  const dataSource = createDataSource();
+
+  return await dataSource.fetchMergeLeadTime(filter);
+});

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -13,6 +13,7 @@ import type {
   ActivityCountFilter,
   WaitTimeFor1stReviewFilter,
   AverageTimeToMergeFilter,
+  MergeLeadTimeFilter,
 } from "~~/server/data/types";
 import type {ActiveContributorsResponse} from "~~/server/data/tinybird/active-contributors-data-source";
 import type {ActiveOrganizationsResponse} from "~~/server/data/tinybird/active-organizations-data-source";
@@ -36,9 +37,10 @@ import {fetchIssuesResolution} from "~~/server/data/tinybird/issues-resolution-d
 import {fetchPullRequests} from "~~/server/data/tinybird/pull-requests-data-source";
 import {fetchAverageTimeToMerge} from "~~/server/data/tinybird/average-time-to-merge-data-source";
 import {fetchWaitTimeFor1stReview} from "~~/server/data/tinybird/wait-time-for-1st-review-data-source";
+import {fetchMergeLeadTime} from "~~/server/data/tinybird/merge-lead-time-data-source";
 import type {ForksData, StarsData} from "~~/types/popularity/responses.types";
 import type {
-  IssuesResolution, PullRequests, AverageTimeMerge, WaitTime1stReview
+  IssuesResolution, PullRequests, AverageTimeMerge, WaitTime1stReview, MergeLeadTime
 } from "~~/types/development/responses.types";
 
 export interface DataSource {
@@ -58,6 +60,7 @@ export interface DataSource {
     fetchPullRequests: (filter: ActivityCountFilter) => Promise<PullRequests>;
     fetchAverageTimeToMerge: (filter: AverageTimeToMergeFilter) => Promise<AverageTimeMerge>;
     fetchWaitTimeFor1stReview: (filter: WaitTimeFor1stReviewFilter) => Promise<WaitTime1stReview>;
+    fetchMergeLeadTime: (filter: MergeLeadTimeFilter) => Promise<MergeLeadTime>;
 }
 
 export function createDataSource(): DataSource {
@@ -75,6 +78,7 @@ export function createDataSource(): DataSource {
         fetchIssuesResolution,
         fetchPullRequests,
         fetchAverageTimeToMerge,
-        fetchWaitTimeFor1stReview
+        fetchWaitTimeFor1stReview,
+        fetchMergeLeadTime
     };
 }

--- a/frontend/server/data/tinybird/merge-lead-time-data-source.test.ts
+++ b/frontend/server/data/tinybird/merge-lead-time-data-source.test.ts
@@ -1,0 +1,104 @@
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import { DateTime } from 'luxon';
+import {
+  mockCurrentData,
+  mockPreviousData,
+} from '../../mocks/tinybird-merge-lead-time-response.mock';
+import type { MergeLeadTime } from '~~/types/development/responses.types';
+import type { MergeLeadTimeFilter } from '~~/server/data/types';
+
+const mockFetchFromTinybird = vi.fn();
+
+describe('Merge Lead Time Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // Here be dragons! vi.doMock is not hoisted, and thus it is executed after the original import statement.
+    // This means that the import for tinybird.ts inside the data source module would still be used,
+    // and thus not mocked. This means we need to import the module again after the mock is set, whenever we want to
+    // use it.
+    vi.doMock(import('./tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  })
+
+  test('should fetch merge lead time data with correct parameters', async () => {
+    // We have to import this here again because vi.doMock is not hoisted. See the explanation in beforeEach().
+    const {fetchMergeLeadTime} = await import('~~/server/data/tinybird/merge-lead-time-data-source');
+
+    mockFetchFromTinybird
+      .mockResolvedValueOnce(mockCurrentData)
+      .mockResolvedValueOnce(mockPreviousData);
+
+    const startDate = DateTime.utc(2024, 3, 20);
+    const endDate = DateTime.utc(2025, 3, 20);
+
+    const filter: MergeLeadTimeFilter = {
+      project: 'the-linux-kernel-organization',
+      repo: 'some-repo',
+      startDate,
+      endDate
+    };
+
+    const result = await fetchMergeLeadTime(filter);
+
+    const expectedTinybirdPath = '/v0/pipes/pull_requests_merge_lead_time.json';
+
+    const expectedPreviousQuery = {
+      ...filter,
+      startDate: DateTime.utc(2023, 3, 19),
+      endDate: DateTime.utc(2024, 3, 19),
+    };
+
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(1, expectedTinybirdPath, filter);
+    expect(mockFetchFromTinybird).toHaveBeenNthCalledWith(2, expectedTinybirdPath, expectedPreviousQuery);
+
+    const currentValue = mockCurrentData.data[0].openedToMergedSeconds;
+    const previousValue = mockPreviousData.data[0].openedToMergedSeconds;
+    const currentToReviewAssigned = mockCurrentData.data[0].openedToReviewAssignedSeconds;
+    const previousToReviewAssigned = mockPreviousData.data[0].openedToReviewAssignedSeconds;
+    const currentToFirstReview = mockCurrentData.data[0].reviewAssignedToFirstReviewSeconds;
+    const previousToFirstReview = mockPreviousData.data[0].reviewAssignedToFirstReviewSeconds;
+    const currentToApproved = mockCurrentData.data[0].firstReviewToApprovedSeconds;
+    const previousToApproved = mockPreviousData.data[0].firstReviewToApprovedSeconds;
+    const currentToMerged = mockCurrentData.data[0].approvedToMergedSeconds;
+    const previousToMerged = mockPreviousData.data[0].approvedToMergedSeconds;
+
+    const expectedResult: MergeLeadTime = {
+      summary: {
+        current: currentValue,
+        previous: previousValue,
+        percentageChange: 100,
+        changeValue: currentValue - previousValue,
+        periodFrom: filter.startDate?.toISO() || '',
+        periodTo: filter.endDate?.toISO() || '',
+      },
+      data: {
+        pickup: {
+          value: currentToReviewAssigned,
+          unit: 'seconds',
+          changeType: currentToReviewAssigned > previousToReviewAssigned ? 'positive' : 'negative'
+        },
+        review: {
+          value: currentToFirstReview,
+          unit: 'seconds',
+          changeType: currentToFirstReview > previousToFirstReview ? 'positive' : 'negative'
+        },
+        accepted: {
+          value: mockCurrentData.data[0].firstReviewToApprovedSeconds,
+          unit: 'seconds',
+          changeType: currentToApproved > previousToApproved ? 'positive' : 'negative'
+        },
+        prMerged: {
+          value: mockCurrentData.data[0].approvedToMergedSeconds,
+          unit: 'seconds',
+          changeType: currentToMerged > previousToMerged ? 'positive' : 'negative'
+        }
+      }
+    };
+
+    expect(result).toEqual(expectedResult);
+  });
+});

--- a/frontend/server/data/tinybird/merge-lead-time-data-source.ts
+++ b/frontend/server/data/tinybird/merge-lead-time-data-source.ts
@@ -1,0 +1,77 @@
+import type { MergeLeadTimeFilter } from "../types";
+import { fetchFromTinybird } from './tinybird'
+import { calculatePercentageChange, getPreviousDates } from "~~/server/data/util";
+import type { MergeLeadTime } from "~~/types/development/responses.types";
+
+// This is the data part of the response from Tinybird
+type TinybirdMergeLeadTimeData = {
+  openedToMergedSeconds: number,
+  openedToReviewAssignedSeconds: number,
+  reviewAssignedToFirstReviewSeconds: number,
+  firstReviewToApprovedSeconds: number,
+  approvedToMergedSeconds: number
+};
+
+export async function fetchMergeLeadTime(filter: MergeLeadTimeFilter): Promise<MergeLeadTime> {
+  // TODO: We're passing unchecked query parameters to TinyBird directly from the frontend.
+  //  We need to ensure this doesn't pose a security risk.
+
+  const dates = getPreviousDates(filter.startDate, filter.endDate);
+
+  const previousSummaryQuery = {
+    ...filter,
+    startDate: dates.previous.from,
+    endDate: dates.previous.to
+  };
+
+  const path = '/v0/pipes/pull_requests_merge_lead_time.json';
+
+  const [currentData, previousData] = await Promise.all([
+    fetchFromTinybird<TinybirdMergeLeadTimeData[]>(path, filter),
+    fetchFromTinybird<TinybirdMergeLeadTimeData[]>(path, previousSummaryQuery),
+  ]);
+
+  const currentValue = currentData.data[0].openedToMergedSeconds;
+  const previousValue = previousData.data[0].openedToMergedSeconds;
+  const currentToReviewAssigned = currentData.data[0].openedToReviewAssignedSeconds;
+  const previousToReviewAssigned = previousData.data[0].openedToReviewAssignedSeconds;
+  const currentToFirstReview = currentData.data[0].reviewAssignedToFirstReviewSeconds;
+  const previousToFirstReview = previousData.data[0].reviewAssignedToFirstReviewSeconds;
+  const currentToApproved = currentData.data[0].firstReviewToApprovedSeconds;
+  const previousToApproved = previousData.data[0].firstReviewToApprovedSeconds;
+  const currentToMerged = currentData.data[0].approvedToMergedSeconds;
+  const previousToMerged = previousData.data[0].approvedToMergedSeconds;
+
+  return {
+    summary: {
+      current: currentValue,
+      previous: previousValue,
+      percentageChange: calculatePercentageChange(currentValue, previousValue),
+      changeValue: currentValue - previousValue,
+      periodFrom: filter.startDate?.toISO() || '',
+      periodTo: filter.endDate?.toISO() || '',
+    },
+    data: {
+      pickup: {
+        value: currentToReviewAssigned,
+        unit: 'seconds',
+        changeType: currentToReviewAssigned > previousToReviewAssigned ? 'positive' : 'negative'
+      },
+      review: {
+        value: currentToFirstReview,
+        unit: 'seconds',
+        changeType: currentToFirstReview > previousToFirstReview ? 'positive' : 'negative'
+      },
+      accepted: {
+        value: currentData.data[0].firstReviewToApprovedSeconds,
+        unit: 'seconds',
+        changeType: currentToApproved > previousToApproved ? 'positive' : 'negative'
+      },
+      prMerged: {
+        value: currentData.data[0].approvedToMergedSeconds,
+        unit: 'seconds',
+        changeType: currentToMerged > previousToMerged ? 'positive' : 'negative'
+      }
+    }
+  };
+}

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -144,3 +144,10 @@ export type WaitTimeFor1stReviewFilter = {
   startDate?: DateTime,
   endDate?: DateTime,
 };
+
+export type MergeLeadTimeFilter = {
+  project: string;
+  repo?: string,
+  startDate?: DateTime,
+  endDate?: DateTime,
+};

--- a/frontend/server/mocks/tinybird-merge-lead-time-response.mock.ts
+++ b/frontend/server/mocks/tinybird-merge-lead-time-response.mock.ts
@@ -1,0 +1,79 @@
+export const mockCurrentData = {
+  meta: [
+    {
+      name: "openedToMergedSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "openedToReviewAssignedSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "reviewAssignedToFirstReviewSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "firstReviewToApprovedSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "approvedToMergedSeconds",
+      type: "Nullable(Float64)"
+    }
+  ],
+  data: [
+    {
+      openedToMergedSeconds: 100,
+      openedToReviewAssignedSeconds: 29628,
+      reviewAssignedToFirstReviewSeconds: 148790,
+      firstReviewToApprovedSeconds: 29272,
+      approvedToMergedSeconds: 96405
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.008990494,
+    rows_read: 146,
+    bytes_read: 10365
+  }
+};
+
+export const mockPreviousData = {
+  meta: [
+    {
+      name: "openedToMergedSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "openedToReviewAssignedSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "reviewAssignedToFirstReviewSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "firstReviewToApprovedSeconds",
+      type: "Nullable(Float64)"
+    },
+    {
+      name: "approvedToMergedSeconds",
+      type: "Nullable(Float64)"
+    }
+  ],
+  data: [
+    {
+      openedToMergedSeconds: 50,
+      openedToReviewAssignedSeconds: 21665,
+      reviewAssignedToFirstReviewSeconds: 55102,
+      firstReviewToApprovedSeconds: 25790,
+      approvedToMergedSeconds: 141256
+    }
+  ],
+  rows: 1,
+  statistics: {
+    elapsed: 0.156914285,
+    rows_read: 732,
+    bytes_read: 50799
+  }
+};

--- a/frontend/types/development/responses.types.ts
+++ b/frontend/types/development/responses.types.ts
@@ -63,8 +63,8 @@ export interface IssuesResolution {
 
 export interface MergeLeadTimeItem {
   value: number;
-  unit: string;
-  changeType: string;
+  unit: 'seconds' | 'minutes' | 'hours' | 'days';
+  changeType: 'positive' | 'negative';
 }
 export interface MergeLeadTime {
   summary: Summary;


### PR DESCRIPTION
The Code Review Engagement widget needs data from both the contributors leaderboard, and the active contributors TinyBird endpoints, but the return types were in the respective data sources.

This PR moves those data sources to a separate module, so we can access them from the Code Review Engagement later.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Refactor**
  - Streamlined the handling of contributor metrics to ensure improved consistency and data reliability for active contributor and leaderboard displays.
  - Enhanced the structure of contributor statistics to support more accurate and maintainable data processing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->