### PR TITLE
chore: refactor the api calls in the collections list and the collection page

### DIFF
--- a/frontend/app/components/modules/collection/services/collections.api.service.ts
+++ b/frontend/app/components/modules/collection/services/collections.api.service.ts
@@ -1,47 +1,131 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import type { QueryFunction } from '@tanstack/vue-query';
-import type { Pagination } from '~~/types/shared/pagination';
-import type { Collection } from '~~/types/collection';
-import type { Category, CategoryGroup } from '~~/types/category';
+import { type QueryFunction, useInfiniteQuery, useQuery, useQueryClient } from '@tanstack/vue-query'
+import { type ComputedRef, computed } from 'vue'
+import type { Pagination } from '~~/types/shared/pagination'
+import type { Collection } from '~~/types/collection'
+import type { Category, CategoryGroup } from '~~/types/category'
+import { TanstackKey } from '~/components/shared/types/tanstack'
 
 export interface CategoryGroupOptions {
-  value: string;
-  categories: Category[];
-  id: string;
-  name: string;
+  value: string
+  categories: Category[]
+  id: string
+  name: string
 }
+
+export interface QueryParams {
+  pageSize: number
+  sort: string
+  categories: string
+}
+
+export interface CategoryGroupsQueryParams {
+  type: 'vertical' | 'horizontal'
+  pageSize: number
+}
+
 class CollectionsApiService {
-  fetchCollectionList(
-      query: Record<string, string | number | string[] | undefined>
-  ): Promise<Pagination<Collection>> {
-    return $fetch('/api/collection', {
-      params: query,
-    });
+  async prefetchCollections(params: ComputedRef<QueryParams>) {
+    const queryClient = useQueryClient()
+    const queryKey = computed(() => [
+      TanstackKey.COLLECTIONS,
+      params.value.sort,
+      params.value.categories,
+    ])
+
+    const queryFn = this.fetchCollectionsQueryFn(() => ({
+      ...params.value,
+    }))
+
+    return await queryClient.prefetchInfiniteQuery<
+      Pagination<Collection>,
+      Error,
+      Pagination<Collection>,
+      readonly unknown[],
+      number
+    >({
+      queryKey,
+      queryFn,
+      initialPageParam: 0,
+      getNextPageParam: this.getNextPageCollectionsParam,
+    })
   }
 
-  fetchCollections(
-    query: () => Record<string, string | number | string[] | undefined>
-  ): QueryFunction<Pagination<Collection>> {
-    return async ({ pageParam = 0 }) => await $fetch('/api/collection', {
+  getNextPageCollectionsParam(lastPage: Pagination<Collection>) {
+    const nextPage = lastPage.page + 1
+    const totalPages = Math.ceil(lastPage.total / lastPage.pageSize)
+    return nextPage < totalPages ? nextPage : null
+  }
+
+  fetchCollections(params: ComputedRef<QueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.COLLECTIONS,
+      params.value.sort,
+      params.value.categories,
+    ])
+
+    const queryFn = this.fetchCollectionsQueryFn(() => ({
+      ...params.value,
+    }))
+
+    return useInfiniteQuery<
+      Pagination<Collection>,
+      Error,
+      Pagination<Collection>,
+      readonly unknown[],
+      number
+    >({
+      queryKey,
+      queryFn,
+      getNextPageParam: this.getNextPageCollectionsParam,
+      initialPageParam: 0,
+    })
+  }
+
+  fetchCollectionsQueryFn(
+    query: () => Record<string, string | number | string[] | undefined>,
+  ): QueryFunction<Pagination<Collection>, readonly unknown[], number> {
+    return async ({ pageParam = 0 }) =>
+      await $fetch('/api/collection', {
         params: {
           page: pageParam,
           ...query(),
         },
-      });
+      })
   }
 
   fetchCollection(slug: string): QueryFunction<Collection> {
-    return () => $fetch(`/api/collection/${slug}`);
+    return () => $fetch(`/api/collection/${slug}`)
   }
 
-  fetchCategoryGroups(
-    query: () => Record<string, string | number>
+  fetchCategoryGroups(params: ComputedRef<CategoryGroupsQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.CATEGORY_GROUPS,
+      params.value.type,
+      params.value.pageSize,
+    ])
+
+    const queryFn = computed<QueryFunction<Pagination<CategoryGroup>>>(() =>
+      this.fetchCategoryGroupsQueryFn(() => ({
+        ...params.value,
+      })),
+    )
+
+    return useQuery<Pagination<CategoryGroup>, Error>({
+      queryKey,
+      queryFn,
+    })
+  }
+
+  fetchCategoryGroupsQueryFn(
+    query: () => Record<string, string | number>,
   ): QueryFunction<Pagination<CategoryGroup>> {
-    return () => $fetch(`/api/category`, {
+    return () =>
+      $fetch(`/api/category`, {
         params: query(),
-      });
+      })
   }
 }
 
