### PR TITLE
fix: merge lead time display for negative values

### DIFF
--- a/frontend/app/components/modules/widget/config/development/merge-lead-time/fragments/merge-lead-item.vue
+++ b/frontend/app/components/modules/widget/config/development/merge-lead-time/fragments/merge-lead-item.vue
@@ -6,14 +6,27 @@ SPDX-License-Identifier: MIT
   <div class="flex flex-col">
     <div class="flex flex-row gap-3 items-start justify-end">
       <div
+        v-if="!!props.itemValue"
         class="flex gap-2 items-center text-sm h-6 px-2.5 py-1 rounded-full
           font-semibold bg-neutral-50 text-neutral-600"
       >
-        {{ itemValue.value }}
-        {{ itemValue.unit }}
+        {{ itemDisplay }}
       </div>
+      <lfx-tooltip 
+        v-else
+        :content="itemDisplay === '-' ? 'Merge time could not be calculated for this stage.' : ''"
+      >
+        <div
+          class="flex gap-2 items-center text-sm h-6 px-2.5 py-1 rounded-full
+            font-semibold bg-neutral-50 text-neutral-600"
+        >
+          {{ itemDisplay }}
+        </div>
+      </lfx-tooltip>
+
       <div>
         <lfx-icon
+          v-if="!!props.itemValue"
           name="arrow-down"
           class="text-neutral-300"
           :size="24"
@@ -35,20 +48,24 @@ SPDX-License-Identifier: MIT
   </div>
 </template>
 <script setup lang="ts">
+import { computed } from 'vue';
 import type { MergeLeadTimeItem } from '~~/types/development/responses.types';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
+import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
 
-withDefaults(
+const props = withDefaults(
   defineProps<{
     title: string;
     description: string;
     icon: string;
-    itemValue: MergeLeadTimeItem;
+    itemValue: MergeLeadTimeItem | undefined;
     isLast?: boolean;
   }>(),
   {
     isLast: false
   }
 );
+
+const itemDisplay= computed(() => props.itemValue ? `${props.itemValue?.value} ${props.itemValue?.unit}` : '-');
 
 </script>

--- a/frontend/app/components/modules/widget/config/development/merge-lead-time/merge-lead-time.vue
+++ b/frontend/app/components/modules/widget/config/development/merge-lead-time/merge-lead-time.vue
@@ -41,28 +41,24 @@ SPDX-License-Identifier: MIT
       <div class="w-full min-h-[250px] mt-5">
         <div class="flex flex-col gap-10">
           <lfx-merge-lead-item
-            v-if="pickup"
             title="Pickup"
             description="Pull Request assigned"
             icon="user-check"
             :item-value="pickup"
           />
           <lfx-merge-lead-item
-            v-if="review"
             title="Review"
             description="Review Started"
             icon="eye"
             :item-value="review"
           />
           <lfx-merge-lead-item
-            v-if="accepted"
             title="Accepted"
             description="Pull Request approved"
             icon="check-circle"
             :item-value="accepted"
           />
           <lfx-merge-lead-item
-            v-if="prMerged"
             title="Pull Request merged"
             description=""
             icon="code-merge"
@@ -165,7 +161,7 @@ const getMergeLeadTimeItem = (
   }
   const item = data.data[key as keyof MergeLeadTime['data']];
 
-  if (item) {
+  if (item && item.value >= 0) {
     return {
       ...item,
       ...formatDuration(item.value)


### PR DESCRIPTION
## In this PR

Fix the merge lead time display if the time is negative. Added tooltip for items that cannot be displayed

## Ticket
[IN-695](https://linuxfoundation.atlassian.net/browse/IN-695)