### PR TITLE
fix: overview card padding

### DIFF
--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
         <lfx-card
           class="pt-6 flex flex-col md:gap-10 gap-5"
           :class="{
-            'pb-6': !displayArchivedReposNote
+            'pb-6': !(hasSelectedArchivedRepos && status !== 'pending')
           }"
         >
           <lfx-project-trust-score
@@ -69,7 +69,6 @@ const route = useRoute();
 const {
   selectedReposValues,
   project,
-  archivedRepos,
   allArchived,
   hasSelectedArchivedRepos
 } = storeToRefs(useProjectStore())
@@ -90,8 +89,6 @@ const displayPopularityScore = computed(() => isScoreVisible(WidgetArea.POPULARI
 
 // Security score is only displayed if security data is available
 const displaySecurityScore = computed(() => securityScore.value && securityScore.value.length > 0);
-
-const displayArchivedReposNote = computed(() => !!archivedRepos.value.length && !allArchived.value)
 
 const scoreDisplay = computed(() => ({
   overall: displayContributorsScore.value


### PR DESCRIPTION
Adds bottom padding to health score card when archived footer is not displayed.

Before:
<img width="1121" height="380" alt="Screenshot 2025-09-02 at 12 07 30" src="https://github.com/user-attachments/assets/b504b2e2-03d7-463c-bc74-64af15ca32c0" />

After:
<img width="1139" height="290" alt="Screenshot 2025-09-02 at 12 07 37" src="https://github.com/user-attachments/assets/a28d1ca6-43a3-4fb7-aa22-be315545b12c" />
