### PR TITLE
fix: add space in organizations leaderboard description

### DIFF
--- a/frontend/app/components/modules/widget/config/contributor/organizations-leaderboard/organizations-leaderboard.config.ts
+++ b/frontend/app/components/modules/widget/config/contributor/organizations-leaderboard/organizations-leaderboard.config.ts
@@ -7,7 +7,7 @@ const organizationsLeaderboard: WidgetConfig = {
     key: 'organizationsLeaderboard',
     name: 'Organizations leaderboard',
     description: () => 'Organizations ranked by the number of contribution activities'
-    + 'performed by contributors on their behalf during the selected time period.',
+    + ' performed by contributors on their behalf during the selected time period.',
     learnMoreLink: `/docs/metrics/contributors#organizations-leaderboard`,
     component: OrganizationsLeaderboard,
     defaultValue: {


### PR DESCRIPTION
This PR adds a space in the string concatenation to fix the following issue:

<img width="719" height="179" alt="Screenshot 2025-10-03 at 19 27 59" src="https://github.com/user-attachments/assets/6165d876-3821-41aa-83f4-2a44e5985c0f" />
