### PR TITLE
feat: add dynamic activity type filtering when toggling collaborations

### DIFF
--- a/frontend/app/components/modules/widget/components/contributors/fragments/activities-dropdown.vue
+++ b/frontend/app/components/modules/widget/components/contributors/fragments/activities-dropdown.vue
@@ -32,7 +32,7 @@ SPDX-License-Identifier: MIT
     </template>
 
     <lfx-dropdown-item
-      value="all:all"
+      :value="defaultAllValue"
       label="All activities"
     />
 
@@ -48,7 +48,7 @@ SPDX-License-Identifier: MIT
         </lfx-dropdown-group-title>
 
         <lfx-dropdown-item
-          v-for="option of group.activityTypes"
+          v-for="option of filterActivityTypes(group.activityTypes)"
           :key="option.key"
           :value="`${group.key}:${option.key}`"
           :label="option.label"
@@ -86,7 +86,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, watch } from 'vue';
 import {storeToRefs} from "pinia";
 import LfxDropdownSelector from "~/components/uikit/dropdown/dropdown-selector.vue";
 import LfxIcon from "~/components/uikit/icon/icon.vue";
@@ -109,6 +109,7 @@ const props = withDefaults(defineProps<{
 });
 
 const emit = defineEmits<{(e: 'update:modelValue', value: string): void }>();
+const defaultAllValue = 'all:all';
 
 const { project } = storeToRefs(useProjectStore());
 
@@ -139,6 +140,36 @@ const selected = computed(() => {
     label: option?.label || '',
   }
 })
+
+/**
+ * Filter activity types based on the property includeCollaborations.
+ * If includeCollaborations is true, return all activity types.
+ * If includeCollaborations is false, return only non-collaboration types (where isCollaborationType is false or undefined).
+ * @param activityTypes 
+ */
+const filterActivityTypes = (activityTypes: ActivityType[]) => {
+  if (props.includeCollaborations) {
+    return activityTypes;
+  }
+  return activityTypes.filter((activityType) => !activityType.isCollaborationType);
+}
+
+/**
+ * Watch for the includeCollaborations property and update the activity types accordingly.
+ * If the current activity type is not included in the filtered activity types, update the activity type to the defaultAllValue.
+ */
+watch(() => props.includeCollaborations, (newVal: boolean) => {
+  const filteredActivityTypes = Object.values(platforms)
+    .filter((platform) => connected.value.includes(platform.key))
+    .flatMap((platform) =>
+      platform.activityTypes
+        .filter((activityType) => !activityType.isCollaborationType)
+        .map((activityType) => `${platform.key}:${activityType.key}`)
+    );
+  if (activity.value !== defaultAllValue && !newVal && !filteredActivityTypes.includes(activity.value)) {
+    activity.value = defaultAllValue;
+  }
+}, { immediate: true });
 </script>
 
 <script lang="ts">

