### PR TITLE
fix: error caused by the github button script

### DIFF
--- a/frontend/app/components/shared/layout/menu/github-button.vue
+++ b/frontend/app/components/shared/layout/menu/github-button.vue
@@ -33,12 +33,16 @@ SPDX-License-Identifier: MIT
 import { onMounted } from 'vue';
 
 onMounted(() => {
+  const scriptSrc = 'https://buttons.github.io/buttons.js'
   // GitHub buttons script adds the functionality
-  const script = document.createElement('script')
-  script.setAttribute('src', 'https://buttons.github.io/buttons.js')
-  script.setAttribute('async', '')
-  script.setAttribute('defer', '')
-  document.body.appendChild(script)
+  // Adding check to prevent adding the script twice that causes the error
+  if (!document.querySelector(`script[src="${scriptSrc}"]`)) {
+    const script = document.createElement('script')
+    script.setAttribute('src', scriptSrc)
+    script.setAttribute('async', '')
+    script.setAttribute('defer', '')
+    document.body.appendChild(script)
+  }
 })
 </script>
 


### PR DESCRIPTION
## In this PR

Fix the error caused by the github button script. The script was being added more than once in the document body which makes the second one trigger the error because the first one already removed the element from the page.

## Ticket
[INS-826](https://linear.app/lfx/issue/INS-826/github-stars-badge-throwing-error)