### PR TITLE
fix: security tabs with 1 repo filter

### DIFF
--- a/frontend/app/components/modules/project/services/security.api.service.ts
+++ b/frontend/app/components/modules/project/services/security.api.service.ts
@@ -17,8 +17,12 @@ class SecurityApiService {
       params.value.projectSlug,
       params.value.repos,
     ]);
-
-    const queryFn = this.securityAssessmentQueryFn(params);
+    const queryFn = computed<QueryFunction<SecurityData[]>>(() =>
+      this.securityAssessmentQueryFn(() => ({
+        projectSlug: params.value.projectSlug,
+        repos: params.value.repos,
+      })),
+    );
 
     return useQuery<SecurityData[]>({
       queryKey,
@@ -27,15 +31,15 @@ class SecurityApiService {
   }
 
   securityAssessmentQueryFn(
-    params: ComputedRef<SecurityAssessmentQueryParams>,
+    query: () => Record<string, string | number | boolean | undefined | string[] | null>,
   ): QueryFunction<SecurityData[]> {
-    return async () => {
-      const { projectSlug, repos } = params.value;
-
-      return await $fetch(`/api/project/${projectSlug}/security/assessment`, {
-        params: { repos },
+    const { projectSlug, repos } = query();
+    return async () =>
+      await $fetch(`/api/project/${projectSlug}/security/assessment`, {
+        params: {
+          repos,
+        },
       });
-    };
   }
 }
 


### PR DESCRIPTION
### Issue
In the security tab, when the user filtered by 1 repo, we were rendering the results for all repos resulting in a list of thousands of results for each assessment. The problem was because the api call was not being called after the repo was selected, and therefore was being called for all repos. This was caused by the method not responding properly to the params reactivity

### Summary

This PR updates the queryFn method to a computed property to be able to respond to the changes of `params`. Other api services were already following this approach and not the security one.