--- a/frontend/app/config/platforms/configs/confluence.platform.ts
+++ b/frontend/app/config/platforms/configs/confluence.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const confluence: PlatformConfig = {
   key: ActivityPlatforms.CONFLUENCE,
@@ -11,35 +11,43 @@ export const confluence: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.PAGE_CREATED,
-      label: 'Created a page'
+      label: 'Created a page',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.PAGE_UPDATED,
-      label: 'Updated a page'
+      label: 'Updated a page',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.COMMENT_CREATED,
-      label: 'Created a comment'
+      label: 'Created a comment',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ATTACHMENT_CREATED,
-      label: 'Created an attachment'
+      label: 'Created an attachment',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.BLOGPOST_CREATED,
-      label: 'Created a blog post'
+      label: 'Created a blog post',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.BLOGPOST_UPDATED,
-      label: 'Updated a blog post'
+      label: 'Updated a blog post',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ATTACHMENT,
-      label: 'Attached a file'
+      label: 'Attached a file',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.COMMENT,
-      label: 'Commented on a page'
-    }
-  ]
-};
+      label: 'Commented on a page',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/discord.platform.ts
+++ b/frontend/app/config/platforms/configs/discord.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const discord: PlatformConfig = {
   key: ActivityPlatforms.DISCORD,
@@ -11,15 +11,18 @@ export const discord: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.MESSAGE,
-      label: 'Sent a message'
+      label: 'Sent a message',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.THREAD_STARTED,
-      label: 'Started a thread'
+      label: 'Started a thread',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.THREAD_MESSAGE,
-      label: 'Sent a message in a thread'
-    }
-  ]
-};
+      label: 'Sent a message in a thread',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/github.platform.ts
+++ b/frontend/app/config/platforms/configs/github.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const github: PlatformConfig = {
   key: ActivityPlatforms.GITHUB,
@@ -11,52 +11,57 @@ export const github: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.AUTHORED_COMMIT,
-      label: 'Authored a commit'
+      label: 'Authored a commit',
     },
     {
       key: ActivityTypes.PULL_REQUEST_CLOSED,
-      label: 'Closed a pull request'
+      label: 'Closed a pull request',
     },
     {
       key: ActivityTypes.PULL_REQUEST_OPENED,
-      label: 'Opened a pull request'
+      label: 'Opened a pull request',
     },
     {
       key: ActivityTypes.PULL_REQUEST_COMMENT,
-      label: 'Commented on a pull request'
+      label: 'Commented on a pull request',
     },
     {
       key: ActivityTypes.PULL_REQUEST_MERGED,
-      label: 'Merged a pull request'
+      label: 'Merged a pull request',
     },
     {
       key: ActivityTypes.PULL_REQUEST_REVIEW_REQUESTED,
-      label: 'Requested a review for a pull request'
+      label: 'Requested a review for a pull request',
     },
     {
       key: ActivityTypes.PULL_REQUEST_REVIEW_THREAD_COMMENT,
-      label: 'Commented on a pull request review thread'
+      label: 'Commented on a pull request review thread',
     },
     {
       key: ActivityTypes.ISSUES_CLOSED,
-      label: 'Closed an issue'
+      label: 'Closed an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUES_OPENED,
-      label: 'Opened an issue'
+      label: 'Opened an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUE_COMMENT,
-      label: 'Commented on an issue'
+      label: 'Commented on an issue',
+      isCollaborationType: true,
     },
 
     {
       key: ActivityTypes.DISCUSSION_STARTED,
-      label: 'Started a discussion'
+      label: 'Started a discussion',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.DISCUSSION_COMMENT,
-      label: 'Commented on a discussion'
-    }
-  ]
-};
+      label: 'Commented on a discussion',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/gitlab.platform.ts
+++ b/frontend/app/config/platforms/configs/gitlab.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const gitlab: PlatformConfig = {
   key: ActivityPlatforms.GITLAB,
@@ -11,39 +11,42 @@ export const gitlab: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.ISSUES_OPENED,
-      label: 'Opened an issue'
+      label: 'Opened an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUES_CLOSED,
-      label: 'Closed an issue'
+      label: 'Closed an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.MERGE_REQUEST_CLOSED,
-      label: 'Closed a merge request'
+      label: 'Closed a merge request',
     },
     {
       key: ActivityTypes.MERGE_REQUEST_OPENED,
-      label: 'Opened a merge request'
+      label: 'Opened a merge request',
     },
     {
       key: ActivityTypes.MERGE_REQUEST_REVIEW_THREAD_COMMENT,
-      label: 'Commented on a merge request review thread'
+      label: 'Commented on a merge request review thread',
     },
     {
       key: ActivityTypes.MERGE_REQUEST_MERGED,
-      label: 'Merged a merge request'
+      label: 'Merged a merge request',
     },
     {
       key: ActivityTypes.MERGE_REQUEST_COMMENT,
-      label: 'Commented on a merge request'
+      label: 'Commented on a merge request',
     },
     {
       key: ActivityTypes.ISSUE_COMMENT,
-      label: 'Commented on an issue'
+      label: 'Commented on an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.AUTHORED_COMMIT,
-      label: 'Authored a commit'
-    }
-  ]
-};
+      label: 'Authored a commit',
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/groupsio.platform.ts
+++ b/frontend/app/config/platforms/configs/groupsio.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const groupsio: PlatformConfig = {
   key: ActivityPlatforms.GROUPS_IO,
@@ -11,7 +11,8 @@ export const groupsio: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.MESSAGE,
-      label: 'Sent a message'
-    }
-  ]
-};
+      label: 'Sent a message',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/jira.platform.ts
+++ b/frontend/app/config/platforms/configs/jira.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const jira: PlatformConfig = {
   key: ActivityPlatforms.JIRA,
@@ -11,31 +11,38 @@ export const jira: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.ISSUE_CREATED,
-      label: 'Created an issue'
+      label: 'Created an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUES_CLOSED,
-      label: 'Closed an issue'
+      label: 'Closed an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUE_ASSIGNED,
-      label: 'Assigned an issue'
+      label: 'Assigned an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUE_UPDATED,
-      label: 'Updated an issue'
+      label: 'Updated an issue',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUE_COMMENT_CREATED,
-      label: 'Created an issue comment'
+      label: 'Created an issue comment',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUE_COMMENT_UPDATED,
-      label: 'Updated an issue comment'
+      label: 'Updated an issue comment',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ISSUE_ATTACHMENT_ADDED,
-      label: 'Added an attachment to an issue'
-    }
-  ]
-};
+      label: 'Added an attachment to an issue',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/slack.platform.ts
+++ b/frontend/app/config/platforms/configs/slack.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const slack: PlatformConfig = {
   key: ActivityPlatforms.SLACK,
@@ -11,7 +11,8 @@ export const slack: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.MESSAGE,
-      label: 'Sent a message'
-    }
-  ]
-};
+      label: 'Sent a message',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/app/config/platforms/configs/stackoverflow.platform.ts
+++ b/frontend/app/config/platforms/configs/stackoverflow.platform.ts
@@ -1,8 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
-import type { PlatformConfig } from '~~/types/shared/platforms.types';
+import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
+import { ActivityTypes } from '~~/types/shared/activity-types'
+import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const stackoverflow: PlatformConfig = {
   key: ActivityPlatforms.STACKOVERFLOW,
@@ -11,11 +11,13 @@ export const stackoverflow: PlatformConfig = {
   activityTypes: [
     {
       key: ActivityTypes.QUESTION,
-      label: 'Asked a question'
+      label: 'Asked a question',
+      isCollaborationType: true,
     },
     {
       key: ActivityTypes.ANSWER,
-      label: 'Answered a question'
-    }
-  ]
-};
+      label: 'Answered a question',
+      isCollaborationType: true,
+    },
+  ],
+}

