### PR TITLE
feat: hide empty columns for package downloads and dependency charts

### DIFF
--- a/frontend/app/components/modules/widget/config/popularity/package-dependency/fragments/package-legend-item.vue
+++ b/frontend/app/components/modules/widget/config/popularity/package-dependency/fragments/package-legend-item.vue
@@ -13,12 +13,13 @@ SPDX-License-Identifier: MIT
     <div class="flex gap-3 w-1/2">
       <div class="text-xs flex flex-col sm:items-end min-w-15 sm:min-w-auto sm:w-1/3">
         <span class="text-neutral-400">Total</span>
-        {{ formatNumber(delta.current) }}
+        {{ delta.current > 9999 ? formatNumberShort(delta.current) : formatNumber(delta.current) }}
       </div>
       <lfx-delta-display
         :flip-display="true"
         :hide-previous-value="true"
         :summary="delta"
+        :is-short="true"
         class="sm:items-end whitespace-nowrap sm:w-2/3"
       />
     </div>
@@ -26,7 +27,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { formatNumber } from '~/components/shared/utils/formatter';
+import { formatNumber, formatNumberShort } from '~/components/shared/utils/formatter';
 import type { Summary } from '~~/types/shared/summary.types';
 import LfxDeltaDisplay from '~/components/uikit/delta-display/delta-display.vue';
 

