### PR TITLE
fix: fix the start and end dates format for the search volume data source

### DIFF
--- a/frontend/server/data/tinybird/search-queries-data-source.ts
+++ b/frontend/server/data/tinybird/search-queries-data-source.ts
@@ -19,10 +19,7 @@ export async function fetchSearchVolume(filter: SearchVolumeFilter): Promise<Sea
   return {
     data: data.data.map((item) => ({
       startDate: item.dataTimestamp,
-      endDate: DateTime.fromFormat(
-        item.dataTimestamp.toString(),
-        "yyyy-MM-dd HH:mm:ss.SSS"
-      ).endOf('month').toString(),
+      endDate: DateTime.fromISO(item.dataTimestamp).endOf('month').toFormat('yyyy-MM-dd'),
       queryCount: item.volume
     }))
   };


### PR DESCRIPTION
This depends on having changed the date format returned from TinyBird, so it doesn't include time, just the date.