### PR TITLE
fix: benchmarks copy

### DIFF
--- a/frontend/app/config/benchmarks/configs/active-days.ts
+++ b/frontend/app/config/benchmarks/configs/active-days.ts
@@ -5,7 +5,7 @@ import type { BenchmarkConfigs } from '~~/types/shared/benchmark.types';
 import { BenchmarkKeys } from '~~/types/shared/benchmark.types';
 
 export const activeDays: BenchmarkConfigs = {
-  title: 'Active Days Benchmarks',
+  title: 'Active Days',
   key: BenchmarkKeys.ActiveDays,
   points: [
     {


### PR DESCRIPTION
This PR fixes a typo in one of the Health Score benchmarks in the Project's Overview page.
Previously we had "Active Days Benchmarks" which is not consistent with the remaining metrics that do not have the "Benchmarks" suffix. This PR removes the "Benchmarks" from the copy.