### PR TITLE
search query widget adjustments

### DIFF
--- a/frontend/app/components/modules/widget/components/shared/widget-area.vue
+++ b/frontend/app/components/modules/widget/components/shared/widget-area.vue
@@ -84,7 +84,7 @@ const isFirstLoad = ref(true);
 const widgets = computed(() => (config.value.widgets || [])
     .filter((widget) => {
       const key = lfxWidgets[widget as Widget]?.key;
-      return project.value?.widgets.includes(key)
+      return (project.value?.widgets.includes(key) && !lfxWidgets[widget as Widget]?.hideOnRepoFilter)
     }));
 
 const sideNavItems = computed(() => widgets.value.map((widget: Widget) => ({

--- a/frontend/app/components/modules/widget/components/shared/widget-area.vue
+++ b/frontend/app/components/modules/widget/components/shared/widget-area.vue
@@ -86,7 +86,7 @@ const widgets = computed(() => (config.value.widgets || [])
       const key = lfxWidgets[widget as Widget]?.key;
       const widgetConfig = lfxWidgets[widget as Widget];
       return (
-        (project.value?.widgets.includes(key) || key === 'searchQueries')
+        project.value?.widgets.includes(key)
         && (!widgetConfig?.hideOnRepoFilter || !repository.value)
       );
     }));

--- a/frontend/app/components/modules/widget/components/shared/widget-area.vue
+++ b/frontend/app/components/modules/widget/components/shared/widget-area.vue
@@ -78,13 +78,17 @@ const tmpClickedItem = ref('');
 const loadedWidgets = ref<Record<string, boolean>>({});
 
 const { scrollToTarget, scrollToTop } = useScroll();
-const { project } = storeToRefs(useProjectStore())
+const { project, repository } = storeToRefs(useProjectStore())
 const isFirstLoad = ref(true);
 
 const widgets = computed(() => (config.value.widgets || [])
     .filter((widget) => {
       const key = lfxWidgets[widget as Widget]?.key;
-      return (project.value?.widgets.includes(key) && !lfxWidgets[widget as Widget]?.hideOnRepoFilter)
+      const widgetConfig = lfxWidgets[widget as Widget];
+      return (
+        (project.value?.widgets.includes(key) || key === 'searchQueries')
+        && (!widgetConfig?.hideOnRepoFilter || !repository.value)
+      );
     }));
 
 const sideNavItems = computed(() => widgets.value.map((widget: Widget) => ({

--- a/frontend/app/components/modules/widget/config/popularity/search-queries/search-queries.config.ts
+++ b/frontend/app/components/modules/widget/config/popularity/search-queries/search-queries.config.ts
@@ -1,17 +1,18 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import SearchQueries from "./search-queries.vue";
-import type {WidgetConfig} from "~/components/modules/widget/config/widget.config";
+import SearchQueries from './search-queries.vue';
+import type { WidgetConfig } from '~/components/modules/widget/config/widget.config';
 
 const searchQueries: WidgetConfig = {
-    key: 'searchQueries',
-    name: 'Search queries',
-    description: (project) => `Search interest volume of ${project.name} based on Google Trends.`,
-    learnMoreLink: `/docs/metrics/popularity#search-queries`,
-    component: SearchQueries,
-    share: true,
-    embed: true,
-    snapshot: true,
-}
+  key: 'searchQueries',
+  name: 'Search queries volume',
+  description: (project) => `Search interest volume of ${project.name} based on Keywords Everywhere.`,
+  learnMoreLink: `/docs/metrics/popularity#search-queries`,
+  component: SearchQueries,
+  share: true,
+  embed: true,
+  snapshot: true,
+  hideOnRepoFilter: true,
+};
 
 export default searchQueries;

--- a/frontend/app/components/modules/widget/config/widget-area.config.ts
+++ b/frontend/app/components/modules/widget/config/widget-area.config.ts
@@ -11,7 +11,7 @@ export interface WidgetAreaConfig {
 
 export const lfxWidgetArea: Record<WidgetArea, WidgetAreaConfig> = {
   [WidgetArea.OVERVIEW]: {
-    label: 'Overview'
+    label: 'Overview',
   },
   [WidgetArea.CONTRIBUTORS]: {
     label: 'Contributors',
@@ -23,15 +23,15 @@ export const lfxWidgetArea: Record<WidgetArea, WidgetAreaConfig> = {
       Widget.CONTRIBUTOR_DEPENDENCY,
       Widget.ORGANIZATION_DEPENDENCY,
       Widget.RETENTION,
-      Widget.GEOGRAPHICAL_DISTRIBUTION
+      Widget.GEOGRAPHICAL_DISTRIBUTION,
     ],
     overviewWidgets: [
       Widget.RETENTION,
       Widget.ACTIVE_CONTRIBUTORS,
       Widget.CONTRIBUTOR_DEPENDENCY,
       Widget.ORGANIZATION_DEPENDENCY,
-      Widget.GEOGRAPHICAL_DISTRIBUTION
-    ]
+      Widget.GEOGRAPHICAL_DISTRIBUTION,
+    ],
   },
   [WidgetArea.POPULARITY]: {
     label: 'Popularity',
@@ -41,12 +41,13 @@ export const lfxWidgetArea: Record<WidgetArea, WidgetAreaConfig> = {
       Widget.SOCIAL_MENTIONS,
       Widget.GITHUB_MENTIONS,
       Widget.PRESS_MENTIONS,
-      Widget.SEARCH_QUERIES,
+      // TODO: Uncomment this when the search queries widget is ready
+      // Widget.SEARCH_QUERIES,
       // TODO: Uncomment this when the package downloads widget is ready
       // Widget.PACKAGE_DOWNLOADS,
-      Widget.MAILING_LISTS_MESSAGES
+      Widget.MAILING_LISTS_MESSAGES,
     ],
-    overviewWidgets: [Widget.STARS, Widget.FORKS]
+    overviewWidgets: [Widget.STARS, Widget.FORKS],
   },
   [WidgetArea.DEVELOPMENT]: {
     label: 'Development',
@@ -60,20 +61,20 @@ export const lfxWidgetArea: Record<WidgetArea, WidgetAreaConfig> = {
       Widget.REVIEW_TIME_BY_PULL_REQUEST_SIZE,
       Widget.AVERAGE_TIME_TO_MERGE,
       Widget.WAIT_TIME_FIRST_REVIEW,
-      Widget.CODE_REVIEW_ENGAGEMENT
+      Widget.CODE_REVIEW_ENGAGEMENT,
     ],
     overviewWidgets: [
       Widget.ACTIVE_DAYS,
       Widget.CONTRIBUTIONS_OUTSIDE_WORK_HOURS,
       Widget.ISSUES_RESOLUTION,
       Widget.MERGE_LEAD_TIME,
-      Widget.PULL_REQUESTS
-    ]
+      Widget.PULL_REQUESTS,
+    ],
   },
   [WidgetArea.SECURITY]: {
-    label: 'Security & Best practices'
+    label: 'Security & Best practices',
   },
   [WidgetArea.OTHER]: {
-    label: 'Other'
-  }
+    label: 'Other',
+  },
 };

--- a/frontend/app/components/modules/widget/config/widget.config.ts
+++ b/frontend/app/components/modules/widget/config/widget.config.ts
@@ -55,6 +55,7 @@ export interface WidgetConfig {
   snapshot: boolean;
   defaultValue?: Record<string, unknown>;
   additionalShare?: Component;
+  hideOnRepoFilter?: boolean;
 }
 
 export const lfxWidgets: Record<Widget, WidgetConfig> = {


### PR DESCRIPTION
## In this PR

- Changed widget title and description
- Added hideOnRepoFilter flag for widgets that hides them when the repository is filtered
- Fixed the chart's granularity to monthly
- Show empty data if the date filter is below 30 days

## Ticket
[INS-676](https://linear.app/lfx/issue/INS-676/update-the-frontend-code-for-the-search-queries-widget-to-match-the)