### PR TITLE
fix: dependency avatars display for different screen sizes

### DIFF
--- a/frontend/app/assets/styles/utils/_dependency-display.scss
+++ b/frontend/app/assets/styles/utils/_dependency-display.scss
@@ -1,0 +1,8 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+.dependency-display-avatars {
+  :nth-child(n+4 of div.p-avatar) {
+    @apply hidden lg:flex;
+  }
+}

--- a/frontend/app/assets/styles/utils/index.scss
+++ b/frontend/app/assets/styles/utils/index.scss
@@ -3,3 +3,4 @@
 @use "container";
 @use "table";
 @use "tree-map";
+@use "dependency-display";

--- a/frontend/app/components/modules/widget/components/contributors/fragments/dependency-display.vue
+++ b/frontend/app/components/modules/widget/components/contributors/fragments/dependency-display.vue
@@ -5,7 +5,7 @@ SPDX-License-Identifier: MIT
 <template>
   <div class="flex flex-col gap-y-3 sm:flex-row justify-between sm:items-center mb-6">
     <div class="flex flex-row gap-3 items-center">
-      <div>
+      <div class="dependency-display-avatars">
         <slot />
       </div>
       <div class="flex flex-col items-start">

--- a/frontend/app/components/modules/widget/config/contributor/organization-dependency/organization-dependency.vue
+++ b/frontend/app/components/modules/widget/config/contributor/organization-dependency/organization-dependency.vue
@@ -137,7 +137,7 @@ const otherOrganizations = computed(() => organizationDependency.value?.otherOrg
 const organizations = computed(() => organizationDependency.value?.list);
 
 const topOrganizationsAvatars = computed(() => (organizations.value?.length
-  ? organizations.value.slice(0, Math.min(3, topOrganizations.value?.count || 0))
+  ? organizations.value.slice(0, Math.min(5, topOrganizations.value?.count || 0))
   : []));
 
 const isEmpty = computed(() => isEmptyData(organizations.value as unknown as Record<string, unknown>[]));


### PR DESCRIPTION
## In this PR

- Set the default display for org dependencies to 5
- Added style rule to only show 3 avatars on screens lower than 1024px for both the contributor and organization dependency widgets

## Ticket
[DE-157](https://linuxfoundation.atlassian.net/browse/DE-157)