### PR TITLE
chore: hide widgets without data

### DIFF
--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -43,8 +43,6 @@ import {
 import { useRoute } from 'nuxt/app';
 import { storeToRefs } from 'pinia';
 import { WidgetArea } from '../../widget/types/widget-area';
-import { lfxProjectDateOptions } from '../config/date-options';
-import { POPULARITY_API_SERVICE } from '../../widget/services/popularity.api.service';
 import LfxProjectAboutSection from '~/components/modules/project/components/overview/about-section.vue';
 import LfxProjectScoreTabs from '~/components/modules/project/components/overview/score-tabs.vue';
 import LfxProjectTrustScore from '~/components/modules/project/components/overview/trust-score.vue';
@@ -52,7 +50,6 @@ import { useProjectStore } from "~~/app/components/modules/project/store/project
 import { OVERVIEW_API_SERVICE } from '~~/app/components/modules/project/services/overview.api.service';
 import type { TrustScoreSummary } from '~~/types/overview/responses.types';
 import LfxCard from '~/components/uikit/card/card.vue';
-import { Granularity } from '~~/types/shared/granularity';
 import type { HealthScoreResults } from '~~/types/overview/responses.types';
 
 const route = useRoute();
@@ -100,33 +97,12 @@ const {
  * This is a workaround to show/hide the Search Queries from the score.
  * ===============================
  */
- const popularityParams = computed(() => ({
-  projectSlug: route.params.slug as string,
-  repos: selectedReposValues.value,
-  granularity: Granularity.MONTHLY,
-  startDate: lfxProjectDateOptions[1]?.startDate || null,
-  endDate: lfxProjectDateOptions[1]?.endDate || null,
-}));
-
-const {
-  data: searchQueriesData, status: searchQueriesStatus, suspense: searchQueriesSuspense
-} = POPULARITY_API_SERVICE.fetchSearchQueries(popularityParams);
-
-const isSearchQueriesEmpty = computed(() => POPULARITY_API_SERVICE
-  .isSearchQueriesEmpty(searchQueriesStatus.value === 'success' ? searchQueriesData.value : undefined));
-
+ 
 // delete the search queries from the overview data
 const data = computed(() => {
   const data = {...overviewData.value};
-  if (isSearchQueriesEmpty.value) {
+  if (overviewData.value?.searchQueries.value === 0) {
     delete data.searchQueries;
-
-    // recompute the scores
-    data.popularityPercentage = ((((data.forks?.benchmark || 0) + (data.stars?.benchmark || 0)) / 2) * 5) / 25 * 100;
-    data.overallScore = (data.popularityPercentage + 
-      (data.contributorPercentage || 0) + 
-      (data.developmentPercentage|| 0) + 
-      (data.securityPercentage || 0)) / 4;
   }
   return data as HealthScoreResults;
 });
@@ -154,7 +130,6 @@ const isRepoSelected = computed(() => selectedReposValues.value.length > 0);
 
 onServerPrefetch(async () => {
   await suspense();
-  await searchQueriesSuspense();
 });
 </script>
 

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -43,6 +43,8 @@ import {
 import { useRoute } from 'nuxt/app';
 import { storeToRefs } from 'pinia';
 import { WidgetArea } from '../../widget/types/widget-area';
+import { lfxProjectDateOptions } from '../config/date-options';
+import { POPULARITY_API_SERVICE } from '../../widget/services/popularity.api.service';
 import LfxProjectAboutSection from '~/components/modules/project/components/overview/about-section.vue';
 import LfxProjectScoreTabs from '~/components/modules/project/components/overview/score-tabs.vue';
 import LfxProjectTrustScore from '~/components/modules/project/components/overview/trust-score.vue';
@@ -50,6 +52,8 @@ import { useProjectStore } from "~~/app/components/modules/project/store/project
 import { OVERVIEW_API_SERVICE } from '~~/app/components/modules/project/services/overview.api.service';
 import type { TrustScoreSummary } from '~~/types/overview/responses.types';
 import LfxCard from '~/components/uikit/card/card.vue';
+import { Granularity } from '~~/types/shared/granularity';
+import type { HealthScoreResults } from '~~/types/overview/responses.types';
 
 const route = useRoute();
 const { selectedReposValues, project } = storeToRefs(useProjectStore())
@@ -83,12 +87,53 @@ const scoreDisplay = computed(() => ({
 }))
 
 const {
-  data, 
+  data: overviewData, 
   status, 
   error, 
   suspense
 } = OVERVIEW_API_SERVICE.fetchHealthScoreOverview(params);
 
+/**
+ * TODO: remove this after https://linear.app/lfx/issue/INS-822/periodicly-check-for-widgets-data-and-enabledisable-them
+ * is implemented
+ *
+ * This is a workaround to show/hide the Search Queries from the score.
+ * ===============================
+ */
+ const popularityParams = computed(() => ({
+  projectSlug: route.params.slug as string,
+  repos: selectedReposValues.value,
+  granularity: Granularity.MONTHLY,
+  startDate: lfxProjectDateOptions[1]?.startDate || null,
+  endDate: lfxProjectDateOptions[1]?.endDate || null,
+}));
+
+const {
+  data: searchQueriesData, status: searchQueriesStatus, suspense: searchQueriesSuspense
+} = POPULARITY_API_SERVICE.fetchSearchQueries(popularityParams);
+
+const isSearchQueriesEmpty = computed(() => POPULARITY_API_SERVICE
+  .isSearchQueriesEmpty(searchQueriesStatus.value === 'success' ? searchQueriesData.value : undefined));
+
+// delete the search queries from the overview data
+const data = computed(() => {
+  const data = {...overviewData.value};
+  if (isSearchQueriesEmpty.value) {
+    delete data.searchQueries;
+
+    // recompute the scores
+    data.popularityPercentage = ((((data.forks?.benchmark || 0) + (data.stars?.benchmark || 0)) / 2) * 5) / 25 * 100;
+    data.overallScore = (data.popularityPercentage + 
+      (data.contributorPercentage || 0) + 
+      (data.developmentPercentage|| 0) + 
+      (data.securityPercentage || 0)) / 4;
+  }
+  return data as HealthScoreResults;
+});
+
+ /**
+  * ===============================
+  */
 
 const securityScore = computed(() => (data.value?.securityCategoryPercentage || []));
 
@@ -109,8 +154,8 @@ const isRepoSelected = computed(() => selectedReposValues.value.length > 0);
 
 onServerPrefetch(async () => {
   await suspense();
+  await searchQueriesSuspense();
 });
-
 </script>
 
 <script lang="ts">

--- a/frontend/app/components/modules/widget/components/shared/widget-area.vue
+++ b/frontend/app/components/modules/widget/components/shared/widget-area.vue
@@ -45,9 +45,10 @@ computed, ref, onServerPrefetch, watch
 import {storeToRefs} from "pinia";
 import {useRoute} from "nuxt/app";
 import { BENCHMARKS_API_SERVICE } from '../../services/benchmarks.api.service';
-import type {Widget} from "~/components/modules/widget/types/widget";
+import { POPULARITY_API_SERVICE } from '../../services/popularity.api.service';
+import {Widget} from "~/components/modules/widget/types/widget";
 import {lfxWidgets} from "~/components/modules/widget/config/widget.config";
-import type {WidgetArea} from "~/components/modules/widget/types/widget-area";
+import {WidgetArea} from "~/components/modules/widget/types/widget-area";
 import {lfxWidgetArea, type WidgetAreaConfig} from "~/components/modules/widget/config/widget-area.config";
 import LfxSideNav from "~/components/uikit/side-nav/side-nav.vue";
 import LfxScrollView from "~/components/uikit/scroll-view/scroll-view.vue";
@@ -62,6 +63,7 @@ import {
 } from "~/components/modules/project/services/project.query.service";
 import useToastService from '~/components/uikit/toast/toast.service';
 import { ToastTypesEnum } from '~/components/uikit/toast/types/toast.types';
+import { Granularity } from '~~/types/shared/granularity';
 
 const props = defineProps<{
   name: WidgetArea
@@ -80,6 +82,86 @@ const loadedWidgets = ref<Record<string, boolean>>({});
 const { scrollToTarget, scrollToTop } = useScroll();
 const { project, selectedRepoSlugs, startDate, endDate, selectedReposValues } = storeToRefs(useProjectStore())
 const isFirstLoad = ref(true);
+
+/**
+ * TODO: remove this after https://linear.app/lfx/issue/INS-822/periodicly-check-for-widgets-data-and-enabledisable-them
+ * is implemented
+ *
+ * This is a workaround to show/hide widgets in the popularity for projects that have no data.
+ * ===============================
+ */
+const popularityParams = computed(() => ({
+  projectSlug: route.params.slug as string,
+  repos: selectedReposValues.value,
+  granularity: Granularity.MONTHLY,
+  startDate: startDate.value,
+  endDate: endDate.value,
+}));
+
+const downloadsParams = computed(() => ({
+  ...popularityParams.value,
+  ecosystem: 'all',
+  name: 'All packages',
+}));
+
+const mailingListMessagesParams = computed(() => ({
+  ...popularityParams.value,
+  type: 'new',
+  countType: 'new',
+}));
+
+// package downloads and dependency share the same endpoint
+const {
+  data: downloadsData, status: downloadsStatus, suspense: downloadsSuspense
+} = POPULARITY_API_SERVICE.fetchPackageDownloads(downloadsParams);
+
+const isPackageDownloadsEmpty = computed(() => POPULARITY_API_SERVICE
+  .isPackageDownloadsEmpty(downloadsStatus.value === 'success' ? downloadsData.value : undefined));
+
+const isPackageDependencyEmpty = computed(() => POPULARITY_API_SERVICE
+  .isPackageDependencyEmpty(downloadsStatus.value === 'success' ? downloadsData.value : undefined));
+
+// search queries
+const {
+  data: searchQueriesData, status: searchQueriesStatus, suspense: searchQueriesSuspense
+} = POPULARITY_API_SERVICE.fetchSearchQueries(popularityParams);
+
+const isSearchQueriesEmpty = computed(() => POPULARITY_API_SERVICE
+  .isSearchQueriesEmpty(searchQueriesStatus.value === 'success' ? searchQueriesData.value : undefined));
+
+// mailing list messages
+const {
+  data: mailingListMessagesData, status: mailingListMessagesStatus, suspense: mailingListMessagesSuspense
+} = POPULARITY_API_SERVICE.fetchMailingListsMessages(mailingListMessagesParams);
+
+const isMailingListMessagesEmpty = computed(() => POPULARITY_API_SERVICE
+  .isMailingListMessagesEmpty(
+    mailingListMessagesStatus.value === 'success' ? mailingListMessagesData.value : undefined
+  ));
+
+const excludedWidgets = computed(() => {
+  const excludedWidgets = [];
+  if (props.name === WidgetArea.POPULARITY) {
+    if (isPackageDownloadsEmpty.value) {
+    excludedWidgets.push(Widget.PACKAGE_DOWNLOADS);
+    }
+    if (isPackageDependencyEmpty.value) {
+      excludedWidgets.push(Widget.PACKAGE_DEPENDENCY);
+    }
+    if (isSearchQueriesEmpty.value) {
+      excludedWidgets.push(Widget.SEARCH_QUERIES);
+    }
+    if (isMailingListMessagesEmpty.value) {
+      excludedWidgets.push(Widget.MAILING_LISTS_MESSAGES);
+    }
+  }
+  return excludedWidgets;
+});
+
+ /**
+  * ===============================
+  */
+
 
 const params = computed(() => ({
   projectSlug: route.params.slug as string,
@@ -101,6 +183,7 @@ const widgets = computed(() => (config.value.widgets || [])
       return (
         project.value?.widgets.includes(key)
         && (!widgetConfig?.hideOnRepoFilter || !selectedRepoSlugs.value.length)
+        && !excludedWidgets.value.includes(widget as Widget)
       );
     }));
 
@@ -167,6 +250,10 @@ const navigateToWidget = () => {
 
 onServerPrefetch(async () => {
   await suspense();
+
+  await downloadsSuspense();
+  await searchQueriesSuspense();
+  await mailingListMessagesSuspense();
 })
 
 watch(error, (err) => {

--- a/frontend/app/components/modules/widget/components/shared/widget-area.vue
+++ b/frontend/app/components/modules/widget/components/shared/widget-area.vue
@@ -100,8 +100,8 @@ const popularityParams = computed(() => ({
 
 const downloadsParams = computed(() => ({
   ...popularityParams.value,
-  ecosystem: 'all',
-  name: 'All packages',
+  ecosystem: undefined,
+  name: undefined,
 }));
 
 const mailingListMessagesParams = computed(() => ({

--- a/frontend/app/components/modules/widget/config/popularity/mailing-list-messages/mailing-list-messages.vue
+++ b/frontend/app/components/modules/widget/config/popularity/mailing-list-messages/mailing-list-messages.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
   <section class="mt-5">
     <div class="mb-6">
       <lfx-skeleton-state
-        :status="model.activeTab === 'cumulative' ? cumulativeStatus : status"
+        :status="status"
         height="2rem"
         width="7.5rem"
       >
@@ -37,8 +37,8 @@ SPDX-License-Identifier: MIT
       <span v-else>{{lineGranularity}} messages growth</span>
     </div>
     <lfx-project-load-state
-      :status="model.activeTab === 'cumulative' ? cumulativeStatus : status"
-      :error="model.activeTab === 'cumulative' ? cumulativeError : error"
+      :status="status"
+      :error="error"
       error-message="Error fetching mailing lists messages"
       :is-empty="isEmpty"
     >
@@ -58,7 +58,6 @@ import {
  computed, watch, onServerPrefetch
 } from 'vue';
 import { storeToRefs } from "pinia";
-import {type QueryFunction, useQuery} from "@tanstack/vue-query";
 import type {MailingListsMessages} from '~~/types/popularity/responses.types';
 import { lineGranularities, barGranularities } from '~/components/shared/types/granularity';
 import type { Summary } from '~~/types/shared/summary.types';
@@ -79,10 +78,10 @@ import { useProjectStore } from "~/components/modules/project/store/project.stor
 import { isEmptyData } from '~/components/shared/utils/helper';
 import { dateOptKeys } from '~/components/modules/project/config/date-options';
 import type { Granularity } from '~~/types/shared/granularity';
-import {TanstackKey} from "~/components/shared/types/tanstack";
 import LfxSkeletonState from "~/components/modules/project/components/shared/skeleton-state.vue";
 import LfxProjectLoadState from "~/components/modules/project/components/shared/load-state.vue";
 import {Widget} from "~/components/modules/widget/types/widget";
+import { POPULARITY_API_SERVICE } from '~/components/modules/widget/services/popularity.api.service';
 
 interface MailingListMessagesModel {
   activeTab: string;
@@ -115,81 +114,29 @@ const lineGranularity = computed(() => (selectedTimeRangeKey.value === dateOptKe
   ? customRangeGranularity.value[0] as Granularity
   : lineGranularities[selectedTimeRangeKey.value as keyof typeof lineGranularities]));
 
-const barQueryKey = computed(() => [
-  TanstackKey.MAILING_LISTS_MESSAGES,
-  route.params.slug,
-  selectedReposValues,
-  startDate,
-  endDate,
-  barGranularity,
-]);
+const queryParams = computed(() => ({
+  projectSlug: route.params.slug as string,
+  granularity: model.value.activeTab === 'cumulative' ? lineGranularity.value : barGranularity.value,
+  repos: selectedReposValues.value,
+  startDate: startDate.value,
+  endDate: endDate.value,
+  type: model.value.activeTab === 'cumulative' ? 'cumulative' : 'new',
+  countType: model.value.activeTab === 'cumulative' ? 'cumulative' : 'new',
+}));
 
-const fetchBarData: QueryFunction<MailingListsMessages> = async () => $fetch(
-    `/api/project/${route.params.slug}/popularity/mailing-lists-messages`,
-    {
-  params: {
-    granularity: barGranularity.value,
-    type: 'new',
-    countType: 'new',
-    activityType: 'message',
-    repos: selectedReposValues.value,
-    startDate: startDate.value,
-    endDate: endDate.value,
-  }
-}
-);
 
 const {
   data,
   status,
   error,
-  suspense: barSuspense
-} = useQuery<MailingListsMessages>({
-  queryKey: barQueryKey,
-  queryFn: fetchBarData,
-});
-
-const lineQueryKey = computed(() => [
-  TanstackKey.MAILING_LISTS_MESSAGES,
-  route.params.slug,
-  selectedReposValues,
-  startDate,
-  endDate,
-  lineGranularity,
-]);
-
-const fetchLineData: QueryFunction<MailingListsMessages> = async () => $fetch(
-    `/api/project/${route.params.slug}/popularity/mailing-lists-messages`,
-    {
-  params: {
-    granularity: lineGranularity.value,
-    type: 'cumulative',
-    countType: 'cumulative',
-    activityType: 'message',
-    repos: selectedReposValues.value,
-    startDate: startDate.value,
-    endDate: endDate.value,
-  }
-}
-);
-
-const {
-  data: cumulativeData,
-  status: cumulativeStatus,
-  error: cumulativeError,
-  suspense: lineSuspense
-} = useQuery<MailingListsMessages>({
-  queryKey: lineQueryKey,
-  queryFn: fetchLineData,
-});
+  suspense
+} = POPULARITY_API_SERVICE.fetchMailingListsMessages(queryParams);
 
 onServerPrefetch(async () => {
-  await Promise.all([barSuspense(), lineSuspense()]);
+  await suspense();
 });
 
-const messages = computed<MailingListsMessages | undefined>(() => (model.value.activeTab === 'cumulative'
-  ? cumulativeData.value as MailingListsMessages
-  : data.value as MailingListsMessages));
+const messages = computed<MailingListsMessages | undefined>(() => (data.value as MailingListsMessages));
 
 const summary = computed<Summary | undefined>(() => messages.value?.summary);
 const chartData = computed<ChartData[]>(

--- a/frontend/app/components/modules/widget/config/popularity/press-mentions/press-mentions.vue
+++ b/frontend/app/components/modules/widget/config/popularity/press-mentions/press-mentions.vue
@@ -33,7 +33,7 @@ SPDX-License-Identifier: MIT
     <lfx-project-load-state
       :status="status"
       :error="error"
-      error-message="Error fetching social mentions"
+      error-message="Error fetching press mentions"
       :is-empty="isEmpty"
     >
       <div class="w-full h-[320px] mt-5">

--- a/frontend/app/components/modules/widget/services/popularity.api.service.ts
+++ b/frontend/app/components/modules/widget/services/popularity.api.service.ts
@@ -290,6 +290,32 @@ class PopularityApiService {
         },
       });
   }
+
+  isPackageDownloadsEmpty(data: PackageDownloads | undefined) {
+    if (!data) {
+      return true;
+    }
+    return data.data.every((item) => item.downloadsCount === 0 && item.dockerDownloadsCount === 0);
+  }
+  isPackageDependencyEmpty(data: PackageDownloads | undefined) {
+    if (!data) {
+      return true;
+    }
+    return data.data.every((item) => item.dependentReposCount === 0 && 
+      item.dependentPackagesCount === 0 && item.dockerDependentsCount === 0);
+  }
+  isSearchQueriesEmpty(data: SearchQueries | undefined) {
+    if (!data) {
+      return true;
+    }
+    return data.data.every((item) => item.queryCount === 0);
+  }
+  isMailingListMessagesEmpty(data: MailingListsMessages | undefined) {
+    if (!data) {
+      return true;
+    }
+    return data.data.every((item) => item.messages === 0);
+  }
 }
 
 export const POPULARITY_API_SERVICE = new PopularityApiService();

--- a/frontend/app/components/modules/widget/services/popularity.api.service.ts
+++ b/frontend/app/components/modules/widget/services/popularity.api.service.ts
@@ -5,16 +5,30 @@ import type { QueryFunction } from '@tanstack/vue-query';
 import { type ComputedRef, computed } from 'vue';
 import { useQuery } from '@tanstack/vue-query';
 import { TanstackKey } from '~/components/shared/types/tanstack';
-import type { Package, PackageDownloads } from '~~/types/popularity/responses.types';
+import type { 
+  ForksData, 
+  MailingListsMessages, 
+  Package, 
+  PackageDownloads, 
+  SearchQueries, 
+  StarsData 
+} from '~~/types/popularity/responses.types';
 
-export interface PopularityQueryParams {
+export interface QueryParams {
   projectSlug: string;
   granularity: string;
   repos?: string[];
   startDate: string | null;
   endDate: string | null;
+}
+export interface PopularityQueryParams extends QueryParams {
   ecosystem?: string;
   name?: string;
+}
+
+export interface ActivityTypeQueryParams extends QueryParams {
+  type: string;
+  countType: string;
 }
 
 export interface PackagesQueryParams {
@@ -22,6 +36,8 @@ export interface PackagesQueryParams {
   repos?: string[];
   search?: string;
 }
+
+
 class PopularityApiService {
   fetchPackageDownloads(params: ComputedRef<PopularityQueryParams>) {
     const queryKey = computed(() => [
@@ -95,6 +111,182 @@ class PopularityApiService {
         params: {
           repos,
           search,
+        },
+      });
+  }
+
+  fetchSearchQueries(params: ComputedRef<QueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.SEARCH_QUERIES,
+      params.value.projectSlug,
+      params.value.granularity,
+      params.value.repos,
+      params.value.startDate,
+      params.value.endDate
+    ]);
+    const queryFn = computed<QueryFunction<SearchQueries>>(() => this.searchQueriesQueryFn(() => ({
+        projectSlug: params.value.projectSlug,
+        repos: params.value.repos,
+        granularity: params.value.granularity,
+        startDate: params.value.startDate,
+        endDate: params.value.endDate,
+      })));
+
+    return useQuery<SearchQueries>({
+      queryKey,
+      queryFn,
+    });
+  }
+
+  searchQueriesQueryFn(
+    query: () => Record<string, string | number | boolean | undefined | string[] | null>
+  ): QueryFunction<SearchQueries> {
+    const {
+      projectSlug, repos, startDate, endDate
+    } = query();
+    return async () => await $fetch(`/api/project/${projectSlug}/popularity/search-queries`, {
+        params: {
+          repos,
+          startDate,
+          endDate,
+        },
+      });
+  }
+
+  fetchMailingListsMessages(params: ComputedRef<ActivityTypeQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.MAILING_LISTS_MESSAGES,
+      params.value.projectSlug,
+      params.value.granularity,
+      params.value.repos,
+      params.value.startDate,
+      params.value.endDate,
+      params.value.type,
+      params.value.countType,
+    ]);
+    const queryFn = computed<QueryFunction<MailingListsMessages>>(() => this.mailingListsMessagesQueryFn(() => ({
+        projectSlug: params.value.projectSlug,
+        repos: params.value.repos,
+        granularity: params.value.granularity,
+        startDate: params.value.startDate,
+        endDate: params.value.endDate,
+        type: params.value.type,
+        countType: params.value.countType,
+      })));
+
+    return useQuery<MailingListsMessages>({
+      queryKey,
+      queryFn,
+    });
+  }
+
+  mailingListsMessagesQueryFn(
+    query: () => Record<string, string | number | boolean | undefined | string[] | null>
+  ): QueryFunction<MailingListsMessages> {
+    const {
+      projectSlug, repos, startDate, endDate, granularity, type, countType
+    } = query();
+    return async () => await $fetch(`/api/project/${projectSlug}/popularity/mailing-lists-messages`, {
+        params: {
+          granularity,
+          type,
+          countType,
+          activityType: 'message',
+          repos,
+          startDate,
+          endDate,
+        },
+      });
+  }
+
+  fetchForks(params: ComputedRef<ActivityTypeQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.FORKS,
+      params.value.projectSlug,
+      params.value.granularity,
+      params.value.repos,
+      params.value.startDate,
+      params.value.endDate,
+      params.value.type,
+      params.value.countType,
+    ]);
+    const queryFn = computed<QueryFunction<ForksData>>(() => this.forksQueryFn(() => ({
+        projectSlug: params.value.projectSlug,
+        repos: params.value.repos,
+        granularity: params.value.granularity,
+        startDate: params.value.startDate,
+        endDate: params.value.endDate,
+        type: params.value.type,
+        countType: params.value.countType,
+      })));
+
+    return useQuery<ForksData>({
+      queryKey,
+      queryFn,
+    });
+  }
+
+  forksQueryFn(
+    query: () => Record<string, string | number | boolean | undefined | string[] | null>
+  ): QueryFunction<ForksData> {
+    const {
+      projectSlug, repos, startDate, endDate, granularity, type, countType
+    } = query();
+    return async () => await $fetch(`/api/project/${projectSlug}/popularity/forks`, {
+        params: {
+          granularity,
+          type,
+          countType,
+          activityType: 'fork',
+          repos,
+          startDate,
+          endDate,
+        },
+      });
+  }
+
+  fetchStars(params: ComputedRef<ActivityTypeQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.STARS,
+      params.value.projectSlug,
+      params.value.granularity,
+      params.value.repos,
+      params.value.startDate,
+      params.value.endDate,
+      params.value.type,
+      params.value.countType,
+    ]);
+    const queryFn = computed<QueryFunction<StarsData>>(() => this.starsQueryFn(() => ({
+        projectSlug: params.value.projectSlug,
+        repos: params.value.repos,
+        granularity: params.value.granularity,
+        startDate: params.value.startDate,
+        endDate: params.value.endDate,
+        type: params.value.type,
+        countType: params.value.countType,
+      })));
+
+    return useQuery<StarsData>({
+      queryKey,
+      queryFn,
+    });
+  }
+
+  starsQueryFn(
+    query: () => Record<string, string | number | boolean | undefined | string[] | null>
+  ): QueryFunction<StarsData> {
+    const {
+      projectSlug, repos, startDate, endDate, granularity, type, countType
+    } = query();
+    return async () => await $fetch(`/api/project/${projectSlug}/popularity/stars`, {
+        params: {
+          granularity,
+          type,
+          countType,
+          activityType: 'star',
+          repos,
+          startDate,
+          endDate,
         },
       });
   }


### PR DESCRIPTION
## In this PR

- Refactored the data fetching for all the widgets under the popularity tab
- Added data calls in the widget area to popularity tab data to check if data is present for certain widgets
- Update the overview health score to hide the search queries score if it's empty

## Ticket
[INS-824](https://linear.app/lfx/issue/INS-824/hide-widgets-if-they-dont-have-value)