### PR TITLE
fix: plausible installation in blog and docs

### DIFF
--- a/frontend/blog/.vitepress/config.mts
+++ b/frontend/blog/.vitepress/config.mts
@@ -9,7 +9,8 @@ export default defineConfig({
     from new features to how we are building our solutions. `,
   head: [
     ['link', { rel: 'icon', href: 'https://cdn.platform.linuxfoundation.org/assets/lf-favicon.png' }], // Adjust the path if you use a different favicon format
-    ['script', { src: 'https://kit.fontawesome.com/b5289aebdf.js' }]
+    ['script', { src: 'https://kit.fontawesome.com/b5289aebdf.js' }],
+    ['script', { defer: '', 'data-domain': 'insights.linuxfoundation.org', src: 'https://plausible.io/js/script.js' }]
   ],
   vite: {
     resolve: {

--- a/frontend/docs/.vitepress/config.ts
+++ b/frontend/docs/.vitepress/config.ts
@@ -10,7 +10,8 @@ export default defineConfig({
   description: "Insights evaluates the health and trustworthiness of the world's most critical open source software.",
   head: [
     ['link', { rel: 'icon', href: 'https://cdn.platform.linuxfoundation.org/assets/lf-favicon.png' }], // Adjust the path if you use a different favicon format
-    ['script', { src: 'https://kit.fontawesome.com/b5289aebdf.js' }]
+    ['script', { src: 'https://kit.fontawesome.com/b5289aebdf.js' }],
+    ['script', { defer: '', 'data-domain': 'insights.linuxfoundation.org', src: 'https://plausible.io/js/script.js' }]
   ],
   vite: {
     resolve: {


### PR DESCRIPTION
Both the docs and the blogs page weren't being tracked as expected.
This PR adds the plausible script to both vitepress configurations.