-export const COLLECTIONS_API_SERVICE = new CollectionsApiService();
+export const COLLECTIONS_API_SERVICE = new CollectionsApiService()

--- a/frontend/app/components/modules/project/services/project.api.service.ts
+++ b/frontend/app/components/modules/project/services/project.api.service.ts
@@ -1,22 +1,93 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import type {QueryFunction} from "@tanstack/vue-query";
-import type {Pagination} from "~~/types/shared/pagination";
-import type {Project} from "~~/types/project";
+import { type QueryFunction, useInfiniteQuery, useQueryClient } from '@tanstack/vue-query'
+import { type ComputedRef, computed } from 'vue'
+import type { Pagination } from '~~/types/shared/pagination'
+import type { Project } from '~~/types/project'
+import { TanstackKey } from '~/components/shared/types/tanstack'
 
-class ProjectApiService {
-    fetchProjects(query: () => Record<string, string | number | boolean>): QueryFunction<Pagination<Project>> {
-        return async ({ pageParam = 0 }) => await $fetch('/api/project', {
-                params: {
-                    page: pageParam,
-                   ...query()
-                },
-            })
-    }
-
-    fetchProject(slug: string): QueryFunction<Project> {
-        return () => $fetch(`/api/project/${slug}`);
-    }
+export interface ProjectsQueryParams {
+  sort: string
+  pageSize: number
+  isLF: boolean
+  collectionSlug: string
 }
 
-export const PROJECT_API_SERVICE = new ProjectApiService();
+class ProjectApiService {
+  async prefetchProjects(params: ComputedRef<ProjectsQueryParams>) {
+    const queryClient = useQueryClient()
+    const queryKey = computed(() => [
+      TanstackKey.PROJECTS,
+      params.value.sort,
+      params.value.isLF,
+      params.value.collectionSlug,
+      params.value.pageSize,
+    ])
+
+    const queryFn = this.fetchProjectsQueryFn(() => ({
+      ...params.value,
+    }))
+
+    return await queryClient.prefetchInfiniteQuery<
+      Pagination<Project>,
+      Error,
+      Pagination<Project>,
+      readonly unknown[],
+      number
+    >({
+      queryKey,
+      queryFn,
+      initialPageParam: 0,
+      getNextPageParam: this.getNextPageProjectsParam,
+    })
+  }
+
+  getNextPageProjectsParam(lastPage: Pagination<Project>) {
+    const nextPage = lastPage.page + 1
+    const totalPages = Math.ceil(lastPage.total / lastPage.pageSize)
+    return nextPage < totalPages ? nextPage : undefined
+  }
+  fetchProjects(params: ComputedRef<ProjectsQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.PROJECTS,
+      params.value.sort,
+      params.value.isLF,
+      params.value.collectionSlug,
+      params.value.pageSize,
+    ])
+
+    const queryFn = this.fetchProjectsQueryFn(() => ({
+      ...params.value,
+    }))
+
+    return useInfiniteQuery<
+      Pagination<Project>,
+      Error,
+      Pagination<Project>,
+      readonly unknown[],
+      number
+    >({
+      queryKey,
+      queryFn,
+      getNextPageParam: this.getNextPageProjectsParam,
+      initialPageParam: 0,
+    })
+  }
+  fetchProjectsQueryFn(
+    query: () => Record<string, string | number | boolean>,
+  ): QueryFunction<Pagination<Project>, readonly unknown[], number> {
+    return async ({ pageParam = 0 }) =>
+      await $fetch('/api/project', {
+        params: {
+          page: pageParam,
+          ...query(),
+        },
+      })
+  }
+
+  fetchProject(slug: string): QueryFunction<Project> {
+    return () => $fetch(`/api/project/${slug}`)
+  }
+}
+
+export const PROJECT_API_SERVICE = new ProjectApiService()


### PR DESCRIPTION
## In this PR

Refactored the api calls on the collections list and the collections details page. Those 2 components no longer imports anything from Tanstack and all the fetching and caching related plugins and calls are moved to the services.

## Ticket
[IN-779](https://linuxfoundation.atlassian.net/browse/IN-779)

[IN-779]: https://linuxfoundation.atlassian.net/browse/IN-779?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