### PR TITLE
fix: fix "includes archived repos" tag being shown when no archived repos are selected

### DIFF
--- a/frontend/app/components/modules/project/components/shared/header.vue
+++ b/frontend/app/components/modules/project/components/shared/header.vue
@@ -64,7 +64,7 @@ SPDX-License-Identifier: MIT
                   >All repositories</span>
                 </p>
                 <lfx-archived-tag
-                  v-if="!!archivedRepos.length"
+                  v-if="hasSelectedArchivedRepos"
                   :archived="true"
                   :label="archivedRepoLabel"
                   @click="isSearchRepoModalOpen = true"
@@ -193,8 +193,8 @@ const {
   projectRepos,
   selectedRepoSlugs,
   selectedRepositories,
-  archivedRepos,
-  allArchived
+  allArchived,
+  hasSelectedArchivedRepos
 } = storeToRefs(useProjectStore());
 const { openReportModal } = useReportStore();
 const { openShareModal } = useShareStore();

--- a/frontend/app/components/modules/project/store/project.store.ts
+++ b/frontend/app/components/modules/project/store/project.store.ts
@@ -81,6 +81,11 @@ export const useProjectStore = defineStore('project', () => {
     )
   );
 
+  const hasSelectedArchivedRepos = computed(() =>
+    !!archivedRepos.value.length && !selectedReposValues.value.length
+    || selectedReposValues.value.some((repo) => archivedRepos.value.includes(repo))
+  );
+
   return {
     selectedTimeRangeKey,
     startDate,
@@ -94,6 +99,7 @@ export const useProjectStore = defineStore('project', () => {
     selectedRepoSlugs,
     selectedRepositories,
     selectedReposValues,
-    allArchived
+    allArchived,
+    hasSelectedArchivedRepos
   };
 });

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -36,7 +36,7 @@ SPDX-License-Identifier: MIT
             />
           </div>
           <lfx-repos-exclusion-footer
-            v-if="status !== 'pending'"
+            v-if="hasSelectedArchivedRepos && status !== 'pending'"
             page-content="health-score"
           />
         </lfx-card>
@@ -71,6 +71,7 @@ const {
   project,
   archivedRepos,
   allArchived,
+  hasSelectedArchivedRepos
 } = storeToRefs(useProjectStore())
 
 const params = computed(() => ({

--- a/frontend/app/components/modules/project/views/security.vue
+++ b/frontend/app/components/modules/project/views/security.vue
@@ -125,6 +125,7 @@ SPDX-License-Identifier: MIT
             </div>
           </div>
           <lfx-repos-exclusion-footer
+            v-if="hasSelectedArchivedRepos && !isFetching"
             class="mt-3"
             page-content="security"
           />
@@ -167,7 +168,8 @@ const { name } = route.params;
 const {
   selectedReposValues,
   allArchived,
-  archivedRepos
+  archivedRepos,
+  hasSelectedArchivedRepos
 } = storeToRefs(useProjectStore())
 
 const isRepository = computed(() => !!name)


### PR DESCRIPTION
When selecting repositories in the search list and no archived repository is selected, the "includes archived repositories" tag is still being shown.

<img width="1053" height="278" alt="image" src="https://github.com/user-attachments/assets/57a92ae4-3438-4c28-8b2c-77f52abe7c77" />

The condition to show the tag was checking just if the project itself contained archived repositories, not if there were archived repositories in the list of selected ones.

This also affects other places, like the security tab and the project overview, where the indication of archived repositories is also shown.