### PR TITLE
fix(scripts): add license header support for .jsx and .tsx

### DIFF
--- a/scripts/add-license.js
+++ b/scripts/add-license.js
@@ -8,8 +8,10 @@ const headerMap = {
   ".ts": path.join(__dirname, "..", "COPYRIGHT_HEADER.txt"),
   ".js": path.join(__dirname, "..", "COPYRIGHT_HEADER.txt"),
   ".scss": path.join(__dirname, "..", "COPYRIGHT_HEADER.txt"),
+  ".jsx": path.join(__dirname, "..", "COPYRIGHT_HEADER.txt"),
   ".css": path.join(__dirname, "..", "COPYRIGHT_HEADER.txt"),
   ".vue": path.join(__dirname, "..", "COPYRIGHT_HEADER_vue.txt"),
+  ".tsx": path.join(__dirname, "..", "COPYRIGHT_HEADER.txt"),
 };
 
 function addHeader(filePath) {


### PR DESCRIPTION
### Summary
This PR closes #474 by extending the license-insertion
script to cover `.jsx` and `.tsx` files. Without this patch, those
files bypass the SPDX header requirement enforced in the pre-commit
hook.

### Changes
* scripts/add-license.js  
  * Added `.jsx` and `.tsx` to `headerMap`.

### Testing
1. Created dummy `demo.jsx` and `demo.tsx`.
2. Ran `node scripts/add-license.js demo.jsx demo.tsx`.
3. Verified that the SPDX header is inserted at the top of each file.
4. Ran `lint-staged` locally; all staged files now receive headers.

### Checklist
- [x] My commit message follows `<type>(scope): <description>` and is signed-off (`git commit -s`).
- [x] Tests pass locally (`npm test` / `pnpm test` if applicable).
- [x] No new linter warnings introduced.
- [x] I have linked the related issue above.