### PR TITLE
fix: chart series object mapping

### DIFF
--- a/frontend/app/components/uikit/chart/configs/tree-map.chart.ts
+++ b/frontend/app/components/uikit/chart/configs/tree-map.chart.ts
@@ -215,9 +215,10 @@ export const getTreeMapConfig = (
   isValueCurrency: boolean,
   options?: ECOption
 ): ECOption => {
-  const treeMapOption = _.merge(defaultTreeMapOption, {
+  const treeMapOption = _.merge({}, defaultTreeMapOption, {
     series: [isValueCurrency ? SERIES_CURRENCY : SERIES_DEFAULT] as ECOption['series'],
   });
+  console.log('!!!treeMapOption', treeMapOption);
 
   const config = _.merge({}, treeMapOption, options);
   if (config.tooltip) {


### PR DESCRIPTION
## In this PR

Fix the object mapping for currency-based series and normal number series that causes the chart to be stuck in the same number formatter

## Ticket
[INS-709](https://linear.app/lfx/issue/INS-709/issue-with-open-source-index-when-changing-between-contributors-and)