### PR TITLE
added function that temporarily hides documentation and vulnerability

### DIFF
--- a/frontend/app/components/modules/project/services/security.service.ts
+++ b/frontend/app/components/modules/project/services/security.service.ts
@@ -1,9 +1,13 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { type SecurityData, SecurityDataResult } from '~~/types/security/responses.types';
+import {
+  type SecurityData,
+  SecurityDataCategory,
+  SecurityDataResult,
+} from '~~/types/security/responses.types';
 import {
   lfxOspsBaselineScore,
-  type OspsBaselineScore
+  type OspsBaselineScore,
 } from '~/components/modules/project/config/osps-baseline-score';
 import { lfxColors } from '~/config/styles/colors';
 
@@ -18,6 +22,19 @@ export interface ScoreDataQueryParams extends OverviewQueryParams {
 
 // TODO: Refactor other services to follow this pattern
 class ProjectSecurityService {
+  // TODO: Remove this when we have data for them
+  /**
+   * This function removes the "Documentation" and "Vulnerability Management" categories from the data
+   * @param data
+   * @returns
+   */
+  removeDocumentationAndVulnerability(data: SecurityData[]): SecurityData[] {
+    return data.filter(
+      (item) => item.category !== SecurityDataCategory.DOCUMENTATION
+        && item.category !== SecurityDataCategory.VULNERABILITY_MANAGEMENT
+    );
+  }
+
   calculateOSPSScore(data: SecurityData[], isRepository: boolean): number {
     if (data.length === 0) {
       return 0;
@@ -71,16 +88,14 @@ class ProjectSecurityService {
 
   getOSPSconfig(results: number): OspsBaselineScore {
     return (
-      lfxOspsBaselineScore.find(
-        (item) => results >= item.minScore && results <= item.maxScore
-      ) || {
+      lfxOspsBaselineScore.find((item) => results >= item.minScore && results <= item.maxScore) || {
         minScore: 0,
         maxScore: 100,
         label: 'No data available',
         description: '',
         lineColor: lfxColors.neutral[200],
         badgeBgColor: lfxColors.neutral[100],
-        badgeTextColor: lfxColors.neutral[500]
+        badgeTextColor: lfxColors.neutral[500],
       }
     );
   }

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -106,10 +106,14 @@ const {
 } = OVERVIEW_API_SERVICE.fetchHealthScore(params);
 
 const {
-  data: securityAssessmentData,
+  data: securityAssessmentDataRaw,
   status: securityAssessmentStatus,
   error: securityAssessmentError, suspense: securityAssessmentSuspense
 } = OVERVIEW_API_SERVICE.fetchSecurityAssessment(params);
+
+// TODO: Remove this when we have data for them
+const securityAssessmentData = computed(() => PROJECT_SECURITY_SERVICE
+.removeDocumentationAndVulnerability(securityAssessmentDataRaw.value || []));
 
 const status = computed<AsyncDataRequestStatus>(() => {
   if (healthScoreStatus.value === 'success' && securityAssessmentStatus.value === 'success') {

--- a/frontend/app/components/modules/project/views/security.vue
+++ b/frontend/app/components/modules/project/views/security.vue
@@ -129,6 +129,7 @@ import {useProjectStore} from "~/components/modules/project/store/project.store"
 import type {SecurityData} from "~~/types/security/responses.types";
 import {links} from "~/config/links";
 import LfxSpinner from "~/components/uikit/spinner/spinner.vue";
+import {PROJECT_SECURITY_SERVICE} from "~/components/modules/project/services/security.service";
 
 const accordion = ref('');
 
@@ -161,7 +162,11 @@ const {
   queryFn: fetchData,
 });
 
-const groupedData = computed(() => (data.value || []).reduce((mapping, check) => {
+// TODO: Remove this when we have data for them
+const securityAssessmentData = computed(() => PROJECT_SECURITY_SERVICE
+.removeDocumentationAndVulnerability(data.value || []));
+
+const groupedData = computed(() => (securityAssessmentData.value || []).reduce((mapping, check) => {
     const obj = {...mapping};
     if (!obj[check.category]) {
       obj[check.category] = [];


### PR DESCRIPTION
## In this PR

- Added function to hide documentation and vulnerability management categories from the security score
- Applied the filter to both the overview and security and best practices tab

## Ticket
[INS-639](https://linear.app/lfx/issue/INS-639/hide-documentation-and-vulnerability-management-metrics-for-now)