### PR TITLE
fix: url parameter history

### DIFF
--- a/frontend/app/components/modules/collection/views/collection-details.vue
+++ b/frontend/app/components/modules/collection/views/collection-details.vue
@@ -79,7 +79,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import {computed, onServerPrefetch} from 'vue'
+import {computed, onServerPrefetch, watch} from 'vue'
 import { useRoute } from 'vue-router'
 import { useInfiniteQuery } from '@tanstack/vue-query'
 import type { Project } from '~~/types/project'
@@ -169,6 +169,16 @@ const updateTab = (value: string) => {
     collectionTab: value,
   }
 }
+
+watch(() => queryParams.value, (value) => {
+  if (value.collectionSort && value.collectionSort !== sort.value) {
+    sort.value = value.collectionSort;
+  }
+
+  if (value.collectionTab && value.collectionTab !== tab.value) {
+    tab.value = value.collectionTab;
+  }
+});
 
 </script>
 

--- a/frontend/app/components/modules/collection/views/collection-list.vue
+++ b/frontend/app/components/modules/collection/views/collection-list.vue
@@ -168,7 +168,6 @@ const {scrollTop} = useScroll();
 const pageSize = 100
 const sort = ref(listSort || 'starred_desc')
 const category = ref('all');
-const isFirstLoad = ref(true);
 
 const queryKey = computed(() => [TanstackKey.COLLECTIONS, sort.value, category.value])
 
@@ -303,7 +302,7 @@ onServerPrefetch(async () => {
  * When that happens, the category is set to 'all'
  */
 watch(queryParams, (value) => {
-  if (value.listCategory && value.listCategory !== 'all' && isFirstLoad.value) {
+  if (value.listCategory && value.listCategory !== 'all') {
     let catId = value.listCategory;
 
     if (value.listCategory.startsWith('group(')) {
@@ -315,9 +314,13 @@ watch(queryParams, (value) => {
 
     const foundGroup = allCategoryGroups.value.find((group) => group.id === catId)
     category.value = foundGroup ? foundGroup.value : 'all';
+  } else {
+    category.value = 'all';
   }
 
-  isFirstLoad.value = false;
+  if (value.listSort && value.listSort !== sort.value) {
+    sort.value = value.listSort;
+  }
 }, { immediate: true })
 </script>
 

--- a/frontend/app/components/modules/project/components/shared/header/date-range-picker.vue
+++ b/frontend/app/components/modules/project/components/shared/header/date-range-picker.vue
@@ -162,6 +162,17 @@ watch(() => selectedDateRange.value, (value) => {
 }, {
   immediate: true
 })
+
+watch(() => queryParams.value, (value) => {
+  if (selectedTimeRangeKey.value !== value.timeRange
+    || (startDate.value !== value.start || endDate.value !== value.end)) {
+      selectedDateRange.value = value.timeRange || defaultTimeRangeKey;
+      if (value.timeRange === 'custom') {
+        startDate.value = value.start || null;
+        endDate.value = value.end || null;
+      }
+  }
+});
 </script>
 
 <script lang="ts">

--- a/frontend/app/components/shared/utils/query-param.ts
+++ b/frontend/app/components/shared/utils/query-param.ts
@@ -33,7 +33,7 @@ export const useQueryParam = (
 
       const processedQuery = setterProcessor(query);
 
-      router.replace({ query: processedQuery });
+      router.push({ query: processedQuery });
     },
   });
 


### PR DESCRIPTION
## In this PR

- Changed the way the URL params are stored by using router.push instead of replace, this enables the browser to store the filter changes and be able to use the back or forward button
- Applied the changes to the projects page and on the collections list page

## Ticket
[INS-631](https://linear.app/lfx/issue/INS-631/url-history-doesnt-seem-to-be-used-when-changing-the-date-range)