### PR TITLE
chore: removed the check for OSPS-AC-01

### DIFF
--- a/frontend/app/components/modules/project/services/security.service.ts
+++ b/frontend/app/components/modules/project/services/security.service.ts
@@ -32,10 +32,21 @@ class ProjectSecurityService {
     if (!data || !Array.isArray(data) || data.length === 0) {
       return [];
     }
-    return data.filter(
+
+    return this.removeUnavailableChecks(data.filter(
         (item) => item.category !== SecurityDataCategory.DOCUMENTATION
-            && item.category !== SecurityDataCategory.VULNERABILITY_MANAGEMENT
+            && item.category !== SecurityDataCategory.VULNERABILITY_MANAGEMENT)
     );
+  }
+
+  removeUnavailableChecks(data: SecurityData[]): SecurityData[] {
+    if (!data || !Array.isArray(data) || data.length === 0) {
+      return [];
+    }
+
+    const filteredCheck = ['OSPS-AC-01'];
+
+    return data.filter((item) => !filteredCheck.includes(item.controlId));
   }
 
   calculateOSPSScore(data: SecurityData[], isRepository: boolean): number {


### PR DESCRIPTION
## In this PR

Added function that filters out the OSPS-AC-01 check on the security and best practices data. This removes it both from the UI and the score calculation

## Ticket
[INS-752](https://linear.app/lfx/issue/INS-752/hide-the-osps-ac-0101-mfa-on-insights)