### PR TITLE
explore page top section text changes and column display

### DIFF
--- a/frontend/app/components/modules/explore/components/top-contributors.vue
+++ b/frontend/app/components/modules/explore/components/top-contributors.vue
@@ -41,12 +41,6 @@ SPDX-License-Identifier: MIT
         >
           {{ formatNumber(row.activityCount) }}
         </div>
-        <div
-          v-if="!isFullList"
-          class="basis-1/3 text-right text-xs text-neutral-500 hidden xl:block text-nowrap"
-        >
-          {{ formatNumber(row.activityCount) }} contributions
-        </div>
       </div>
     </div>
   </lfx-project-load-state>

--- a/frontend/app/components/modules/explore/components/top-organizations.vue
+++ b/frontend/app/components/modules/explore/components/top-organizations.vue
@@ -41,12 +41,6 @@ SPDX-License-Identifier: MIT
         >
           {{ formatNumber(row.activityCount) }}
         </div>
-        <div
-          v-if="!isFullList"
-          class="basis-1/3 text-right text-xs text-neutral-500 hidden xl:block text-nowrap"
-        >
-          {{ formatNumber(row.activityCount) }} contributions
-        </div>
       </div>
 
     </div>

--- a/frontend/app/components/modules/explore/config/top-section-tabs.ts
+++ b/frontend/app/components/modules/explore/config/top-section-tabs.ts
@@ -8,24 +8,24 @@ import LfxExploreTopOrganizations from '../components/top-organizations.vue';
 export const TOP_SECTION_TABS: ExploreTab[] = [
   {
     title: 'Top projects',
-    description: `Projects ranked by Criticality Score — a metric that reflects their 
-    importance, usage, and potential impact across the ecosystem.`,
+    description: `Projects ranked by Criticality Score, considering 
+    their importance, usage, and potential impact across the ecosystem.`,
     component: LfxExploreTopProjects,
     icon: 'laptop-code',
     type: 'project',
   },
   {
-    title: 'Top active contributors',
-    description: `Developers ranked by volume of contributions over the last 10 years, 
-    highlighting the most active and influential individuals in the open source ecosystem.`,
+    title: 'Top contributors',
+    description: `Contributors ranked by the number of contributions in all 
+    projects tracked by Insights over the last 10 years.`,
     component: LfxExploreTopContributors,
     icon: 'people-group',
     type: 'contributor',
   },
   {
-    title: 'Top active organizations',
-    description: `Most influential organizations based on the total number of contributions 
-    made across the most relevant open source projects over the last 10 years.`,
+    title: 'Top organizations',
+    description: `Organizations ranked by the number of affiliated contributions in 
+    all projects tracked by Insights over the last 10 years.`,
     component: LfxExploreTopOrganizations,
     icon: 'buildings',
     type: 'organization',


### PR DESCRIPTION
## In this PR

- Removed the contributions value from the top contributors and organization and made it only visible on the view more
- Removed the word "active" from the title
- Description changes for top contributors and organization components

## Ticket
[INS-678](https://linear.app/lfx/issue/INS-678/changes-to-leaderboards-on-explore-page)