### PR TITLE
bugfix: remove share badge query parameters

### DIFF
--- a/frontend/app/components/shared/modules/share/components/active-contributor-badge.vue
+++ b/frontend/app/components/shared/modules/share/components/active-contributor-badge.vue
@@ -77,7 +77,7 @@ const activeBadgeUrl = computed(() => getBadgeUrl(
 ));
 
 const markdown = (badgeUrl: string) => {
-  const link = window?.location.href;
+  const link = window?.location.href.split('?')[0];
   return `[![LFX Active Contributors](${badgeUrl})](${link})`;
 };
 

--- a/frontend/app/components/shared/modules/share/components/share-badge.vue
+++ b/frontend/app/components/shared/modules/share/components/share-badge.vue
@@ -37,7 +37,6 @@ SPDX-License-Identifier: MIT
           Copy markdown
         </lfx-button>
       </div>
-
       <div class="flex items-center justify-between">
         <lfx-skeleton-state
           :status="project?.contributorCount ? 'success' : 'pending'"
@@ -158,7 +157,8 @@ const contributorBadgeUrl = computed(() => getBadgeUrl(
 ));
 
 const markdown = (badgeUrl: string, title: string) => {
-  const link = window?.location.href;
+  const link = window?.location.href.split('?')[0];
+
   return `[![${title}](${badgeUrl})](${link})`;
 };
 


### PR DESCRIPTION
## In this PR
Remove the query parameters from the share badge - copy markdown feature

## Ticket
[INS-662](https://linear.app/lfx/issue/INS-662/remove-query-params-from-badge-link)