### PR TITLE
feat: hide activity types that don't exist in project [IN-751]

### DIFF
--- a/frontend/app/components/shared/types/tanstack.ts
+++ b/frontend/app/components/shared/types/tanstack.ts
@@ -19,6 +19,7 @@ export enum TanstackKey {
 
   // Development
   ACTIVE_DAYS = 'active-days',
+  ACTIVITY_TYPES = 'activity-types',
   AVERAGE_TIME_TO_MERGE = 'average-time-to-merge',
   CODE_REVIEW_ENGAGEMENT = 'code-review-engagement',
   CONTRIBUTIONS_OUTSIDE_WORK_HOURS = 'contributions-outside-work-hours',

--- a/frontend/app/config/platforms/configs/confluence.platform.ts
+++ b/frontend/app/config/platforms/configs/confluence.platform.ts
@@ -1,53 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const confluence: PlatformConfig = {
   key: ActivityPlatforms.CONFLUENCE,
   label: 'Confluence',
   image: '/images/integrations/confluence.svg',
-  activityTypes: [
-    {
-      key: ActivityTypes.PAGE_CREATED,
-      label: 'Created a page',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.PAGE_UPDATED,
-      label: 'Updated a page',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.COMMENT_CREATED,
-      label: 'Created a comment',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ATTACHMENT_CREATED,
-      label: 'Created an attachment',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.BLOGPOST_CREATED,
-      label: 'Created a blog post',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.BLOGPOST_UPDATED,
-      label: 'Updated a blog post',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ATTACHMENT,
-      label: 'Attached a file',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.COMMENT,
-      label: 'Commented on a page',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/devto.platform.ts
+++ b/frontend/app/config/platforms/configs/devto.platform.ts
@@ -1,17 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const devto: PlatformConfig = {
   key: ActivityPlatforms.DEVTO,
   label: 'Dev.to',
   image: '/images/integrations/devto.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.COMMENT,
-      label: 'Commented on a post'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/discord.platform.ts
+++ b/frontend/app/config/platforms/configs/discord.platform.ts
@@ -1,28 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const discord: PlatformConfig = {
   key: ActivityPlatforms.DISCORD,
   label: 'Discord',
   image: '/images/integrations/discord.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.MESSAGE,
-      label: 'Sent a message',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.THREAD_STARTED,
-      label: 'Started a thread',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.THREAD_MESSAGE,
-      label: 'Sent a message in a thread',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/discourse.platform.ts
+++ b/frontend/app/config/platforms/configs/discourse.platform.ts
@@ -1,21 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const discourse: PlatformConfig = {
   key: ActivityPlatforms.DISCOURSE,
   label: 'Discourse',
   image: '/images/integrations/discourse.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.CREATE_TOPIC,
-      label: 'Created a topic'
-    },
-    {
-      key: ActivityTypes.MESSAGE_IN_TOPIC,
-      label: 'Sent a message in a topic'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/gerrit.platform.ts
+++ b/frontend/app/config/platforms/configs/gerrit.platform.ts
@@ -1,45 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const gerrit: PlatformConfig = {
   key: ActivityPlatforms.GERRIT,
   label: 'Gerrit',
   image: '/images/integrations/gerrit.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.CHANGESET_CREATED,
-      label: 'Created a changeset'
-    },
-    {
-      key: ActivityTypes.CHANGESET_MERGED,
-      label: 'Merged a changeset'
-    },
-    {
-      key: ActivityTypes.CHANGESET_CLOSED,
-      label: 'Closed a changeset'
-    },
-    {
-      key: ActivityTypes.CHANGESET_ABANDONED,
-      label: 'Abandoned a changeset'
-    },
-    {
-      key: ActivityTypes.CHANGESET_COMMENT_CREATED,
-      label: 'Created a changeset comment'
-    },
-    {
-      key: ActivityTypes.PATCHSET_CREATED,
-      label: 'Created a patchset'
-    },
-    {
-      key: ActivityTypes.PATCHSET_COMMENT_CREATED,
-      label: 'Created a patchset comment'
-    },
-    {
-      key: ActivityTypes.PATCHSET_APPROVAL_CREATED,
-      label: 'Created a patchset approval'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/git.platform.ts
+++ b/frontend/app/config/platforms/configs/git.platform.ts
@@ -1,57 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const git: PlatformConfig = {
   key: ActivityPlatforms.GIT,
   label: 'Git',
   image: '/images/integrations/git.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.AUTHORED_COMMIT,
-      label: 'Authored a commit'
-    },
-    {
-      key: ActivityTypes.REVIEWED_COMMIT,
-      label: 'Reviewed a commit'
-    },
-    {
-      key: ActivityTypes.TESTED_COMMIT,
-      label: 'Tested a commit'
-    },
-    {
-      key: ActivityTypes.COAUTHORED_COMMIT,
-      label: 'Co-authored a commit'
-    },
-    {
-      key: ActivityTypes.INFORMED_COMMIT,
-      label: 'Informed a commit'
-    },
-    {
-      key: ActivityTypes.INFLUENCED_COMMIT,
-      label: 'Influenced a commit'
-    },
-    {
-      key: ActivityTypes.APPROVED_COMMIT,
-      label: 'Approved a commit'
-    },
-    {
-      key: ActivityTypes.COMMITTED_COMMIT,
-      label: 'Committed a commit'
-    },
-    {
-      key: ActivityTypes.REPORTED_COMMIT,
-      label: 'Reported a commit'
-    },
-    {
-      key: ActivityTypes.RESOLVED_COMMIT,
-      label: 'Resolved a commit'
-    },
-    {
-      key: ActivityTypes.SIGNEDOFF_COMMIT,
-      label: 'Signed off a commit'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/github.platform.ts
+++ b/frontend/app/config/platforms/configs/github.platform.ts
@@ -1,67 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const github: PlatformConfig = {
   key: ActivityPlatforms.GITHUB,
   label: 'GitHub',
   image: '/images/integrations/github.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.AUTHORED_COMMIT,
-      label: 'Authored a commit',
-    },
-    {
-      key: ActivityTypes.PULL_REQUEST_CLOSED,
-      label: 'Closed a pull request',
-    },
-    {
-      key: ActivityTypes.PULL_REQUEST_OPENED,
-      label: 'Opened a pull request',
-    },
-    {
-      key: ActivityTypes.PULL_REQUEST_COMMENT,
-      label: 'Commented on a pull request',
-    },
-    {
-      key: ActivityTypes.PULL_REQUEST_MERGED,
-      label: 'Merged a pull request',
-    },
-    {
-      key: ActivityTypes.PULL_REQUEST_REVIEW_REQUESTED,
-      label: 'Requested a review for a pull request',
-    },
-    {
-      key: ActivityTypes.PULL_REQUEST_REVIEW_THREAD_COMMENT,
-      label: 'Commented on a pull request review thread',
-    },
-    {
-      key: ActivityTypes.ISSUES_CLOSED,
-      label: 'Closed an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUES_OPENED,
-      label: 'Opened an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUE_COMMENT,
-      label: 'Commented on an issue',
-      isCollaborationType: true,
-    },
-
-    {
-      key: ActivityTypes.DISCUSSION_STARTED,
-      label: 'Started a discussion',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.DISCUSSION_COMMENT,
-      label: 'Commented on a discussion',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/gitlab.platform.ts
+++ b/frontend/app/config/platforms/configs/gitlab.platform.ts
@@ -1,52 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const gitlab: PlatformConfig = {
   key: ActivityPlatforms.GITLAB,
   label: 'GitLab',
   image: '/images/integrations/gitlab.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.ISSUES_OPENED,
-      label: 'Opened an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUES_CLOSED,
-      label: 'Closed an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.MERGE_REQUEST_CLOSED,
-      label: 'Closed a merge request',
-    },
-    {
-      key: ActivityTypes.MERGE_REQUEST_OPENED,
-      label: 'Opened a merge request',
-    },
-    {
-      key: ActivityTypes.MERGE_REQUEST_REVIEW_THREAD_COMMENT,
-      label: 'Commented on a merge request review thread',
-    },
-    {
-      key: ActivityTypes.MERGE_REQUEST_MERGED,
-      label: 'Merged a merge request',
-    },
-    {
-      key: ActivityTypes.MERGE_REQUEST_COMMENT,
-      label: 'Commented on a merge request',
-    },
-    {
-      key: ActivityTypes.ISSUE_COMMENT,
-      label: 'Commented on an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.AUTHORED_COMMIT,
-      label: 'Authored a commit',
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/groupsio.platform.ts
+++ b/frontend/app/config/platforms/configs/groupsio.platform.ts
@@ -1,18 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const groupsio: PlatformConfig = {
   key: ActivityPlatforms.GROUPS_IO,
   label: 'Groups.io',
   image: '/images/integrations/groupsio.svg',
-  activityTypes: [
-    {
-      key: ActivityTypes.MESSAGE,
-      label: 'Sent a message',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/hackernews.platform.ts
+++ b/frontend/app/config/platforms/configs/hackernews.platform.ts
@@ -1,21 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const hackernews: PlatformConfig = {
   key: ActivityPlatforms.HACKERNEWS,
   label: 'Hacker News',
   image: '/images/integrations/hackernews.svg',
-  activityTypes: [
-    {
-      key: ActivityTypes.POST,
-      label: 'Posted a post'
-    },
-    {
-      key: ActivityTypes.COMMENT,
-      label: 'Commented on a post'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/jira.platform.ts
+++ b/frontend/app/config/platforms/configs/jira.platform.ts
@@ -1,48 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const jira: PlatformConfig = {
   key: ActivityPlatforms.JIRA,
   label: 'Jira',
   image: '/images/integrations/jira.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.ISSUE_CREATED,
-      label: 'Created an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUES_CLOSED,
-      label: 'Closed an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUE_ASSIGNED,
-      label: 'Assigned an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUE_UPDATED,
-      label: 'Updated an issue',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUE_COMMENT_CREATED,
-      label: 'Created an issue comment',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUE_COMMENT_UPDATED,
-      label: 'Updated an issue comment',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ISSUE_ATTACHMENT_ADDED,
-      label: 'Added an attachment to an issue',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/linkedin.platform.ts
+++ b/frontend/app/config/platforms/configs/linkedin.platform.ts
@@ -1,17 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const linkedin: PlatformConfig = {
   key: ActivityPlatforms.LINKEDIN,
   label: 'LinkedIn',
   image: '/images/integrations/linkedin.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.COMMENT,
-      label: 'Commented on a post'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/reddit.platform.ts
+++ b/frontend/app/config/platforms/configs/reddit.platform.ts
@@ -1,21 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const reddit: PlatformConfig = {
   key: ActivityPlatforms.REDDIT,
   label: 'Reddit',
   image: '/images/integrations/reddit.svg',
-  activityTypes: [
-    {
-      key: ActivityTypes.POST,
-      label: 'Posted a post'
-    },
-    {
-      key: ActivityTypes.COMMENT,
-      label: 'Commented on a post'
-    }
-  ]
 };

--- a/frontend/app/config/platforms/configs/slack.platform.ts
+++ b/frontend/app/config/platforms/configs/slack.platform.ts
@@ -1,18 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const slack: PlatformConfig = {
   key: ActivityPlatforms.SLACK,
   label: 'Slack',
   image: '/images/integrations/slack.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.MESSAGE,
-      label: 'Sent a message',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/stackoverflow.platform.ts
+++ b/frontend/app/config/platforms/configs/stackoverflow.platform.ts
@@ -1,23 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms'
-import { ActivityTypes } from '~~/types/shared/activity-types'
 import type { PlatformConfig } from '~~/types/shared/platforms.types'
 
 export const stackoverflow: PlatformConfig = {
   key: ActivityPlatforms.STACKOVERFLOW,
   label: 'Stack Overflow',
   image: '/images/integrations/stackoverflow.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.QUESTION,
-      label: 'Asked a question',
-      isCollaborationType: true,
-    },
-    {
-      key: ActivityTypes.ANSWER,
-      label: 'Answered a question',
-      isCollaborationType: true,
-    },
-  ],
 }

--- a/frontend/app/config/platforms/configs/twitter.platform.ts
+++ b/frontend/app/config/platforms/configs/twitter.platform.ts
@@ -1,21 +1,10 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { ActivityPlatforms } from '~~/types/shared/activity-platforms';
-import { ActivityTypes } from '~~/types/shared/activity-types';
 import type { PlatformConfig } from '~~/types/shared/platforms.types';
 
 export const twitter: PlatformConfig = {
   key: ActivityPlatforms.TWITTER,
   label: 'X/Twitter',
   image: '/images/integrations/x.png',
-  activityTypes: [
-    {
-      key: ActivityTypes.HASHTAG,
-      label: 'Used a hashtag'
-    },
-    {
-      key: ActivityTypes.MENTION,
-      label: 'Mentioned a user'
-    }
-  ]
 };

--- a/frontend/server/api/project/[slug]/activity-types.get.ts
+++ b/frontend/server/api/project/[slug]/activity-types.get.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { createDataSource } from "~~/server/data/data-sources";
+import type { ActivityTypesFilter } from "~~/types/development/requests.types";
+import { getBooleanQueryParam } from "~~/server/utils/common";
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+  const project = (event.context.params as { slug: string }).slug;
+
+  const filter: ActivityTypesFilter = {
+    project,
+    repos: query?.repos ? (Array.isArray(query.repos) ? query.repos as string[] : [query.repos as string]) : undefined,
+    includeCodeContributions: getBooleanQueryParam(query, 'includeCodeContributions', true),
+    includeCollaborations: getBooleanQueryParam(query, 'includeCollaborations', false),
+    includeOtherContributions: getBooleanQueryParam(query, 'includeOtherContributions', false),
+  };
+
+  const dataSource = createDataSource();
+
+  return await dataSource.fetchActivityTypes(filter);
+});

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -69,14 +69,16 @@ import type {
   WaitTime1stReview,
   MergeLeadTime,
   CodeReviewEngagement,
-  ContributionOutsideHours
+  ContributionOutsideHours,
+  ActivityTypesByPlatformResponse
 } from "~~/types/development/responses.types";
-import type {CodeReviewEngagementFilter} from "~~/types/development/requests.types";
+import type {CodeReviewEngagementFilter, ActivityTypesFilter} from "~~/types/development/requests.types";
 import {fetchMailingListsMessageActivities} from "~~/server/data/tinybird/mailing-lists-messages-data-source";
 import {fetchCommitActivities} from "~~/server/data/tinybird/commit-activites-data-source";
 import {fetchPackages} from "~~/server/data/tinybird/packages-data-source";
 import {fetchPackageMetrics} from "~~/server/data/tinybird/package-metrics-data-source";
 import type {PackageDownloadsResponse} from "~~/server/data/tinybird/package-metrics-data-source";
+import {fetchActivityTypes} from "~~/server/data/tinybird/activity-types-data-source";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
@@ -103,6 +105,7 @@ export interface DataSource {
       => Promise<ContributionOutsideHours>;
     fetchPackages(filter: PackageFilter): Promise<Package[]>;
     fetchPackageMetrics(filter: PackageMetricsFilter): Promise<PackageDownloadsResponse>;
+    fetchActivityTypes(filter: ActivityTypesFilter): Promise<ActivityTypesByPlatformResponse>;
 }
 
 export function createDataSource(): DataSource {
@@ -130,5 +133,6 @@ export function createDataSource(): DataSource {
         fetchContributionsOutsideWorkHours,
         fetchPackages,
         fetchPackageMetrics,
+        fetchActivityTypes,
     };
 }

--- a/frontend/server/data/tinybird/activity-types-data-source.test.ts
+++ b/frontend/server/data/tinybird/activity-types-data-source.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import type {ActivityTypesFilter} from "~~/types/development/requests.types";
+import type {ActivityTypesTinybirdQuery} from "~~/server/data/tinybird/requests.types";
+
+const mockFetchFromTinybird = vi.fn();
+
+const mockTinybirdResponse = {
+  data: [
+    { platform: 'github', activityType: 'pull_request-opened', label: 'Opened a pull request' },
+    { platform: 'github', activityType: 'pull_request-merged', label: 'Merged a pull request' },
+    { platform: 'github', activityType: 'issue-comment', label: 'Commented on an issue' },
+    { platform: 'gitlab', activityType: 'merge_request-opened', label: 'Opened a merge request' },
+    { platform: 'gitlab', activityType: 'merge_request-merged', label: 'Merged a merge request' },
+    { platform: 'jira', activityType: 'issue-created', label: 'Created an issue' },
+    { platform: 'jira', activityType: 'issue-updated', label: 'Updated an issue' },
+  ]
+};
+
+const expectedGroupedResponse = {
+  github: [
+    { key: 'pull_request-opened', label: 'Opened a pull request' },
+    { key: 'pull_request-merged', label: 'Merged a pull request' },
+    { key: 'issue-comment', label: 'Commented on an issue' },
+  ],
+  gitlab: [
+    { key: 'merge_request-opened', label: 'Opened a merge request' },
+    { key: 'merge_request-merged', label: 'Merged a merge request' },
+  ],
+  jira: [
+    { key: 'issue-created', label: 'Created an issue' },
+    { key: 'issue-updated', label: 'Updated an issue' },
+  ]
+};
+
+describe('Activity Types Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('should fetch activity types with correct parameters and transform response', async () => {
+    const {fetchActivityTypes} = await import("~~/server/data/tinybird/activity-types-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockTinybirdResponse);
+
+    const filter: ActivityTypesFilter = {
+      project: 'test-project',
+      repos: ['test-repo'],
+      includeCodeContributions: true,
+      includeCollaborations: false,
+      includeOtherContributions: true,
+    };
+
+    const result = await fetchActivityTypes(filter);
+
+    const expectedQuery: ActivityTypesTinybirdQuery = {
+      project: 'test-project',
+      repos: ['test-repo'],
+      includeCodeContributions: true,
+      includeCollaborations: false,
+      includeOtherContributions: true,
+    };
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/activityTypes_by_project.json',
+      expectedQuery
+    );
+
+    expect(result).toEqual(expectedGroupedResponse);
+  });
+
+  test('should fetch activity types without optional parameters', async () => {
+    const {fetchActivityTypes} = await import("~~/server/data/tinybird/activity-types-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockTinybirdResponse);
+
+    const filter: ActivityTypesFilter = {
+      project: 'test-project'
+    };
+
+    const result = await fetchActivityTypes(filter);
+
+    const expectedQuery: ActivityTypesTinybirdQuery = {
+      project: 'test-project',
+      repos: undefined,
+      includeCodeContributions: undefined,
+      includeCollaborations: undefined,
+      includeOtherContributions: undefined,
+    };
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/activityTypes_by_project.json',
+      expectedQuery
+    );
+
+    expect(result).toEqual(expectedGroupedResponse);
+  });
+});

--- a/frontend/server/data/tinybird/activity-types-data-source.ts
+++ b/frontend/server/data/tinybird/activity-types-data-source.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { fetchFromTinybird } from "~~/server/data/tinybird/tinybird";
+import type { ActivityTypesFilter } from "~~/types/development/requests.types";
+import type { ActivityTypesByPlatformResponse } from "~~/types/development/responses.types";
+import type { ActivityTypesTinybirdQuery } from "~~/server/data/tinybird/requests.types";
+import type { TinybirdActivityTypesResponse } from "~~/server/data/tinybird/responses.types";
+
+export async function fetchActivityTypes(filter: ActivityTypesFilter): Promise<ActivityTypesByPlatformResponse> {
+  const query: ActivityTypesTinybirdQuery = {
+    project: filter.project,
+    repos: filter.repos,
+    includeCodeContributions: filter.includeCodeContributions,
+    includeCollaborations: filter.includeCollaborations,
+    includeOtherContributions: filter.includeOtherContributions,
+  };
+
+  const response = await fetchFromTinybird<TinybirdActivityTypesResponse>(
+    '/v0/pipes/activityTypes_by_project.json',
+    query
+  );
+
+  const activityTypesByPlatform: ActivityTypesByPlatformResponse = {};
+
+  for (const item of response.data) {
+    if (!activityTypesByPlatform[item.platform]) {
+      activityTypesByPlatform[item.platform] = [];
+    }
+
+    activityTypesByPlatform[item.platform].push({
+      key: item.activityType,
+      label: item.label,
+    });
+  }
+
+  return activityTypesByPlatform;
+}

--- a/frontend/server/data/tinybird/requests.types.ts
+++ b/frontend/server/data/tinybird/requests.types.ts
@@ -10,6 +10,7 @@ import type {Granularity} from "~~/types/shared/granularity";
  * They don't necessarily match the types that the frontend uses because they are only meant to be used with TinyBird.
  */
 
+
 export type ContributorsLeaderboardTinybirdQuery = {
   project: string;
   platform?: ActivityPlatforms;
@@ -77,4 +78,12 @@ export type ActivitiesCountTinybirdQuery = {
   includeCollaborations?: boolean;
   startDate?: DateTime;
   endDate?: DateTime;
+}
+
+export type ActivityTypesTinybirdQuery = {
+  project: string;
+  repos?: string[];
+  includeCodeContributions?: boolean;
+  includeCollaborations?: boolean;
+  includeOtherContributions?: boolean;
 }

--- a/frontend/server/data/tinybird/responses.types.ts
+++ b/frontend/server/data/tinybird/responses.types.ts
@@ -63,3 +63,11 @@ export type TinyBirdActivitiesCountDataItem = {
   endDate: string,
   activityCount?: number
 };
+
+export type TinybirdActivityTypeItem = {
+  platform: string;
+  activityType: string;
+  label: string;
+};
+
+export type TinybirdActivityTypesResponse = TinybirdActivityTypeItem[];

--- a/frontend/types/development/requests.types.ts
+++ b/frontend/types/development/requests.types.ts
@@ -29,3 +29,11 @@ export type ContributionsOutsideWorkHoursFilter = {
   startDate?: DateTime,
   endDate?: DateTime,
 };
+
+export type ActivityTypesFilter = {
+  project: string;
+  repos?: string[];
+  includeCodeContributions?: boolean;
+  includeCollaborations?: boolean;
+  includeOtherContributions?: boolean;
+};

--- a/frontend/types/development/responses.types.ts
+++ b/frontend/types/development/responses.types.ts
@@ -129,3 +129,12 @@ export interface WaitTime1stReview {
     waitTime: number;
   }[];
 }
+
+export interface ActivityTypeItem {
+  key: string;
+  label: string;
+}
+
+export type ActivityTypesByPlatformResponse = {
+  [platform: string]: ActivityTypeItem[];
+};

--- a/frontend/types/shared/platforms.types.ts
+++ b/frontend/types/shared/platforms.types.ts
@@ -1,14 +1,7 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-export interface ActivityType {
-  key: string
-  label: string
-  isCollaborationType?: boolean
-}
-
 export interface PlatformConfig {
   key: string
   label: string
   image: string
-  activityTypes: ActivityType[]
 }


### PR DESCRIPTION
In the widgets that currently support filtering by activity type (see image below for an example), we want to change the available options, so that activity types that do not exist for the displayed project are not shown as filter options.

<img width="752" height="554" alt="image" src="https://github.com/user-attachments/assets/3c2b3bb4-1dc6-4b7f-a352-eaa7804a25b7" />

This is hard-coded in the platform config files [here](https://github.com/linuxfoundation/insights/tree/58d116bac9b20cb77a14d4fb6b75377aeb073aa7/frontend/app/config/platforms/configs).

We want to change this so that only activity types that exist for the given project are shown - i.e. if a project has no github issues, this activity type should not be displayed in the dropdown as a filtering option.

In this PR we:
* create an API endpoint for the frontend to get this information;
* the corresponding Tinybird data source that fetches the required data;
* change the frontend so that it fetches the list of activity types to display from Tinybird (via the backend API), which filters them at the source based on the provided project and, optionally, repositories.

Since the activity types from the platforms config files are not necessary or even wanted anymore, they are also being removed.

This depends on my two other related PRs from crowd.dev to be merged and deployed first ([3488](https://github.com/CrowdDotDev/crowd.dev/pull/3488) and [3489](https://github.com/CrowdDotDev/crowd.dev/pull/3489)).

Jira tickets:
* [IN-511](https://linuxfoundation.atlassian.net/browse/IN-511) (for adding the backend endpoint)
* [IN-751](https://linuxfoundation.atlassian.net/browse/IN-751) (for modifying the frontend)

These were initially two separate PRs but to avoid some issues and make it easier to review (despite this way having more files in a single PR) I merged them into a single one, and so I'm closing #745 in favour of this one.

- `main` <!-- branch-stack -->
  - \#745
    - \#733 :point\_left:


[IN-511]: https://linuxfoundation.atlassian.net/browse/IN-511?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