### PR TITLE
fix: jumping layout issue on trust score when loading

### DIFF
--- a/frontend/app/components/modules/project/components/overview/trust-score.vue
+++ b/frontend/app/components/modules/project/components/overview/trust-score.vue
@@ -27,7 +27,7 @@ SPDX-License-Identifier: MIT
             </lfx-skeleton-state>
 
             <div
-              v-if="hideOverallScore || isEmpty"
+              v-if="(hideOverallScore || isEmpty) && status !== 'pending'"
               class="block"
             >
               <div class="text-xs text-neutral-500 mt-4">
@@ -62,7 +62,7 @@ SPDX-License-Identifier: MIT
     </div>
 
     <div
-      v-if="isEmpty"
+      v-if="isEmpty && status !== 'pending'"
       class="flex flex-col items-center justify-center h-[240px]"
     >
       <lfx-icon


### PR DESCRIPTION
## In this PR

Fix issue on the overview trust score component that causes the layout to be broken while loading. This was caused by the empty state message showing up.

NO TICKET