### PR TITLE
chore: enable oss index menu link

### DIFF
--- a/frontend/app/config/menu/index.ts
+++ b/frontend/app/config/menu/index.ts
@@ -26,11 +26,11 @@ export const lfxMenu: MenuConfig = {
       icon: 'rectangle-history',
       route: LfxRoutes.COLLECTIONS
     },
-    // {
-    //   label: 'Open Source Index',
-    //   icon: 'globe',
-    //   route: LfxRoutes.OPENSOURCEINDEX
-    // },
+    {
+      label: 'Open Source Index',
+      icon: 'globe',
+      route: LfxRoutes.OPENSOURCEINDEX
+    },
     {
       label: 'Documentation',
       icon: 'book-open',


### PR DESCRIPTION
This PR enables the Menu link for the Open Source Index page.