### PR TITLE
docs: add email to collected data points

### DIFF
--- a/frontend/docs/introduction/maintainers/index.md
+++ b/frontend/docs/introduction/maintainers/index.md
@@ -36,7 +36,7 @@ Our automated system:
 From maintainer files, we extract:
 
 - **GitHub usernames** of maintainers.
-- **Display names** and contact information.
+- **Display names** and contact information including email addresses when available.
 - **Roles and titles** (e.g., "Lead Maintainer", "Core Developer", "Security Lead").
 - **Organizational affiliations** when available.
 


### PR DESCRIPTION
This pull request makes a minor update to the documentation for maintainers, clarifying the types of contact information extracted by the automated system.

* Updated the description in `frontend/docs/introduction/maintainers/index.md` to specify that email addresses are included in the contact information extracted for maintainers.