### PR TITLE
fix: active org and contributor chart display for all time

### DIFF
--- a/frontend/app/components/uikit/chart/helpers/chart-helpers.ts
+++ b/frontend/app/components/uikit/chart/helpers/chart-helpers.ts
@@ -7,7 +7,7 @@ import type {
   ChartSeries,
   RawChartData,
   SeriesTypes,
-  CategoryData
+  CategoryData,
 } from '../types/ChartTypes';
 
 /**
@@ -29,42 +29,48 @@ export const convertToChartData = (
         key: item[keyField], // usually the startDate
         yAxisKey: yAxisKey ? item[yAxisKey] : undefined,
         values: valuesKey.map((key: string) => item[key]),
-        xAxisKey2: xAxisKey2 ? item[xAxisKey2] : undefined
-      } as ChartData)
+        xAxisKey2: xAxisKey2 ? item[xAxisKey2] : undefined,
+      }) as ChartData
   ) ?? [];
 
 export const getMaxValue = (data: ChartData[]): number => data //
     .filter((item) => item.key !== 'Unknown')
     .reduce((max, item) => Math.max(max, item.values[0] ?? 0), 0);
 
-export const convertToCategoryData = (
-  xData: ChartData[],
-  yData: ChartData[]
-): CategoryData => ({
+export const convertToCategoryData = (xData: ChartData[], yData: ChartData[]): CategoryData => ({
   xAxis: xData.map((item: ChartData) => ({
     key: parseInt(item.key, 10),
-    value: item.values[0] || 0
+    value: item.values[0] || 0,
   })),
   yAxis: yData.map((item: ChartData) => ({
     key: parseInt(item.key, 10),
-    value: item.values[0] || 0
-  }))
+    value: item.values[0] || 0,
+  })),
 });
 
 // function to convert date data to timestamp since the chart needs the date in this format
 export const convertDateData = (
   chartData: ChartData[] //
-) => chartData.map((item: ChartData) => DateTime.fromISO(item.key).toUTC().endOf('day').toMillis()) || [];
+) => chartData.map((item: ChartData) => DateTime.fromISO(item.key).toUTC().endOf('day').toMillis())
+  || [];
 
-// TODO: check if we'll need multiple yAxis
-// export const buildYAxis = (series: ChartSeries[]): YAXisOption[] | undefined =>
-//   series.length > 0
-//     ? series.map((item: ChartSeries) => ({
-//         type: 'value',
-//         position: item.position || 'left',
-//         alignTicks: true
-//       }))
-//     : undefined;
+/**
+ * Function to remove the 0 values from the beginning of the chart data
+ */
+export const removeZeroValues = (data: ChartData[]): ChartData[] => {
+  let startIndex = 0;
+
+  // Find the first non-zero value
+  for (let i = 0; i < data.length; i += 1) {
+    if (data[i]?.values[0] !== 0) {
+      startIndex = i;
+      break;
+    }
+  }
+
+  // Return the array starting from the first non-zero value
+  return data.slice(startIndex);
+};
 
 /**
  * Build series for the chart. The series is where the data is added to the chart.
@@ -72,18 +78,15 @@ export const convertDateData = (
  * @param data - Data
  * @returns Series
  */
-export const buildSeries = (
-  series: ChartSeries[],
-  data: ChartData[]
-): SeriesTypes[] | undefined => (series.length > 0
+export const buildSeries = (series: ChartSeries[], data: ChartData[]): SeriesTypes[] | undefined => (series.length > 0
     ? series.map(
         (series: ChartSeries) => ({
             type: series.type,
             name: series.name,
             yAxisIndex: series.yAxisIndex,
             dataIndex: series.dataIndex,
-            data: data.map((item: ChartData) => item.values[series.dataIndex]) || []
-          } as SeriesTypes)
+            data: data.map((item: ChartData) => item.values[series.dataIndex]) || [],
+          }) as SeriesTypes
       )
     : undefined);
 
