### PR TITLE
fix: incorrect project criticality learn more link

### DIFF
--- a/frontend/app/components/modules/project/components/overview/about-section/project-criticality.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section/project-criticality.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
         <p class="text-xs leading-4 text-neutral-400">
           Based on OpenSSF Criticality Score project.
           <a
-            href="/docs/"
+            :href="links.criticality"
             target="_blank"
             class="text-brand-500"
           >Learn more</a>
@@ -70,6 +70,7 @@ import { storeToRefs } from 'pinia';
 import { useProjectStore } from '~~/app/components/modules/project/store/project.store';
 import LfxCard from "~/components/uikit/card/card.vue";
 import LfxTooltip from "~/components/uikit/tooltip/tooltip.vue";
+import { links } from '~/config/links';
 
 const { project, repository } = storeToRefs(useProjectStore())
 

--- a/frontend/app/config/links.ts
+++ b/frontend/app/config/links.ts
@@ -5,4 +5,5 @@ export const links = {
   trustScore: `/docs/metrics/health-score`,
   securityScore: `/docs/metrics/security`,
   ospsScore: 'https://baseline.openssf.org/versions/2025-02-25',
+  criticality: '/docs/introduction/lf-oss-index/#criticality-score',
 };


### PR DESCRIPTION
## In this PR

Fixed the learn more link on the project criticality score widget

## Ticket
[INS-730](https://linear.app/lfx/issue/INS-730/fix-learn-more-link-in-criticality-score-card)