### PR TITLE
feat: provide a new endpoint with available activity types [IN-511]

### DIFF
--- a/frontend/server/api/project/[slug]/activity-types.get.ts
+++ b/frontend/server/api/project/[slug]/activity-types.get.ts
@@ -1,0 +1,22 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { createDataSource } from "~~/server/data/data-sources";
+import type { ActivityTypesFilter } from "~~/types/development/requests.types";
+import { getBooleanQueryParam } from "~~/server/utils/common";
+
+export default defineEventHandler(async (event) => {
+  const query = getQuery(event);
+  const project = (event.context.params as { slug: string }).slug;
+
+  const filter: ActivityTypesFilter = {
+    project,
+    repos: query?.repos ? (Array.isArray(query.repos) ? query.repos as string[] : [query.repos as string]) : undefined,
+    includeCodeContributions: getBooleanQueryParam(query, 'includeCodeContributions', true),
+    includeCollaborations: getBooleanQueryParam(query, 'includeCollaborations', false),
+    includeOtherContributions: getBooleanQueryParam(query, 'includeOtherContributions', false),
+  };
+
+  const dataSource = createDataSource();
+
+  return await dataSource.fetchActivityTypes(filter);
+});

--- a/frontend/server/data/data-sources.ts
+++ b/frontend/server/data/data-sources.ts
@@ -69,14 +69,16 @@ import type {
   WaitTime1stReview,
   MergeLeadTime,
   CodeReviewEngagement,
-  ContributionOutsideHours
+  ContributionOutsideHours,
+  ActivityTypesByPlatformResponse
 } from "~~/types/development/responses.types";
-import type {CodeReviewEngagementFilter} from "~~/types/development/requests.types";
+import type {CodeReviewEngagementFilter, ActivityTypesFilter} from "~~/types/development/requests.types";
 import {fetchMailingListsMessageActivities} from "~~/server/data/tinybird/mailing-lists-messages-data-source";
 import {fetchCommitActivities} from "~~/server/data/tinybird/commit-activites-data-source";
 import {fetchPackages} from "~~/server/data/tinybird/packages-data-source";
 import {fetchPackageMetrics} from "~~/server/data/tinybird/package-metrics-data-source";
 import type {PackageDownloadsResponse} from "~~/server/data/tinybird/package-metrics-data-source";
