### PR TITLE
fix: height bug repository modal

### DIFF
--- a/frontend/app/components/modules/project/components/shared/header/repository-switch.vue
+++ b/frontend/app/components/modules/project/components/shared/header/repository-switch.vue
@@ -3,8 +3,11 @@ Copyright (c) 2025 The Linux Foundation and each contributor.
 SPDX-License-Identifier: MIT
 -->
 <template>
-  <lfx-modal v-model="isModalOpen">
-    <div class="p-1 flex flex-col gap-1">
+  <lfx-modal
+    v-model="isModalOpen"
+    content-class="flex w-full justify-stretch items-stretch"
+  >
+    <div class="p-1 flex flex-col gap-1 w-full">
 
       <nuxt-link
         :to="{ name: routeName.project }"

--- a/frontend/app/components/uikit/modal/modal.vue
+++ b/frontend/app/components/uikit/modal/modal.vue
@@ -11,6 +11,7 @@ SPDX-License-Identifier: MIT
       >
         <div
           class="c-modal__content"
+          :class="props.contentClass"
           :style="{ 'max-width': props.width }"
           v-bind="$attrs"
           @click.stop
@@ -27,6 +28,7 @@ import { computed, watch } from 'vue';
 
 const props = withDefaults(defineProps<{
   modelValue: boolean,
+  contentClass?: string,
   width?: string,
   closeFunction?:() => boolean,
 }>(), {


### PR DESCRIPTION
## In this PR

Fixed the height issue for the repository modal that causes 2 scroll bars when the user views the app in smaller screen sizes

## Ticket
[INS-735](https://linear.app/lfx/issue/INS-735/repositories-list-scroll-bar-messed-up-in-shorter-browser-window)