### PR TITLE
fix: github name typo

### DIFF
--- a/frontend/app/components/modules/widget/config/popularity/stars/stars.config.ts
+++ b/frontend/app/components/modules/widget/config/popularity/stars/stars.config.ts
@@ -16,7 +16,7 @@ const stars: WidgetConfig = {
   embed: true,
   snapshot: true,
   benchmark: {
-    title: 'Github Stars',
+    title: 'GitHub Stars',
     showOnOverview: true,
     isVisible: () => true,
     points: {


### PR DESCRIPTION
## In this PR

Fix minor typo on the GitHub name that appears in the benchmark scores