### PR TITLE
fix: set top section of explore to grid

### DIFF
--- a/frontend/app/components/modules/explore/components/list-card.vue
+++ b/frontend/app/components/modules/explore/components/list-card.vue
@@ -4,8 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <template>
   <article
-    class="border border-neutral-200 rounded-xl flex flex-col gap-4 bg-white
-    basis-1/3 lg:max-w-1/3 max-w-full"
+    class="border border-neutral-200 rounded-xl flex flex-col gap-4 bg-white h-full"
   >
     <div class="flex flex-col gap-2 px-6 pt-6">
       <h3 class="text-heading-3 font-secondary font-bold text-neutral-900">
@@ -15,7 +14,7 @@ SPDX-License-Identifier: MIT
         {{ props.value.description }}
       </p>
     </div>
-    <div class="px-4 pb-6">
+    <div class="px-4 pb-6 grow flex flex-col justify-between">
       <component
         :is="props.value.component"
       />

--- a/frontend/app/components/modules/explore/components/top-section.vue
+++ b/frontend/app/components/modules/explore/components/top-section.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <template>
   <section>
-    <div class="lg:flex hidden flex-row gap-4 xl:gap-8 items-start">
+    <div class="lg:grid hidden grid-cols-3 gap-4 xl:gap-8 items-start">
       <lfx-explore-list-card
         v-for="tab in TOP_SECTION_TABS"
         :key="tab.title"


### PR DESCRIPTION
## In this PR

- Set the top section cards of the explore page to grid so that the columns would appear equal heights
- Align the view more button on each card to the bottom of the card

## Ticket
[INS-705](https://linear.app/lfx/issue/INS-705/leaderboard-boxes-should-have-same-length)