### PR TITLE
use hasNextPage flag to determine loadmore visibility

### DIFF
--- a/frontend/app/components/modules/widget/components/contributors/fragments/contributors-table.vue
+++ b/frontend/app/components/modules/widget/components/contributors/fragments/contributors-table.vue
@@ -95,18 +95,18 @@ const props = withDefaults(
     contributors: Contributor[];
     showPercentage?: boolean;
     showFullList?: boolean;
-    total?: number;
+    hasNextPage?: boolean;
     isFetchingNextPage?: boolean;
   }>(),
   {
     showPercentage: false,
     showFullList: false,
-    total: 0,
+    hasNextPage: false,
     isFetchingNextPage: false
   }
 );
 
-const showLoadMore = computed(() => props.total && props.total > props.contributors.length && props.showFullList);
+const showLoadMore = computed(() => props.hasNextPage && props.showFullList);
 
 const options = {
   root: null,

--- a/frontend/app/components/modules/widget/components/contributors/fragments/organizations-table.vue
+++ b/frontend/app/components/modules/widget/components/contributors/fragments/organizations-table.vue
@@ -96,18 +96,18 @@ const props = withDefaults(
     organizations: Organization[];
     showPercentage?: boolean;
     showFullList?: boolean;
-    total?: number;
+    hasNextPage?: boolean;
     isFetchingNextPage?: boolean;
   }>(),
   {
     showPercentage: false,
     showFullList: false,
-    total: 0,
+    hasNextPage: false,
     isFetchingNextPage: false
   }
 );
 
-const showLoadMore = computed(() => props.total && props.total > props.organizations.length && props.showFullList);
+const showLoadMore = computed(() => props.hasNextPage && props.showFullList);
 
 const options = {
   root: null,

--- a/frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/fragments/contributor-leaderboard-drawer.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/fragments/contributor-leaderboard-drawer.vue
@@ -43,7 +43,7 @@ SPDX-License-Identifier: MIT
             :metric="metric"
             :contributors="contributors"
             :show-full-list="true"
-            :total="total"
+            :has-next-page="hasNextPage"
             :is-fetching-next-page="isFetchingNextPage"
             :show-percentage="true"
             @load-more="loadMore"
@@ -122,6 +122,7 @@ const {
   data,
   isSuccess,
   isError,
+  hasNextPage,
   fetchNextPage,
   isFetchingNextPage,
   suspense
@@ -133,13 +134,13 @@ const contributors = computed<Contributor[]>(() => {
   }
   return data.value?.pages.flatMap((page) => (page as ContributorLeaderboard).data) || [];
 });
-const total = computed(() => (data.value?.pages[0]
-  ? (data.value?.pages[0] as unknown as ContributorLeaderboard).meta.total || 0 : 0));
 
 const isEmpty = computed(() => isEmptyData(contributors.value as unknown as Record<string, unknown>[]));
 
 const loadMore = () => {
-  fetchNextPage();
+  if (hasNextPage.value) {
+    fetchNextPage();
+  }
 };
 
 watch(props, () => {

--- a/frontend/app/components/modules/widget/config/contributor/organizations-leaderboard/fragments/organization-leaderboard-drawer.vue
+++ b/frontend/app/components/modules/widget/config/contributor/organizations-leaderboard/fragments/organization-leaderboard-drawer.vue
@@ -43,7 +43,7 @@ SPDX-License-Identifier: MIT
             :metric="metric"
             :organizations="organizations"
             :show-full-list="true"
-            :total="total"
+            :has-next-page="hasNextPage"
             :is-fetching-next-page="isFetchingNextPage"
             @load-more="loadMore"
           />
@@ -122,6 +122,7 @@ const {
   data,
   isSuccess,
   isError,
+  hasNextPage,
   fetchNextPage,
   isFetchingNextPage,
   suspense
@@ -133,13 +134,13 @@ const organizations = computed<Organization[]>(() => {
   }
   return data.value?.pages.flatMap((page) => (page as OrganizationLeaderboard).data) || [];
 });
-const total = computed(() => (data.value?.pages[0]
-  ? (data.value?.pages[0] as unknown as OrganizationLeaderboard).meta.total || 0 : 0));
 
 const isEmpty = computed(() => isEmptyData(organizations.value as unknown as Record<string, unknown>[]));
 
 const loadMore = () => {
-  fetchNextPage();
+  if (hasNextPage.value) {
+    fetchNextPage();
+  }
 };
 
 watch(props, () => {


### PR DESCRIPTION
## In this PR

- Changed the flag checking used for showing the load more row on the org and contributor drawers
- Added additional check before fetching next page

## Ticket
[INS-665](https://linear.app/lfx/issue/INS-665/page-crashes-when-opening-all-contributors-and-all-organizations-tab)