### PR TITLE
feat: changed the sorting and description of the top projects list

### DIFF
--- a/frontend/app/components/modules/explore/config/top-section-tabs.ts
+++ b/frontend/app/components/modules/explore/config/top-section-tabs.ts
@@ -8,8 +8,7 @@ import LfxExploreTopOrganizations from '../components/top-organizations.vue';
 export const TOP_SECTION_TABS: ExploreTab[] = [
   {
     title: 'Top Linux Foundation projects',
-    description: `Linux Foundation projects ranked by Criticality Score, considering 
-    their importance, usage, and potential impact across the ecosystem.`,
+    description: `Linux Foundation projects ranked by the total number of contributors.`,
     component: LfxExploreTopProjects,
     icon: 'laptop-code',
     type: 'project',

--- a/frontend/app/components/modules/explore/services/explore.api.service.ts
+++ b/frontend/app/components/modules/explore/services/explore.api.service.ts
@@ -92,7 +92,7 @@ class ExploreApiService {
         params: {
           page: pageParam,
           pageSize,
-          sort: 'score_desc',
+          sort: 'contributorCount_desc',
           onboarded: true, // Only fetch onboarded projects
           isLF: true, // Only fetch LF projects
         },


### PR DESCRIPTION
## In this PR

- Changed the description of the top projects list in the explore page
- Changed the sorting "contributorCount_desc" to match the description

## Ticket
[INS-714](https://linear.app/lfx/issue/INS-714/change-the-description-and-sorting-of-top-projects-in-the-leaderboard)