--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,136 +1,137 @@
-import pluginVue from "eslint-plugin-vue";
-import typescriptEslint from "typescript-eslint";
-import prettier from "eslint-config-prettier";
-import pluginImport from "eslint-plugin-import";
-import vueParser from "vue-eslint-parser";
+import pluginVue from 'eslint-plugin-vue'
+import typescriptEslint from 'typescript-eslint'
+import prettier from 'eslint-config-prettier'
+import pluginImport from 'eslint-plugin-import'
+import vueParser from 'vue-eslint-parser'
 
-import { FlatCompat } from "@eslint/eslintrc";
-import tsParser from "@typescript-eslint/parser";
-import path from "node:path";
-import { fileURLToPath } from "node:url";
-import js from "@eslint/js";
-import { fixupConfigRules } from "@eslint/compat";
+import { FlatCompat } from '@eslint/eslintrc'
+import tsParser from '@typescript-eslint/parser'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import js from '@eslint/js'
+import { fixupConfigRules } from '@eslint/compat'
 
-const __filename = fileURLToPath(import.meta.url);
-const __dirname = path.dirname(__filename);
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
 const compat = new FlatCompat({
   baseDirectory: __dirname,
   recommendedConfig: js.configs.recommended,
   allConfig: js.configs.all,
-});
+})
 
 export default [
   // Ignore patterns
   {
     ignores: [
-      "*.config.*js",
-      ".tailwind/*",
-      "shims-vue.d.ts",
-      "docs/.vitepress/theme/cssOverrides/*",
-      "docs/.vitepress/dist/**",
-      "pnpm-lock.yaml",
-      "vitest.config.ts",
-      ".nuxt/**",
-      "dist/**",
-      "node_modules/**",
-      ".stress/**",
-      ".output/**",
-      "storybook-static/**",
-      "docs/**",
+      '*.config.*js',
+      '.tailwind/*',
+      'shims-vue.d.ts',
+      'docs/.vitepress/theme/cssOverrides/*',
+      'docs/.vitepress/dist/**',
+      'pnpm-lock.yaml',
+      'vitest.config.ts',
+      '.nuxt/**',
+      'dist/**',
+      'node_modules/**',
+      '.stress/**',
+      '.output/**',
+      'storybook-static/**',
+      'docs/**',
+      '**/.vitepress/**',
     ],
   },
 
-  ...fixupConfigRules(
-    compat.extends("eslint:recommended", "plugin:import/typescript"),
-  ).map((config) => ({
-    ...config,
-    files: ["**/*.ts", "**/*.vue"],
-  })),
+  ...fixupConfigRules(compat.extends('eslint:recommended', 'plugin:import/typescript')).map(
+    (config) => ({
+      ...config,
+      files: ['**/*.ts', '**/*.vue'],
+    }),
+  ),
 
   // TypeScript files configuration
   {
-    files: ["**/*.ts"],
+    files: ['**/*.ts'],
     languageOptions: {
       parser: tsParser,
       ecmaVersion: 2022,
-      sourceType: "module",
+      sourceType: 'module',
     },
   },
 
   // Vue files configuration
   {
-    files: ["**/*.vue"],
+    files: ['**/*.vue'],
     languageOptions: {
       parser: vueParser,
       ecmaVersion: 2022,
-      sourceType: "module",
+      sourceType: 'module',
       parserOptions: {
         parser: tsParser,
-        extraFileExtensions: [".vue"],
+        extraFileExtensions: ['.vue'],
         ecmaFeatures: {
           jsx: true,
         },
       },
       globals: {
         // Vue 3 Composition API
-        defineProps: "readonly",
-        defineEmits: "readonly",
-        defineExpose: "readonly",
-        withDefaults: "readonly",
-        defineSlots: "readonly",
-        defineModel: "readonly",
+        defineProps: 'readonly',
+        defineEmits: 'readonly',
+        defineExpose: 'readonly',
+        withDefaults: 'readonly',
+        defineSlots: 'readonly',
+        defineModel: 'readonly',
 
         // Vue 3 Reactivity
-        ref: "readonly",
-        reactive: "readonly",
-        computed: "readonly",
-        watch: "readonly",
-        watchEffect: "readonly",
-        toRef: "readonly",
-        toRefs: "readonly",
-        unref: "readonly",
-        nextTick: "readonly",
-        onMounted: "readonly",
-        onBeforeUnmount: "readonly",
-        inject: "readonly",
-        useAttrs: "readonly",
+        ref: 'readonly',
+        reactive: 'readonly',
+        computed: 'readonly',
+        watch: 'readonly',
+        watchEffect: 'readonly',
+        toRef: 'readonly',
+        toRefs: 'readonly',
+        unref: 'readonly',
+        nextTick: 'readonly',
+        onMounted: 'readonly',
+        onBeforeUnmount: 'readonly',
+        inject: 'readonly',
+        useAttrs: 'readonly',
 
         // Nuxt 3 Composables
-        useRuntimeConfig: "readonly",
-        useRouter: "readonly",
-        useRoute: "readonly",
-        useSeoMeta: "readonly",
-        useHead: "readonly",
-        useLazyFetch: "readonly",
-        useFetch: "readonly",
-        useNuxtData: "readonly",
-        navigateTo: "readonly",
-        definePageMeta: "readonly",
-        $fetch: "readonly",
+        useRuntimeConfig: 'readonly',
+        useRouter: 'readonly',
+        useRoute: 'readonly',
+        useSeoMeta: 'readonly',
+        useHead: 'readonly',
+        useLazyFetch: 'readonly',
+        useFetch: 'readonly',
+        useNuxtData: 'readonly',
+        navigateTo: 'readonly',
+        definePageMeta: 'readonly',
+        $fetch: 'readonly',
 
         // Browser globals for client-side
-        document: "readonly",
-        window: "readonly",
-        HTMLElement: "readonly",
-        HTMLDivElement: "readonly",
-        Element: "readonly",
-        Event: "readonly",
-        MouseEvent: "readonly",
-        Node: "readonly",
-        KeyboardEvent: "readonly",
-        TouchEvent: "readonly",
-        IntersectionObserver: "readonly",
-        IntersectionObserverEntry: "readonly",
-        console: "readonly",
-        navigator: "readonly",
-        localStorage: "readonly",
-        setTimeout: "readonly",
-        clearTimeout: "readonly",
-        URL: "readonly",
-        URLSearchParams: "readonly",
+        document: 'readonly',
+        window: 'readonly',
+        HTMLElement: 'readonly',
+        HTMLDivElement: 'readonly',
+        Element: 'readonly',
+        Event: 'readonly',
+        MouseEvent: 'readonly',
+        Node: 'readonly',
+        KeyboardEvent: 'readonly',
+        TouchEvent: 'readonly',
+        IntersectionObserver: 'readonly',
+        IntersectionObserverEntry: 'readonly',
+        console: 'readonly',
+        navigator: 'readonly',
+        localStorage: 'readonly',
+        setTimeout: 'readonly',
+        clearTimeout: 'readonly',
+        URL: 'readonly',
+        URLSearchParams: 'readonly',
 
         // Global types
-        ECOption: "readonly",
+        ECOption: 'readonly',
       },
     },
   },
@@ -139,7 +140,7 @@ export default [
   ...typescriptEslint.configs.recommended,
 
   // Vue configuration
-  ...pluginVue.configs["flat/recommended"],
+  ...pluginVue.configs['flat/recommended'],
 
   // Prettier configuration (must be last)
   prettier,
@@ -150,79 +151,79 @@ export default [
       import: pluginImport,
     },
     settings: {
-      "import/resolver": {
+      'import/resolver': {
         typescript: {
           alwaysTryTypes: true,
-          project: "./tsconfig.json",
+          project: './tsconfig.json',
         },
         node: {
-          extensions: [".js", ".jsx", ".ts", ".tsx", ".vue"],
+          extensions: ['.js', '.jsx', '.ts', '.tsx', '.vue'],
         },
       },
     },
     rules: {
-      "no-console": ["error", { allow: ["warn", "error"] }],
-      "no-debugger": "error",
-      "vue/no-unused-components": "error",
-      "vue/first-attribute-linebreak": "error",
-      "vue/max-attributes-per-line": "error",
-      "vue/html-closing-bracket-newline": "error",
-      "vue/html-closing-bracket-spacing": "warn",
-      "vue/html-indent": "warn",
-      "vue/html-self-closing": "warn",
-      "vue/html-button-has-type": "warn",
-      "vue/no-multiple-template-root": "off",
-      "vue/no-required-prop-with-default": "off",
-      "import/order": "warn",
-      "no-unused-vars": "off",
-      "@typescript-eslint/no-unused-vars": [
-        "error",
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+      'no-debugger': 'error',
+      'vue/no-unused-components': 'error',
+      'vue/first-attribute-linebreak': 'error',
+      'vue/max-attributes-per-line': 'error',
+      'vue/html-closing-bracket-newline': 'error',
+      'vue/html-closing-bracket-spacing': 'warn',
+      'vue/html-indent': 'warn',
+      'vue/html-self-closing': 'warn',
+      'vue/html-button-has-type': 'warn',
+      'vue/no-multiple-template-root': 'off',
+      'vue/no-required-prop-with-default': 'off',
+      'import/order': 'warn',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
         {
-          argsIgnorePattern: "^_",
-          varsIgnorePattern: "^_",
-          destructuredArrayIgnorePattern: "^_",
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
         },
       ],
-      "vue/no-v-html": "off",
-      "import/prefer-default-export": "off",
-      "import/no-named-as-default": "off",
-      "class-methods-use-this": "off",
-      "no-shadow": "off",
-      "vuejs-accessibility/mouse-events-have-key-events": "off",
-      "vuejs-accessibility/click-events-have-key-events": "off",
-      "vuejs-accessibility/form-control-has-label": "off",
-      "vuejs-accessibility/label-has-for": "off",
-      "func-names": "off",
-      "import/no-cycle": "off",
-      "vue/multi-word-component-names": "off",
-      "vue/no-parsing-error": "off",
-      "vue/max-len": [
-        "error",
+      'vue/no-v-html': 'off',
+      'import/prefer-default-export': 'off',
+      'import/no-named-as-default': 'off',
+      'class-methods-use-this': 'off',
+      'no-shadow': 'off',
+      'vuejs-accessibility/mouse-events-have-key-events': 'off',
+      'vuejs-accessibility/click-events-have-key-events': 'off',
+      'vuejs-accessibility/form-control-has-label': 'off',
+      'vuejs-accessibility/label-has-for': 'off',
+      'func-names': 'off',
+      'import/no-cycle': 'off',
+      'vue/multi-word-component-names': 'off',
+      'vue/no-parsing-error': 'off',
+      'vue/max-len': [
+        'error',
         {
           code: 120,
           ignoreComments: true,
           ignoreUrls: true,
         },
       ],
-      "max-len": [
-        "error",
+      'max-len': [
+        'error',
         {
           code: 120,
           ignoreComments: true,
           ignoreUrls: true,
         },
       ],
-      "import/extensions": [
-        "error",
-        "ignorePackages",
+      'import/extensions': [
+        'error',
+        'ignorePackages',
         {
-          js: "never",
-          jsx: "never",
-          ts: "never",
-          tsx: "never",
-          "": "never",
+          js: 'never',
+          jsx: 'never',
+          ts: 'never',
+          tsx: 'never',
+          '': 'never',
         },
       ],
     },
   },
-];
+]

--- a/frontend/types/shared/platforms.types.ts
+++ b/frontend/types/shared/platforms.types.ts
@@ -1,13 +1,14 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 export interface ActivityType {
-  key: string;
-  label: string;
+  key: string
+  label: string
+  isCollaborationType?: boolean
 }
 
 export interface PlatformConfig {
-  key: string;
-  label: string;
-  image: string;
-  activityTypes: ActivityType[];
+  key: string
+  label: string
+  image: string
+  activityTypes: ActivityType[]
 }


### PR DESCRIPTION
## In this PR

- Added new flag to the activity types in the platform configs for the collaboration flag
- Used new flag in the activity types dropdown to filter out collaborations only types if the the include collaborations toggle is set to false
- Reset the selected activity type if the current one is not included in the activity types list when the user toggles the include collaborations back to false

## Ticket
[N-760](https://linuxfoundation.atlassian.net/browse/IN-760)