### PR TITLE
fix: sorting of data returned by the search queries endpoint

### DIFF
--- a/frontend/server/api/project/[slug]/popularity/search-queries.get.ts
+++ b/frontend/server/api/project/[slug]/popularity/search-queries.get.ts
@@ -42,10 +42,12 @@ export default defineEventHandler(async (event) => {
   const searchVolumeData = await fetchSearchVolume(filter);
 
   return {
-    data: searchVolumeData.data.map((item) => ({
-      startDate: item.startDate,
-      endDate: item.endDate,
-      queryCount: item.queryCount
-    }))
+    data: searchVolumeData.data
+      .map((item) => ({
+        startDate: item.startDate,
+        endDate: item.endDate,
+        queryCount: item.queryCount
+      }))
+      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
   };
 });

--- a/frontend/server/api/project/[slug]/popularity/search-queries.get.ts
+++ b/frontend/server/api/project/[slug]/popularity/search-queries.get.ts
@@ -48,6 +48,6 @@ export default defineEventHandler(async (event) => {
         endDate: item.endDate,
         queryCount: item.queryCount
       }))
-      .sort((a, b) => new Date(a.startDate).getTime() - new Date(b.startDate).getTime())
+      .sort((a, b) => DateTime.fromISO(a.startDate).toMillis() - DateTime.fromISO(b.startDate).toMillis())
   };
 });


### PR DESCRIPTION
## In this PR

Added a sort function on the search queries endpoint to sort the data returned by startDate

## Ticket
[INS-734](https://linear.app/lfx/issue/INS-734/wrong-display-of-data-in-search-queries-volume-widget)