### PR TITLE
fix: added exclude function on the share badge modal

### DIFF
--- a/frontend/app/components/shared/modules/share/components/share-badge.vue
+++ b/frontend/app/components/shared/modules/share/components/share-badge.vue
@@ -113,10 +113,14 @@ const {
 } = OVERVIEW_API_SERVICE.fetchHealthScore(params);
 
 const {
-  data: securityAssessmentData,
+  data: securityAssessmentDataRaw,
   status: securityAssessmentStatus,
   error: securityAssessmentError
 } = OVERVIEW_API_SERVICE.fetchSecurityAssessment(params);
+
+// TODO: Remove this when we have data for them
+const securityAssessmentData = computed(() => PROJECT_SECURITY_SERVICE
+.removeDocumentationAndVulnerability(securityAssessmentDataRaw.value || []));
 
 const statusHealthScore = computed<AsyncDataRequestStatus>(() => {
   if (healthScoreStatus.value === 'success' && securityAssessmentStatus.value === 'success') {


### PR DESCRIPTION
## In this PR

The osps score computation on the share badge modal still included the documentation and vulnerability management which cause the incorrect score. Add the function in the modal's data fetch to fix this.

## Ticket
[INS-680](https://linear.app/lfx/issue/INS-680/generated-badge-not-matching-healthscore-of-the-project)