--- a/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.config.ts
+++ b/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.config.ts
@@ -7,7 +7,7 @@ const packageDependency: WidgetConfig = {
   key: 'packageDependency',
   name: 'Package dependency',
   description: () => `Amount of packages, repositories, and Docker packages that rely on the 
-    selected package(s) during the selected period. 
+    selected package(s) during the selected period. <i>(Note: We don't have data before June 2025.)</i> 
     <span class="font-semibold italic text-neutral-600">Powered by Ecosyste.ms.</span>`,
   learnMoreLink: `/docs/metrics/popularity#package-dependency`,
   component: PackageDependency,

--- a/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.config.ts
+++ b/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.config.ts
@@ -7,7 +7,7 @@ const packageDependency: WidgetConfig = {
   key: 'packageDependency',
   name: 'Package dependency',
   description: () => `Amount of packages, repositories, and Docker packages that rely on the 
-    selected package(s) during the selected period. <i>(Note: We don't have data before June 2025.)</i> 
+    selected package(s) during the selected period. 
     <span class="font-semibold italic text-neutral-600">Powered by Ecosyste.ms.</span>`,
   learnMoreLink: `/docs/metrics/popularity#package-dependency`,
   component: PackageDependency,

--- a/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.vue
+++ b/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.vue
@@ -45,7 +45,7 @@ import LfxPackageDropdown from '../package-downloads/fragments/package-dropdown.
 import LfxProjectPackageLegendItem from './fragments/package-legend-item.vue';
 import type { Package, PackageDownloads } from '~~/types/popularity/responses.types';
 import type { Summary } from '~~/types/shared/summary.types';
-import { convertToChartData } from '~/components/uikit/chart/helpers/chart-helpers';
+import { convertToChartData, removeZeroValues } from '~/components/uikit/chart/helpers/chart-helpers';
 import type {
   ChartData,
   RawChartData,
@@ -204,13 +204,14 @@ const dockerDependentsSummary = computed<Summary | undefined>(() => {
   }
 });
 
-const chartData = computed<ChartData[]>(
-  // convert the data to chart data
-  () => convertToChartData((packageDownloads.value?.data || []) as RawChartData[], 'startDate', [
-    'dependentReposCount',
-    'dependentPackagesCount',
-    'dockerDependentsCount',
-  ], undefined, 'endDate')
+const chartData = computed<ChartData[]>(() => {
+    const tmpData = convertToChartData((packageDownloads.value?.data || []) as RawChartData[], 'startDate', [
+      'dependentReposCount',
+      'dependentPackagesCount',
+      'dockerDependentsCount',
+    ], undefined, 'endDate');
+    return removeZeroValues(tmpData);
+  }
 );
 const isEmpty = computed(() => {
   if (isEmptyData(chartData.value as unknown as Record<string, unknown>[])) {

--- a/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.vue
+++ b/frontend/app/components/modules/widget/config/popularity/package-dependency/package-dependency.vue
@@ -33,6 +33,14 @@ SPDX-License-Identifier: MIT
           :color="series.color!"
         />
       </div>
+      <div class="flex justify-center items-center gap-2 text-xs text-neutral-400 mt-5">
+        <lfx-icon
+          name="info-circle"
+          type="regular"
+          :size="12"
+        />
+        Data available from June 2025 onward
+      </div>
     </lfx-project-load-state>
   </section>
 </template>
@@ -64,6 +72,7 @@ import LfxProjectLoadState from "~/components/modules/project/components/shared/
 import {Widget} from "~/components/modules/widget/types/widget";
 import { POPULARITY_API_SERVICE } from '~/components/modules/widget/services/popularity.api.service';
 import { EcosystemSeparator } from '~~/types/shared/ecosystems.types';
+import LfxIcon from '~/components/uikit/icon/icon.vue';
 
 interface PackageDownloadsModel {
   package: string;

--- a/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.config.ts
+++ b/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.config.ts
@@ -7,7 +7,7 @@ const packageDownloads: WidgetConfig = {
   key: 'packageDownloads',
   name: 'Package downloads',
   description: () => `Tracking of package downloads over time, providing insights into how widely 
-    the project is adopted and integrated within other software. 
+    the project is adopted and integrated within other software. <i>(Note: We don't have data before June 2025.)</i>
     <span class="font-semibold italic text-neutral-600">Powered by Ecosyste.ms.</span>`,
   learnMoreLink: `/docs/metrics/popularity#package-downloads`,
   component: PackageDownloads,

--- a/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.config.ts
+++ b/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.config.ts
@@ -7,7 +7,7 @@ const packageDownloads: WidgetConfig = {
   key: 'packageDownloads',
   name: 'Package downloads',
   description: () => `Tracking of package downloads over time, providing insights into how widely 
-    the project is adopted and integrated within other software. <i>(Note: We don't have data before June 2025.)</i>
+    the project is adopted and integrated within other software.
     <span class="font-semibold italic text-neutral-600">Powered by Ecosyste.ms.</span>`,
   learnMoreLink: `/docs/metrics/popularity#package-downloads`,
   component: PackageDownloads,

--- a/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.vue
+++ b/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.vue
@@ -54,7 +54,7 @@ import LfxPackageDropdown from './fragments/package-dropdown.vue';
 import type { Package, PackageDownloads } from '~~/types/popularity/responses.types';
 import type { Summary } from '~~/types/shared/summary.types';
 import LfxDeltaDisplay from '~/components/uikit/delta-display/delta-display.vue';
-import { convertToChartData } from '~/components/uikit/chart/helpers/chart-helpers';
+import { convertToChartData, removeZeroValues } from '~/components/uikit/chart/helpers/chart-helpers';
 import type {
   ChartData,
   RawChartData,
@@ -177,10 +177,13 @@ const summary = computed<Summary>(() => {
 });
 const chartData = computed<ChartData[]>(
   // convert the data to chart data
-  () => convertToChartData((packageDownloads.value?.data || []) as RawChartData[], 'startDate', [
-    'downloadsCount',
-    'dockerDownloadsCount',
-  ], undefined, 'endDate')
+  () => {
+    const tmpData = convertToChartData((packageDownloads.value?.data || []) as RawChartData[], 'startDate', [
+      'downloadsCount',
+      'dockerDownloadsCount',
+    ], undefined, 'endDate');
+    return removeZeroValues(tmpData, true);
+  }
 );
 const isEmpty = computed(() => {
   if (isEmptyData(chartData.value as unknown as Record<string, unknown>[])) {

--- a/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.vue
+++ b/frontend/app/components/modules/widget/config/popularity/package-downloads/package-downloads.vue
@@ -40,7 +40,28 @@ SPDX-License-Identifier: MIT
         <lfx-chart
           :config="lineChartConfig"
           :animation="!props.snapshot"
+        >
+          <template #legend>
+            <div class="flex flex-row gap-5 items-center justify-center pt-2">
+              <div class="flex flex-row items-center gap-2">
+                <div class="w-5 border-brand-500 border-b-2 border-solid" />
+                <span class="text-xs text-neutral-900">Total package downloads</span>
+              </div>
+              <div class="flex flex-row items-center gap-2">
+                <div class="w-5 border-neutral-600 border-b-2 border-dotted" />
+                <span class="text-xs text-neutral-900">Docker downloads</span>
+              </div>
+            </div>
+          </template>
+        </lfx-chart>
+      </div>
+      <div class="flex justify-center items-center gap-2 text-xs text-neutral-400 mt-5">
+        <lfx-icon
+          name="info-circle"
+          type="regular"
+          :size="12"
         />
+        Data available from June 2025 onward
       </div>
     </lfx-project-load-state>
   </section>
@@ -74,6 +95,7 @@ import LfxProjectLoadState from "~/components/modules/project/components/shared/
 import {Widget} from "~/components/modules/widget/types/widget";
 import { POPULARITY_API_SERVICE } from '~/components/modules/widget/services/popularity.api.service';
 import { EcosystemSeparator } from '~~/types/shared/ecosystems.types';
+import LfxIcon from '~/components/uikit/icon/icon.vue';
 
 interface PackageDownloadsModel {
   package: string;

--- a/frontend/app/components/uikit/chart/helpers/chart-helpers.ts
+++ b/frontend/app/components/uikit/chart/helpers/chart-helpers.ts
@@ -57,13 +57,13 @@ export const convertDateData = (
 /**
  * Function to remove the 0 values from the beginning of the chart data
  */
-export const removeZeroValues = (data: ChartData[]): ChartData[] => {
+export const removeZeroValues = (data: ChartData[], padLeft?: boolean): ChartData[] => {
   let startIndex = 0;
 
   // Find the first non-zero value
   for (let i = 0; i < data.length; i += 1) {
     if (data[i]?.values[0] !== 0) {
-      startIndex = i;
+      startIndex = (padLeft && i > 0) ? i - 1 : i;
       break;
     }
   }

--- a/frontend/app/components/uikit/delta-display/delta-display.vue
+++ b/frontend/app/components/uikit/delta-display/delta-display.vue
@@ -33,7 +33,7 @@ SPDX-License-Identifier: MIT
 import { computed } from 'vue';
 import type { DeltaDisplayProps } from './types/delta-display.types';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
-import { formatNumber, formatSecondsToDuration } from '~/components/shared/utils/formatter';
+import { formatNumber, formatNumberShort, formatSecondsToDuration } from '~/components/shared/utils/formatter';
 
 const props = withDefaults(defineProps<DeltaDisplayProps>(), {
   isReverse: false
@@ -60,13 +60,14 @@ const deltaDirection = computed<'positive' | 'negative'>(() => {
 // TODO: remove isDuration and use deltaUnit instead
 const delta = computed(() => {
   const value = props.summary.changeValue;
-  const changeValue = formatSecondsToDuration(
+  const changeDuration = formatSecondsToDuration(
     Math.abs(value),
     'short'
   );
+  const changeValue = props.isShort ? formatNumberShort(value) : formatNumber(value, 1);
 
   const sign = value >= 0 ? '+' : '';
-  return sign + (props.isDuration ? changeValue : formatNumber(value, 1));
+  return sign + (props.isDuration ? changeDuration : changeValue);
 });
 
 const deltaColor = computed(() => (deltaDirection.value === 'negative'

--- a/frontend/app/components/uikit/delta-display/types/delta-display.types.ts
+++ b/frontend/app/components/uikit/delta-display/types/delta-display.types.ts
@@ -10,4 +10,5 @@ export type DeltaDisplayProps = {
   percentageOnly?: boolean;
   unit?: string;
   isDuration?: boolean;
+  isShort?: boolean;
 };


### PR DESCRIPTION
## In this PR

- Hide empty columns for both the package downloads and dependency widgets
- Added "We don't have data before June 2025." to the description for both widgets
- Fix summary display for the dependency chart that overlaps for large values

## Ticket
[INS-732](https://linear.app/lfx/issue/INS-732/exclude-all-periods-before-june-2025-in-package-downloadsdependencies)