### PR TITLE
feat: make first commit linkable and add birthday celebration 

### DIFF
--- a/frontend/app/components/modules/project/components/overview/about-section/about-software-value.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section/about-software-value.vue
@@ -14,8 +14,26 @@ SPDX-License-Identifier: MIT
     class="flex flex-col gap-2 text-xs"
   >
     <div class="text-neutral-400 font-semibold">First commit</div>
-    <div class="text-neutral-900">
-      {{ formatFirstCommit(project.firstCommit) }}
+    <div class="text-neutral-900 flex items-center gap-2">
+      <a
+        v-if="project.repositories?.[0]?.url"
+        :href="project.repositories[0].url"
+        target="_blank"
+        rel="noopener noreferrer"
+        class="hover:underline text-primary-500"
+      >
+        {{ formatFirstCommit(project.firstCommit) }}
+      </a>
+      <span v-else>
+        {{ formatFirstCommit(project.firstCommit) }}
+      </span>
+      <span
+        v-if="isBirthday(project.firstCommit)"
+        class="animate-bounce text-lg cursor-help"
+        title="Happy Birthday!"
+      >
+        🎈
+      </span>
     </div>
   </div>
   <div class="flex flex-col gap-2 text-xs">
@@ -78,6 +96,12 @@ const { project } = storeToRefs(useProjectStore());
 const formatFirstCommit = (date: string) => {
   const dt = DateTime.fromSQL(date);
   return dt.toFormat('LLLL yyyy');
+};
+
+const isBirthday = (date: string) => {
+  const dt = DateTime.fromSQL(date);
+  const now = DateTime.now();
+  return dt.month === now.month && dt.day === now.day;
 };
 </script>
 


### PR DESCRIPTION
## Description
This PR addresses issue #1436 by making the "First Commit" date in the project overview linkable and adding a celebratory animation for the project's birthday.

## Changes
- **Linkable First Commit**: The "First Commit" date now links to the project's repository URL (if available).
- **Birthday Celebration**: Added logic to check if today matches the month and day of the first commit. If it does, a bouncing balloon is displayed next to the date.

## Verification
- Verified that the date is clickable and opens the repository URL.
- Verified that the balloon icon appears on the correct date (tested by mocking the date).

Fixes #1436