### PR TITLE
Fix stars and forks data sources

### DIFF
--- a/frontend/server/data/tinybird/forks-data-source.test.ts
+++ b/frontend/server/data/tinybird/forks-data-source.test.ts
@@ -47,8 +47,9 @@ describe('Forks Data Source', () => {
       countType: ActivityFilterCountType.CUMULATIVE,
       activity_type: ActivityTypes.FORKS,
       onlyContributions: false,
-      includeCodeContributions: true,
-      includeCollaborations: true,
+      includeCodeContributions: false,
+      includeCollaborations: false,
+      includeOtherContributions: true,
       startDate,
       endDate
     };

--- a/frontend/server/data/tinybird/forks-data-source.ts
+++ b/frontend/server/data/tinybird/forks-data-source.ts
@@ -27,6 +27,7 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
       activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repos: filter.repos, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      includeOtherContributions: true
     },
     previousSummaryQuery: {
       ...filter,
@@ -34,12 +35,14 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repos: filter.repos, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       startDate: dates.previous.from,
-      endDate: dates.previous.to
+      endDate: dates.previous.to,
+      includeOtherContributions: true
     },
     dataQuery: {
       ...filter,
       activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       repos: filter.repos,
+      includeOtherContributions: true
     }
   }
 }

--- a/frontend/server/data/tinybird/stars-data-source.test.ts
+++ b/frontend/server/data/tinybird/stars-data-source.test.ts
@@ -47,8 +47,9 @@ describe('Stars Data Source', () => {
       countType: ActivityFilterCountType.CUMULATIVE,
       activity_type: ActivityTypes.FORKS,
       onlyContributions: false,
-      includeCodeContributions: true,
-      includeCollaborations: true,
+      includeCodeContributions: false,
+      includeCollaborations: false,
+      includeOtherContributions: true,
       startDate,
       endDate
     };

--- a/frontend/server/data/tinybird/stars-data-source.ts
+++ b/frontend/server/data/tinybird/stars-data-source.ts
@@ -27,6 +27,7 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
       activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repos: filter.repos, // We need this due to a discrepancy between variable names in Tinybird and the frontend
+      includeOtherContributions: true
     },
     previousSummaryQuery: {
       ...filter,
@@ -34,12 +35,14 @@ function getTinybirdQueries(filter: ActivityCountFilter) {
       granularity: undefined, // This tells TinyBird to return a summary instead of time series
       repos: filter.repos, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       startDate: dates.previous.from,
-      endDate: dates.previous.to
+      endDate: dates.previous.to,
+      includeOtherContributions: true
     },
     dataQuery: {
       ...filter,
       activity_type: filter.activity_type, // We need this due to a discrepancy between variable names in Tinybird and the frontend
       repos: filter.repos,
+      includeOtherContributions: true
     }
   }
 }


### PR DESCRIPTION
The stars and forks data sources need to request "other contributions" from Tinybird, since that's how they're now categorised. Otherwise, the contributions data will be totally filtered out and these widgets will not display anything.

This fixes the requests done to Tinybird to include the `includeOtherContributions` set to true.