### PR TITLE
fix: benchmark scores

### DIFF
--- a/frontend/app/components/modules/widget/config/development/pull-requests/pull-requests.vue
+++ b/frontend/app/components/modules/widget/config/development/pull-requests/pull-requests.vue
@@ -220,7 +220,7 @@ const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<
 const callEmit = () => {
   emit('update:benchmarkValue', status.value === 'success' ? {
     key: BenchmarkKeys.PullRequests,
-    value: summary.value?.current || 0,
+    value: openedSummary.value?.current || 0,
     additionalCheck: granularity.value === Granularity.MONTHLY
   } : undefined);
 }

--- a/frontend/server/api/project/[slug]/overview/health-score.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score.get.ts
@@ -48,6 +48,13 @@ export default defineEventHandler(async (event) => {
     endDate: DateTime.now().minus({ quarters: 1 }).endOf('quarter')
   };
 
+  const endOfLastQuarter = DateTime.now().minus({ quarters: 1 }).endOf('quarter');
+  const filterPreviousQuarterYear: DefaultFilter = {
+    ...filter,
+    startDate: endOfLastQuarter.minus({ years: 1 }),
+    endDate: endOfLastQuarter
+  };
+
   const dataSource = createDataSource();
 
   try {
@@ -57,7 +64,7 @@ export default defineEventHandler(async (event) => {
       dataSource.fetchContributorDependency(filter),
       dataSource.fetchOrganizationDependency(filter),
       dataSource.fetchRetention({
-        ...filter,
+        ...filterPreviousQuarterYear,
         demographicType: DemographicType.CONTRIBUTORS,
         onlyContributions: false,
         granularity: FilterGranularity.QUARTERLY

--- a/frontend/server/api/project/[slug]/overview/health-score.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score.get.ts
@@ -92,6 +92,7 @@ export default defineEventHandler(async (event) => {
       }),
       dataSource.fetchPullRequests({
         ...filter,
+        granularity: FilterGranularity.MONTHLY,
         countType: ActivityFilterCountType.NEW, // This isn't used but required the interface
         activity_type: ActivityTypes.ISSUES_CLOSED, // This isn't used but required the interface
         onlyContributions: false
@@ -163,7 +164,7 @@ export default defineEventHandler(async (event) => {
 
     healthScore.push({
       key: BenchmarkKeys.PullRequests,
-      value: pullRequests.summary.current
+      value: pullRequests.openedSummary.current
     });
 
     const mergeLeadTimeValue = Number(

--- a/frontend/server/api/project/[slug]/overview/health-score.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score.get.ts
@@ -49,9 +49,9 @@ export default defineEventHandler(async (event) => {
   };
 
   const endOfLastQuarter = DateTime.now().minus({ quarters: 1 }).endOf('quarter');
-  const filterPreviousQuarterYear: DefaultFilter = {
+  const filterPrevious2Quarters: DefaultFilter = {
     ...filter,
-    startDate: endOfLastQuarter.minus({ years: 1 }),
+    startDate: endOfLastQuarter.minus({ quarters: 2 }),
     endDate: endOfLastQuarter
   };
 
@@ -64,7 +64,7 @@ export default defineEventHandler(async (event) => {
       dataSource.fetchContributorDependency(filter),
       dataSource.fetchOrganizationDependency(filter),
       dataSource.fetchRetention({
-        ...filterPreviousQuarterYear,
+        ...filterPrevious2Quarters,
         demographicType: DemographicType.CONTRIBUTORS,
         onlyContributions: false,
         granularity: FilterGranularity.QUARTERLY


### PR DESCRIPTION
## In this PR

- Changed the date parameter for the retention score in the overview health scores. 
- Changed the metric used for calculating the new pull request score. Before we were using the total pull request, it is now set to use the opened pull requests only

## Ticket
[INS-751](https://linear.app/lfx/issue/INS-751/benchmark-fixes) and all it's sub tickets