### PR TITLE
fix: address overlapping issue for project name

### DIFF
--- a/frontend/app/components/modules/project/components/shared/header.vue
+++ b/frontend/app/components/modules/project/components/shared/header.vue
@@ -33,10 +33,10 @@ SPDX-License-Identifier: MIT
 
               <h1
                 class="font-bold mr-3 ease-linear transition-all
-                 font-secondary duration-200 text-heading-4 line-clamp-1 sm:line-clamp-none"
+                 font-secondary duration-200 text-heading-4 line-clamp-1"
                 :class="[
                   scrollTop > 50 ? 'md:text-heading-3' : 'md:text-heading-2',
-                  repoName ? 'max-w-[25ch] truncate' : 'max-w-[25ch] sm:max-w-none'
+                  repoName ? 'max-w-[25ch] truncate' : 'max-w-[25ch] sm:max-w-none sm:line-clamp-none'
                 ]"
               >
                 {{ props.project?.name }}


### PR DESCRIPTION
## In this PR

Quick fix for the overlapping issue for the project name in the header component by making it always truncate whenever a repository is selected

## Ticket
[INS-763](https://linear.app/lfx/issue/INS-763/project-name-overlaps-with-repository-dropdown)