### PR TITLE
chore: plausible projects api

### DIFF
--- a/frontend/server/api/project/[slug]/insights.get.ts
+++ b/frontend/server/api/project/[slug]/insights.get.ts
@@ -19,8 +19,14 @@ export default defineEventHandler(async (event) => {
       slug,
     });
 
-    useApiTrackEvent(event, 'project-insights-api', `/api/project/${slug}/insights`, {
-      props: { project: slug },
+    useApiTrackEvent({
+      event,
+      eventName: 'project-insights-api',
+      url: `/project/${slug}`,
+      referer: `https://www.cncf.io/projects/${slug}`,
+      options: {
+        props: { project: slug },
+      },
     });
 
     return response.data?.[0];

--- a/frontend/server/utils/plausible.ts
+++ b/frontend/server/utils/plausible.ts
@@ -21,12 +21,19 @@ interface TrackEventOptions {
  *   props: { project: 'foo' }
  * })
  */
-export function useApiTrackEvent(
-  event: H3Event,
-  eventName: string,
-  url: string,
-  options?: TrackEventOptions,
-) {
+export function useApiTrackEvent({
+  event,
+  eventName,
+  url,
+  options,
+  referer,
+}: {
+  event: H3Event;
+  eventName: string;
+  url: string;
+  referer: string;
+  options?: TrackEventOptions;
+}) {
   const config = useRuntimeConfig();
 
   // Only track in production
@@ -51,6 +58,7 @@ export function useApiTrackEvent(
     body: {
       name: eventName,
       url: `${config.public.appUrl}${url}`,
+      referer,
       domain: 'insights.linuxfoundation.org',
       props: options?.props,
     },


### PR DESCRIPTION
Fixing the custom event call to the plausible api to be considered a pageview instead of a custom event.
It's following the recommendations on https://plausible.io/docs/events-api