### PR TITLE
fix: empty platform names showing when include collaborations toggle is off

### DIFF
--- a/frontend/app/components/modules/widget/components/contributors/fragments/activities-dropdown.vue
+++ b/frontend/app/components/modules/widget/components/contributors/fragments/activities-dropdown.vue
@@ -42,7 +42,7 @@ SPDX-License-Identifier: MIT
       v-for="group in platforms"
       :key="group.key"
     >
-      <template v-if="connected.includes(group.key)">
+      <template v-if="connected.includes(group.key) && filterActivityTypes(group.activityTypes).length > 0">
         <lfx-dropdown-group-title>
           {{ group.label }}
         </lfx-dropdown-group-title>


### PR DESCRIPTION
## In this PR

Quick fix for hiding platform names from activity dropdown when the include collaborations toggle is turned off