@@ -94,12 +97,12 @@ export const convertToGradientColor = (
 ) => new graphic.LinearGradient(0, 0, 0, 1, [
     {
       offset: offsetStart,
-      color // Start color
+      color, // Start color
     },
     {
       offset: offsetEnd,
-      color: 'rgba(255, 255, 255, 0)' // Transparent white for gradient fade
-    }
+      color: 'rgba(255, 255, 255, 0)', // Transparent white for gradient fade
+    },
   ]);
 
 // handy function to convert hex color to rgba used for gradient colors in charts
@@ -128,10 +131,7 @@ export const hexToRgba = (hex: string, alpha: number = 1): string => {
  * @param data - Array of ChartData objects
  * @returns Array of number arrays representing [x, y, value] coordinates
  */
-export const convertToScatterData = (
-  data: ChartData[],
-  categoryData: CategoryData
-): number[][] => {
+export const convertToScatterData = (data: ChartData[], categoryData: CategoryData): number[][] => {
   const { xAxis } = categoryData;
   const yAxis = [...categoryData.yAxis].reverse();
 
@@ -143,7 +143,7 @@ export const convertToScatterData = (
     ) => [
       xAxis.findIndex((x) => x.value === item.key),
       yAxis.findIndex((y) => y.value === item.yAxisKey),
-      item.values[0] || 0
+      item.values[0] || 0,
     ]
   );
 };

--- a/frontend/pnpm-lock.yaml
+++ b/frontend/pnpm-lock.yaml
@@ -9,8 +9,8 @@ importers:
   .:
     dependencies:
       '@linuxfoundation/lfx-ui-core':
-        specifier: ^0.0.14
-        version: 0.0.14
+        specifier: ^0.0.18
+        version: 0.0.18
       '@nuxt/eslint':
         specifier: ^0.7.5
         version: 0.7.6(@typescript-eslint/utils@8.34.1(eslint@9.29.0(jiti@2.4.2))(typescript@5.8.3))(@vue/compiler-sfc@3.5.17)(eslint-import-resolver-node@0.3.9)(eslint@9.29.0(jiti@2.4.2))(magicast@0.3.5)(typescript@5.8.3)(vite@5.4.19(@types/node@24.0.3)(sass-embedded@1.89.2)(sass@1.89.2)(terser@5.43.1))
@@ -1204,8 +1204,8 @@ packages:
   '@kwsites/promise-deferred@1.1.1':
     resolution: {integrity: sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw==}
 
-  '@linuxfoundation/lfx-ui-core@0.0.14':
-    resolution: {integrity: sha512-QoH0NJbula6mV8a6OX9cMN+d3IvWMrE/F0qbW5Abn+WWxUnAjdlYytouWwQtNz37720eF36QhfRzribT6ytDgw==}
+  '@linuxfoundation/lfx-ui-core@0.0.18':
+    resolution: {integrity: sha512-XizKlRk9DfZuI0RlOwqbo/i9qswTf8/PGmkHtnNQdtYJ5eo4eBdqpt+LwFzyHPO6f8qXJmhH9NYucCxXjsUJbw==}
     peerDependencies:
       prettier: '>=3.0.0'
     peerDependenciesMeta:
@@ -8218,7 +8218,7 @@ snapshots:
 
   '@kwsites/promise-deferred@1.1.1': {}
 
-  '@linuxfoundation/lfx-ui-core@0.0.14': {}
+  '@linuxfoundation/lfx-ui-core@0.0.18': {}
 
   '@mapbox/node-pre-gyp@2.0.0':
     dependencies:


### PR DESCRIPTION
## In this PR

- Fix bug on the active contributors and orgs granularity tab not setting correctly for All Time
- Removed the empty or 0 rows from the data on those 2 widgets when the user selects All Time

## Ticket
[INS-722](https://linear.app/lfx/issue/INS-722/dont-show-empty-bars-for-alltime)