+import {fetchActivityTypes} from "~~/server/data/tinybird/activity-types-data-source";
 
 export interface DataSource {
     fetchActiveContributors: (filter: ActiveContributorsFilter) => Promise<ActiveContributorsResponse>;
@@ -103,6 +105,7 @@ export interface DataSource {
       => Promise<ContributionOutsideHours>;
     fetchPackages(filter: PackageFilter): Promise<Package[]>;
     fetchPackageMetrics(filter: PackageMetricsFilter): Promise<PackageDownloadsResponse>;
+    fetchActivityTypes(filter: ActivityTypesFilter): Promise<ActivityTypesByPlatformResponse>;
 }
 
 export function createDataSource(): DataSource {
@@ -130,5 +133,6 @@ export function createDataSource(): DataSource {
         fetchContributionsOutsideWorkHours,
         fetchPackages,
         fetchPackageMetrics,
+        fetchActivityTypes,
     };
 }

--- a/frontend/server/data/tinybird/activity-types-data-source.test.ts
+++ b/frontend/server/data/tinybird/activity-types-data-source.test.ts
@@ -1,0 +1,105 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import {
+  describe, test, expect, vi, beforeEach
+} from 'vitest';
+import type {ActivityTypesFilter} from "~~/types/development/requests.types";
+import type {ActivityTypesTinybirdQuery} from "~~/server/data/tinybird/requests.types";
+
+const mockFetchFromTinybird = vi.fn();
+
+const mockTinybirdResponse = {
+  data: [
+    { platform: 'github', activityType: 'pull_request-opened', label: 'Opened a pull request' },
+    { platform: 'github', activityType: 'pull_request-merged', label: 'Merged a pull request' },
+    { platform: 'github', activityType: 'issue-comment', label: 'Commented on an issue' },
+    { platform: 'gitlab', activityType: 'merge_request-opened', label: 'Opened a merge request' },
+    { platform: 'gitlab', activityType: 'merge_request-merged', label: 'Merged a merge request' },
+    { platform: 'jira', activityType: 'issue-created', label: 'Created an issue' },
+    { platform: 'jira', activityType: 'issue-updated', label: 'Updated an issue' },
+  ]
+};
+
+const expectedGroupedResponse = {
+  github: [
+    { key: 'pull_request-opened', label: 'Opened a pull request' },
+    { key: 'pull_request-merged', label: 'Merged a pull request' },
+    { key: 'issue-comment', label: 'Commented on an issue' },
+  ],
+  gitlab: [
+    { key: 'merge_request-opened', label: 'Opened a merge request' },
+    { key: 'merge_request-merged', label: 'Merged a merge request' },
+  ],
+  jira: [
+    { key: 'issue-created', label: 'Created an issue' },
+    { key: 'issue-updated', label: 'Updated an issue' },
+  ]
+};
+
+describe('Activity Types Data Source', () => {
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    vi.doMock(import("./tinybird"), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('should fetch activity types with correct parameters and transform response', async () => {
+    const {fetchActivityTypes} = await import("~~/server/data/tinybird/activity-types-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockTinybirdResponse);
+
+    const filter: ActivityTypesFilter = {
+      project: 'test-project',
+      repos: ['test-repo'],
+      includeCodeContributions: true,
+      includeCollaborations: false,
+      includeOtherContributions: true,
+    };
+
+    const result = await fetchActivityTypes(filter);
+
+    const expectedQuery: ActivityTypesTinybirdQuery = {
+      project: 'test-project',
+      repos: ['test-repo'],
+      includeCodeContributions: true,
+      includeCollaborations: false,
+      includeOtherContributions: true,
+    };
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/activityTypes_by_project.json',
+      expectedQuery
+    );
+
+    expect(result).toEqual(expectedGroupedResponse);
+  });
+
+  test('should fetch activity types without optional parameters', async () => {
+    const {fetchActivityTypes} = await import("~~/server/data/tinybird/activity-types-data-source");
+
+    mockFetchFromTinybird.mockResolvedValueOnce(mockTinybirdResponse);
+
+    const filter: ActivityTypesFilter = {
+      project: 'test-project'
+    };
+
+    const result = await fetchActivityTypes(filter);
+
+    const expectedQuery: ActivityTypesTinybirdQuery = {
+      project: 'test-project',
+      repos: undefined,
+      includeCodeContributions: undefined,
+      includeCollaborations: undefined,
+      includeOtherContributions: undefined,
+    };
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/activityTypes_by_project.json',
+      expectedQuery
+    );
+
+    expect(result).toEqual(expectedGroupedResponse);
+  });
+});

--- a/frontend/server/data/tinybird/activity-types-data-source.ts
+++ b/frontend/server/data/tinybird/activity-types-data-source.ts
@@ -1,0 +1,37 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { fetchFromTinybird } from "~~/server/data/tinybird/tinybird";
+import type { ActivityTypesFilter } from "~~/types/development/requests.types";
+import type { ActivityTypesByPlatformResponse } from "~~/types/development/responses.types";
+import type { ActivityTypesTinybirdQuery } from "~~/server/data/tinybird/requests.types";
+import type { TinybirdActivityTypesResponse } from "~~/server/data/tinybird/responses.types";
+
+export async function fetchActivityTypes(filter: ActivityTypesFilter): Promise<ActivityTypesByPlatformResponse> {
+  const query: ActivityTypesTinybirdQuery = {
+    project: filter.project,
+    repos: filter.repos,
+    includeCodeContributions: filter.includeCodeContributions,
+    includeCollaborations: filter.includeCollaborations,
+    includeOtherContributions: filter.includeOtherContributions,
+  };
+
+  const response = await fetchFromTinybird<TinybirdActivityTypesResponse>(
+    '/v0/pipes/activityTypes_by_project.json',
+    query
+  );
+
+  const activityTypesByPlatform: ActivityTypesByPlatformResponse = {};
+
+  for (const item of response.data) {
+    if (!activityTypesByPlatform[item.platform]) {
+      activityTypesByPlatform[item.platform] = [];
+    }
+
+    activityTypesByPlatform[item.platform].push({
+      key: item.activityType,
+      label: item.label,
+    });
+  }
+
+  return activityTypesByPlatform;
+}

--- a/frontend/server/data/tinybird/requests.types.ts
+++ b/frontend/server/data/tinybird/requests.types.ts
@@ -10,6 +10,7 @@ import type {Granularity} from "~~/types/shared/granularity";
  * They don't necessarily match the types that the frontend uses because they are only meant to be used with TinyBird.
  */
 
+
 export type ContributorsLeaderboardTinybirdQuery = {
   project: string;
   platform?: ActivityPlatforms;
@@ -77,4 +78,12 @@ export type ActivitiesCountTinybirdQuery = {
   includeCollaborations?: boolean;
   startDate?: DateTime;
   endDate?: DateTime;
+}
+
+export type ActivityTypesTinybirdQuery = {
+  project: string;
+  repos?: string[];
+  includeCodeContributions?: boolean;
+  includeCollaborations?: boolean;
+  includeOtherContributions?: boolean;
 }

--- a/frontend/server/data/tinybird/responses.types.ts
+++ b/frontend/server/data/tinybird/responses.types.ts
@@ -63,3 +63,11 @@ export type TinyBirdActivitiesCountDataItem = {
   endDate: string,
   activityCount?: number
 };
+
+export type TinybirdActivityTypeItem = {
+  platform: string;
+  activityType: string;
+  label: string;
+};
+
+export type TinybirdActivityTypesResponse = TinybirdActivityTypeItem[];

--- a/frontend/types/development/requests.types.ts
+++ b/frontend/types/development/requests.types.ts
@@ -29,3 +29,11 @@ export type ContributionsOutsideWorkHoursFilter = {
   startDate?: DateTime,
   endDate?: DateTime,
 };
+
+export type ActivityTypesFilter = {
+  project: string;
+  repos?: string[];
+  includeCodeContributions?: boolean;
+  includeCollaborations?: boolean;
+  includeOtherContributions?: boolean;
+};

--- a/frontend/types/development/responses.types.ts
+++ b/frontend/types/development/responses.types.ts
@@ -129,3 +129,12 @@ export interface WaitTime1stReview {
     waitTime: number;
   }[];
 }
+
+export interface ActivityTypeItem {
+  key: string;
+  label: string;
+}
+
+export type ActivityTypesByPlatformResponse = {
+  [platform: string]: ActivityTypeItem[];
+};

--- a/frontend/types/shared/platforms.types.ts
+++ b/frontend/types/shared/platforms.types.ts
@@ -1,14 +1,7 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-export interface ActivityType {
-  key: string
-  label: string
-  isCollaborationType?: boolean
-}
-
 export interface PlatformConfig {
   key: string
   label: string
   image: string
-  activityTypes: ActivityType[]
 }


### PR DESCRIPTION
In the widgets that currently support filtering by activity type (see image below for an example), we want to change the available options, so that activity types that do not exist for the displayed project are not shown as filter options.

<img width="752" height="554" alt="image" src="https://github.com/user-attachments/assets/3c2b3bb4-1dc6-4b7f-a352-eaa7804a25b7" />

This PR creates an API endpoint for the frontend to get this information, and the corresponding Tinybird data source that fetches the required data.

[Jira ticket](https://linuxfoundation.atlassian.net/browse/IN-511)

- `main` <!-- branch-stack -->
  - \#745 :point\_left:
    - \#733
