### PR TITLE
fix: only show archived repositories disclaimer when appropriate

### DIFF
--- a/frontend/app/components/modules/widget/components/shared/widget-area.vue
+++ b/frontend/app/components/modules/widget/components/shared/widget-area.vue
@@ -21,6 +21,7 @@ SPDX-License-Identifier: MIT
           <template #default="{ observer }">
             
             <lfx-repos-inclusion-note
+              v-if="hasSelectedArchivedRepos"
               :all-archived="allArchived"            
             />
 
@@ -93,6 +94,7 @@ const {
   endDate,
   selectedReposValues,
   allArchived,
+  hasSelectedArchivedRepos
 } = storeToRefs(useProjectStore())
 const isFirstLoad = ref(true);
 


### PR DESCRIPTION
Same issue as in #620.
In this case, it was the disclaimer about the archived repositories above the was not using the conditional to only be displayed when an archived repository was selected.

<img width="1221" height="512" alt="image" src="https://github.com/user-attachments/assets/02ede0e8-af0e-478f-8825-11d78e48f405" />
