### PR TITLE
fix: incorrect org dependency avatar display

### DIFF
--- a/frontend/app/components/modules/widget/config/contributor/organization-dependency/organization-dependency.vue
+++ b/frontend/app/components/modules/widget/config/contributor/organization-dependency/organization-dependency.vue
@@ -137,7 +137,7 @@ const otherOrganizations = computed(() => organizationDependency.value?.otherOrg
 const organizations = computed(() => organizationDependency.value?.list);
 
 const topOrganizationsAvatars = computed(() => (organizations.value?.length
-  ? organizations.value.slice(0, Math.min(3, organizations.value.length))
+  ? organizations.value.slice(0, Math.min(3, topOrganizations.value?.count || 0))
   : []));
 
 const isEmpty = computed(() => isEmptyData(organizations.value as unknown as Record<string, unknown>[]));


### PR DESCRIPTION
## In this PR

Fix the incorrect value used for getting the top organization dependency avatar display. 

## Ticket
[DE-157](https://linuxfoundation.atlassian.net/browse/DE-157)

[DE-157]: https://linuxfoundation.atlassian.net/browse/DE-157?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