### PR TITLE
feat: use Kustomize for deploying to K8s

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -1,0 +1,6 @@
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true
+  }
+}

--- a/docs/k8s-migration.md
+++ b/docs/k8s-migration.md
@@ -1,0 +1,38 @@
+# Kubernetes Migration Prerequisites & Tooling Checklist
+
+This checklist captures the pre-flight requirements for consolidating Insights Kubernetes manifests into the `insights/k8s` tree and enabling Kustomize-driven deployments.
+
+## Access & Credentials
+
+- [ ] OCI tenancy access with permissions to read Oracle Secrets Vault entries for staging and production environments.
+- [ ] kubectl contexts configured for `insights-staging` and `insights-production` clusters (verify via `kubectl config get-contexts`).
+- [ ] GitHub access tokens with rights to push branches and update CI workflows in this repository.
+- [ ] Crowd-kube repository checked out for reference to existing manifests and scripts.
+
+## Tooling Baseline
+
+- [ ] `kustomize` v5.x installed locally and in CI runner images.
+- [ ] `kubectl` v1.34.x available for local validation and automated pipelines (built-in `-k`/`kustomize` support).
+- [ ] `kubeconform` installed for schema validation of rendered manifests.
+- [ ] `conftest` (OPA) installed with policy bundle for manifest compliance checks.
+- [ ] `oci` CLI configured for secret verification workflows.
+
+## Environment Snapshots & References
+
+- [ ] Production manifest snapshot captured at `insights/k8s/reference/production-manifests.yaml`.
+- [ ] Staging manifest snapshot (if needed) captured for regression comparison.
+- [ ] Existing `.env.enc` secret references documented with corresponding Oracle Vault secret OCIDs.
+
+## Pipeline & Observability
+
+- [ ] GitHub Actions runner images updated to include required tooling versions.
+- [ ] Observability dashboards prepared to ingest render/deploy duration metrics from the new validation pipeline.
+- [ ] Alerting thresholds agreed (render + validation <2 minutes; full deploy <=30 minutes; secret sync overhead <1 minute).
+
+## Approvals & Communication
+
+- [ ] Platform maintainers sign off on migration plan and cutover timeline.
+- [ ] Security team acknowledges secrets-handling changes and audit requirements.
+- [ ] Release management informed about temporary deployment freeze during final cutover window.
+
+Mark each item as completed before beginning the foundational implementation phase.

--- a/docs/runbooks/secret-rotation.md
+++ b/docs/runbooks/secret-rotation.md
@@ -1,0 +1,42 @@
+# Secret Rotation Runbook (Oracle Cloud Secrets Vault → Kubernetes)
+
+## Purpose
+Ensure application configuration secrets stored in Oracle Cloud Secrets Vault are
+safely synchronized into the Insights Kubernetes clusters without committing
+secret material to source control.
+
+## Prerequisites
+- OCI CLI configured with permissions to read the required Vault secrets.
+- kubectl v1.34.x pointing at the target cluster/context.
+- jq installed (used by the helper script).
+
+## Rotation Steps
+1. Update the secret payload in Oracle Cloud Secrets Vault via console or CLI.
+2. Run the helper script from repository root:
+   ```bash
+   ./insights/k8s/tests/secret-rotation.sh \
+     --vault-secret-id <OCID_FROM_VAULT> \
+     --secret-name insights-runtime \
+     --namespace insights
+   ```
+3. The script fetches the CURRENT stage, writes `stringData` into the
+   `insights-runtime` Kubernetes Secret, and restarts dependent deployments
+   (`insights-app-dpl`, `package-downloads-worker-dpl`, `search-volume-worker-dpl`).
+4. Verify rollout status for each deployment finishes successfully.
+5. Confirm new configuration values are in effect (e.g., check application
+   endpoints).
+
+## Audit & Logging
+- OCI audit logs capture secret reads; review them after rotation.
+- Kubernetes events show Secret updates and rollout restarts.
+
+## Rollback
+- Re-run the script with the OCID of the previous secret version (use the OCI
+  console to locate the version).
+- If rollout fails, use `kubectl rollout undo deployment/<name>` for each
+  affected deployment.
+
+## Scheduled Rotations
+- SecretSync CRD (`insights/k8s/secrets/mappings.yaml`) refreshes automatically
+  every 15 minutes. The manual script exists for ad-hoc rotations or validation
+  drills.

--- a/k8s/base/README.md
+++ b/k8s/base/README.md
@@ -1,0 +1,28 @@
+# Insights Kubernetes Base
+
+The `insights/k8s/base` package contains the shared Kubernetes resources for the Insights application. All environment overlays inherit from this directory to guarantee staging and production remain in sync.
+
+## Directory Layout
+
+- `kustomization.yaml` – root manifest listing shared resources and enforcing the `insights` namespace.
+- `config/` – cluster-scoped configuration such as the namespace definition.
+- `deployments/` – Deployments for the web app, Redis, and worker processes.
+- `services/` – ClusterIP Services exposing shared workloads.
+- `ingress/` – Ingress definitions routing traffic to the application service.
+
+## Authoring Guidelines
+
+1. Make changes in this base directory first. Overlays should only introduce environment-specific patches (domains, replica counts, feature flags).
+2. Avoid embedding sensitive values directly in manifests; use secrets sourced from Oracle Cloud Secrets Vault.
+3. Run `kubectl kustomize insights/k8s/base | kubeconform -summary` before opening a pull request. CI will enforce the same checks.
+4. Document any new shared resource or convention in this README to assist other contributors.
+
+## Validation
+
+Use the validation harness:
+
+```bash
+./insights/k8s/tests/render-validate.sh
+```
+
+The script renders the base, validates schemas, runs policy checks, and writes overlay diffs for inspection.

--- a/k8s/base/config/namespace.yaml
+++ b/k8s/base/config/namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: insights

--- a/k8s/base/deployments/insights-app.yaml
+++ b/k8s/base/deployments/insights-app.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights-app-dpl
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: insights-app
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insights-app
+  template:
+    metadata:
+      labels:
+        app: insights-app
+    spec:
+      nodeSelector:
+        name: pg-insights
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: insights
+          effect: NoSchedule
+      imagePullSecrets:
+        - name: ocir-secret
+      containers:
+        - name: frontend
+          image: sjc.ocir.io/axbydjxa5zuh/insights-app:2
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              port: 3000
+              path: /api/health/live
+          livenessProbe:
+            httpGet:
+              port: 3000
+              path: /api/health/live

--- a/k8s/base/deployments/package-downloads-worker.yaml
+++ b/k8s/base/deployments/package-downloads-worker.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: package-downloads-worker-dpl
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: package-downloads-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: package-downloads-worker
+  template:
+    metadata:
+      labels:
+        app: package-downloads-worker
+    spec:
+      nodeSelector:
+        name: pg-insights
+      imagePullSecrets:
+        - name: ocir-secret
+      containers:
+        - name: package-downloads-worker
+          image: sjc.ocir.io/axbydjxa5zuh/package-downloads-worker:1750147302.2d64686
+          workingDir: /usr/insights/app/workers/temporal/package_downloads_worker
+          command:
+            - pnpm
+          args:
+            - run
+            - start
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+          env:
+            - name: KUBE_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP

--- a/k8s/base/deployments/redis.yaml
+++ b/k8s/base/deployments/redis.yaml
@@ -1,0 +1,29 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-dpl
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      nodeSelector:
+        name: pg-insights-redis
+      containers:
+        - name: redis
+          image: crowddotdev/redis:1668671743.d99338c4
+          command:
+            - redis-server
+          args:
+            - /redis.conf
+            - --requirepass
+            - V434DbYua628UmgD8BHxiCuMNXxXu4kD
+          ports:
+            - containerPort: 6379

--- a/k8s/base/deployments/search-volume-worker.yaml
+++ b/k8s/base/deployments/search-volume-worker.yaml
@@ -1,0 +1,38 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-volume-worker-dpl
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: search-volume-worker
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-volume-worker
+  template:
+    metadata:
+      labels:
+        app: search-volume-worker
+    spec:
+      nodeSelector:
+        name: pg-insights
+      imagePullSecrets:
+        - name: ocir-secret
+      containers:
+        - name: search-volume-worker
+          image: sjc.ocir.io/axbydjxa5zuh/insights-search-volume-worker:1752680491.4e4905d
+          workingDir: /insights-search-volume-app/workers/temporal/search_volume_worker
+          command:
+            - pnpm
+          args:
+            - run
+            - start
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+          env:
+            - name: KUBE_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP

--- a/k8s/base/ingress/insights.yaml
+++ b/k8s/base/ingress/insights.yaml
@@ -1,0 +1,40 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: insights
+  labels:
+    name: ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+spec:
+  tls:
+    - hosts:
+        - insights.production.lfx.dev
+        - insights.linuxfoundation.org
+      secretName: letsencrypt-production
+  rules:
+    - host: insights.production.lfx.dev
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: insights-app-svc
+                port:
+                  number: 3000
+    - host: insights.linuxfoundation.org
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: insights-app-svc
+                port:
+                  number: 3000

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -1,0 +1,12 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - config/namespace.yaml
+  - secrets/operator.yaml
+  - deployments/insights-app.yaml
+  - deployments/package-downloads-worker.yaml
+  - deployments/search-volume-worker.yaml
+  - deployments/redis.yaml
+  - services/insights-app.yaml
+  - services/redis.yaml
+  - ingress/insights.yaml

--- a/k8s/base/secrets/operator.yaml
+++ b/k8s/base/secrets/operator.yaml
@@ -1,0 +1,70 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: oci-secrets-operator
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: oci-secrets-operator
+  namespace: oci-secrets-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: oci-secrets-operator
+rules:
+  - apiGroups: [""]
+    resources: ["secrets"]
+    verbs: ["get", "list", "watch", "create", "update", "patch"]
+  - apiGroups: ["secrets.oracle.com"]
+    resources: ["secretsyncs", "secretsyncs/status"]
+    verbs: ["*" ]
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: oci-secrets-operator
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: oci-secrets-operator
+subjects:
+  - kind: ServiceAccount
+    name: oci-secrets-operator
+    namespace: oci-secrets-operator
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: oci-secrets-operator
+  namespace: oci-secrets-operator
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: oci-secrets-operator
+  template:
+    metadata:
+      labels:
+        app: oci-secrets-operator
+    spec:
+      serviceAccountName: oci-secrets-operator
+      containers:
+        - name: controller
+          image: ghcr.io/oracle/oci-secrets-operator:1.0.0
+          args:
+            - "--leader-elect=true"
+          env:
+            - name: WATCH_NAMESPACE
+              value: "insights"
+            - name: METRICS_BIND_ADDRESS
+              value: ":8080"
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi

--- a/k8s/base/services/insights-app.yaml
+++ b/k8s/base/services/insights-app.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: insights-app-svc
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: insights-app
+spec:
+  type: ClusterIP
+  selector:
+    app: insights-app
+  ports:
+    - port: 3000
+      targetPort: 3000

--- a/k8s/base/services/redis.yaml
+++ b/k8s/base/services/redis.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-svc
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: redis
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379

--- a/k8s/overlays/production/deployment-env.yaml
+++ b/k8s/overlays/production/deployment-env.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights-app-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: frontend
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+            - secretRef:
+                name: insights-runtime
+          env:
+            - name: BACKEND_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: BACKEND_ENV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: package-downloads-worker-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: package-downloads-worker
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+            - secretRef:
+                name: insights-runtime
+          env:
+            - name: BACKEND_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: BACKEND_ENV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-volume-worker-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: search-volume-worker
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+            - secretRef:
+                name: insights-runtime
+          env:
+            - name: BACKEND_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: BACKEND_ENV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: REDIS_PASSWORD
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - redis-server /redis.conf --requirepass "$REDIS_PASSWORD"

--- a/k8s/overlays/production/kustomization.yaml
+++ b/k8s/overlays/production/kustomization.yaml
@@ -1,0 +1,8 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - secrets-mapping.yaml
+patches:
+  - path: secret-mapping.yaml
+  - path: deployment-env.yaml

--- a/k8s/overlays/production/secret-mapping.yaml
+++ b/k8s/overlays/production/secret-mapping.yaml
@@ -1,0 +1,10 @@
+apiVersion: secrets.oracle.com/v1alpha1
+kind: SecretSync
+metadata:
+  name: insights-runtime-secrets
+  namespace: insights
+  labels:
+    app.kubernetes.io/environment: production
+spec:
+  vaultSecretId: ocid1.vaultsecret.oc1..production-placeholder
+  secretName: insights-runtime

--- a/k8s/overlays/production/secrets-mapping.yaml
+++ b/k8s/overlays/production/secrets-mapping.yaml
@@ -1,0 +1,19 @@
+apiVersion: secrets.oracle.com/v1alpha1
+kind: SecretSync
+metadata:
+  name: insights-runtime-secrets
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: insights-runtime
+spec:
+  vaultSecretId: ocid1.vaultsecret.oc1..placeholder
+  refreshPeriod: 15m
+  secretName: insights-runtime
+  secretType: Opaque
+  data:
+    - vaultSecretKey: backend.env
+      secretKey: BACKEND_ENV
+      encoding: none
+    - vaultSecretKey: redis.password
+      secretKey: REDIS_PASSWORD
+      encoding: none

--- a/k8s/overlays/staging/kustomization.yaml
+++ b/k8s/overlays/staging/kustomization.yaml
@@ -1,0 +1,9 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+resources:
+  - ../../base
+  - secrets-mapping.yaml
+patches:
+  - path: patches/ingress.yaml
+  - path: patches/secret-mapping.yaml
+  - path: patches/deployment-env.yaml

--- a/k8s/overlays/staging/patches/deployment-env.yaml
+++ b/k8s/overlays/staging/patches/deployment-env.yaml
@@ -1,0 +1,88 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights-app-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: frontend
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+            - secretRef:
+                name: insights-runtime
+          env:
+            - name: BACKEND_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: BACKEND_ENV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: package-downloads-worker-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: package-downloads-worker
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+            - secretRef:
+                name: insights-runtime
+          env:
+            - name: BACKEND_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: BACKEND_ENV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-volume-worker-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: search-volume-worker
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+            - secretRef:
+                name: insights-runtime
+          env:
+            - name: BACKEND_ENV
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: BACKEND_ENV
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-dpl
+  namespace: insights
+spec:
+  template:
+    spec:
+      containers:
+        - name: redis
+          env:
+            - name: REDIS_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: insights-runtime
+                  key: REDIS_PASSWORD
+          command:
+            - /bin/sh
+            - -c
+          args:
+            - redis-server /redis.conf --requirepass "$REDIS_PASSWORD"

--- a/k8s/overlays/staging/patches/ingress.yaml
+++ b/k8s/overlays/staging/patches/ingress.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: insights
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-staging
+spec:
+  tls:
+    - hosts:
+        - insights.staging.lfx.dev
+      secretName: letsencrypt-staging
+  rules:
+    - host: insights.staging.lfx.dev
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: insights-app-svc
+                port:
+                  number: 3000

--- a/k8s/overlays/staging/patches/secret-mapping.yaml
+++ b/k8s/overlays/staging/patches/secret-mapping.yaml
@@ -1,0 +1,10 @@
+apiVersion: secrets.oracle.com/v1alpha1
+kind: SecretSync
+metadata:
+  name: insights-runtime-secrets
+  namespace: insights
+  labels:
+    app.kubernetes.io/environment: staging
+spec:
+  vaultSecretId: ocid1.vaultsecret.oc1..staging-placeholder
+  secretName: insights-runtime

--- a/k8s/overlays/staging/secrets-mapping.yaml
+++ b/k8s/overlays/staging/secrets-mapping.yaml
@@ -1,0 +1,19 @@
+apiVersion: secrets.oracle.com/v1alpha1
+kind: SecretSync
+metadata:
+  name: insights-runtime-secrets
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: insights-runtime
+spec:
+  vaultSecretId: ocid1.vaultsecret.oc1..placeholder
+  refreshPeriod: 15m
+  secretName: insights-runtime
+  secretType: Opaque
+  data:
+    - vaultSecretKey: backend.env
+      secretKey: BACKEND_ENV
+      encoding: none
+    - vaultSecretKey: redis.password
+      secretKey: REDIS_PASSWORD
+      encoding: none

--- a/k8s/reference/production-manifests.yaml
+++ b/k8s/reference/production-manifests.yaml
@@ -1,0 +1,221 @@
+# Source: infra/ingress.yaml
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: ingress
+  namespace: insights
+  labels:
+    name: ingress
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    nginx.ingress.kubernetes.io/ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/force-ssl-redirect: 'true'
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+
+spec:
+  tls:
+    - hosts:
+        - insights.production.lfx.dev
+        - insights.linuxfoundation.org
+      secretName: letsencrypt-production
+  rules:
+    - host: insights.production.lfx.dev
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: insights-app-svc
+                port:
+                  number: 3000
+    - host: insights.linuxfoundation.org
+      http:
+        paths:
+          - path: /(.*)
+            pathType: Prefix
+            backend:
+              service:
+                name: insights-app-svc
+                port:
+                  number: 3000
+---
+# Source: infra/namespace.yaml
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: insights
+---
+# Source: infra/redis.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-dpl
+  namespace: insights
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      nodeSelector:
+        name: pg-insights-redis
+      containers:
+        - name: redis
+          image: crowddotdev/redis:1668671743.d99338c4
+          command: ['redis-server']
+          args:
+            ['/redis.conf', '--requirepass', 'V434DbYua628UmgD8BHxiCuMNXxXu4kD']
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-svc
+  namespace: insights
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+---
+# Source: insights-app.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: insights-app-dpl
+  namespace: insights
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insights-app
+  template:
+    metadata:
+      labels:
+        app: insights-app
+    spec:
+      nodeSelector:
+        name: pg-insights
+      tolerations:
+        - key: "dedicated"
+          operator: "Equal"
+          value: "insights"
+          effect: "NoSchedule"
+      imagePullSecrets:
+        - name: ocir-secret
+      containers:
+        - name: frontend
+          image: sjc.ocir.io/axbydjxa5zuh/insights-app:2
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+          ports:
+            - containerPort: 3000
+          readinessProbe:
+            httpGet:
+              port: 3000
+              path: /api/health/live
+          livenessProbe:
+            httpGet:
+              port: 3000
+              path: /api/health/live
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: insights-app-svc
+  namespace: insights
+spec:
+  type: ClusterIP
+  selector:
+    app: insights-app
+  ports:
+    - port: 3000
+      targetPort: 3000
+---
+# Source: package-downloads-worker.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: package-downloads-worker-dpl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: package-downloads-worker
+  template:
+    metadata:
+      labels:
+        app: package-downloads-worker
+    spec:
+      nodeSelector:
+        name: pg-insights
+      imagePullSecrets:
+        - name: ocir-secret
+      containers:
+        - name: package-downloads-worker
+          image: sjc.ocir.io/axbydjxa5zuh/package-downloads-worker:1750147302.2d64686
+          workingDir: /usr/insights/app/workers/temporal/package_downloads_worker
+          command:
+            - pnpm
+          args:
+            - run
+            - start
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+          env:
+            - name: KUBE_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
+---
+# Source: search-volume-worker.yaml
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: search-volume-worker-dpl
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-volume-worker
+  template:
+    metadata:
+      labels:
+        app: search-volume-worker
+    spec:
+      nodeSelector:
+        name: pg-insights
+      imagePullSecrets:
+        - name: ocir-secret
+      containers:
+        - name: search-volume-worker
+          image: sjc.ocir.io/axbydjxa5zuh/insights-search-volume-worker:1752680491.4e4905d
+          workingDir: /insights-search-volume-app/workers/temporal/search_volume_worker
+          command:
+            - pnpm
+          args:
+            - run
+            - start
+          envFrom:
+            - configMapRef:
+                name: insights-config-map
+          env:
+            - name: KUBE_HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP

--- a/k8s/secrets/mappings.yaml
+++ b/k8s/secrets/mappings.yaml
@@ -1,0 +1,19 @@
+apiVersion: secrets.oracle.com/v1alpha1
+kind: SecretSync
+metadata:
+  name: insights-runtime-secrets
+  namespace: insights
+  labels:
+    app.kubernetes.io/name: insights-runtime
+spec:
+  vaultSecretId: ocid1.vaultsecret.oc1..placeholder
+  refreshPeriod: 15m
+  secretName: insights-runtime
+  secretType: Opaque
+  data:
+    - vaultSecretKey: backend.env
+      secretKey: BACKEND_ENV
+      encoding: none
+    - vaultSecretKey: redis.password
+      secretKey: REDIS_PASSWORD
+      encoding: none

--- a/k8s/tests/README.md
+++ b/k8s/tests/README.md
@@ -1,0 +1,33 @@
+# Kubernetes Validation Harness
+
+This directory hosts utilities that help keep the Insights Kubernetes configuration provably correct.
+
+## `render-validate.sh`
+
+Runs the full validation pipeline used locally and in CI:
+
+1. Renders the shared base (`insights/k8s/base`) with `kubectl kustomize`.
+2. Renders every environment overlay (`insights/k8s/overlays/*`) via `kubectl kustomize`.
+3. Executes `kubeconform` against each rendered manifest to enforce Kubernetes schema compliance.
+4. Executes `conftest` policies (when present in `insights/k8s/policies/`) to catch configuration rule violations.
+5. Writes unified diffs between the base and each overlay to the system temp directory for quick inspection.
+
+Artifacts land under `$TMPDIR/insights-k8s` (or `/tmp/insights-k8s` when `TMPDIR` is unset).
+
+### Local Usage
+
+```bash
+./insights/k8s/tests/render-validate.sh
+```
+
+Prerequisites: `kubectl` v1.34.x (for `kubectl kustomize`), `kubeconform`, `conftest`. The script honours `KUBECTL`, `KUBECONFORM`, and `CONFTEST` environment variables if you want to override tool locations.
+
+### CI Integration
+
+The `.github/workflows/insights-k8s-validate.yml` workflow installs the same tooling and calls the script on every push and pull request touching `insights/k8s/**`. Validation failures block the merge until corrected.
+
+### Troubleshooting
+
+- **Tool not found**: export the executable path via the corresponding environment variable (`KUSTOMIZE`, `KUBECONFORM`, `CONFTEST`).
+- **Schema download errors**: ensure the CI runner has outbound network access; retry locally with `kubeconform -cache` if needed.
+- **Unexpected overlay diff**: review the diff files in the temp directory to confirm only intentional changes exist.

--- a/k8s/tests/base-expected.yaml
+++ b/k8s/tests/base-expected.yaml
@@ -1,0 +1,225 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: insights
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: insights-app
+  name: insights-app-svc
+  namespace: insights
+spec:
+  ports:
+  - port: 3000
+    targetPort: 3000
+  selector:
+    app: insights-app
+  type: ClusterIP
+---
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: redis
+  name: redis-svc
+  namespace: insights
+spec:
+  ports:
+  - port: 6379
+    targetPort: 6379
+  selector:
+    app: redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: insights-app
+  name: insights-app-dpl
+  namespace: insights
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: insights-app
+  template:
+    metadata:
+      labels:
+        app: insights-app
+    spec:
+      containers:
+      - envFrom:
+        - configMapRef:
+            name: insights-config-map
+        image: sjc.ocir.io/axbydjxa5zuh/insights-app:2
+        livenessProbe:
+          httpGet:
+            path: /api/health/live
+            port: 3000
+        name: frontend
+        ports:
+        - containerPort: 3000
+        readinessProbe:
+          httpGet:
+            path: /api/health/live
+            port: 3000
+      imagePullSecrets:
+      - name: ocir-secret
+      nodeSelector:
+        name: pg-insights
+      tolerations:
+      - effect: NoSchedule
+        key: dedicated
+        operator: Equal
+        value: insights
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: package-downloads-worker
+  name: package-downloads-worker-dpl
+  namespace: insights
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: package-downloads-worker
+  template:
+    metadata:
+      labels:
+        app: package-downloads-worker
+    spec:
+      containers:
+      - args:
+        - run
+        - start
+        command:
+        - pnpm
+        env:
+        - name: KUBE_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        envFrom:
+        - configMapRef:
+            name: insights-config-map
+        image: sjc.ocir.io/axbydjxa5zuh/package-downloads-worker:1750147302.2d64686
+        name: package-downloads-worker
+        workingDir: /usr/insights/app/workers/temporal/package_downloads_worker
+      imagePullSecrets:
+      - name: ocir-secret
+      nodeSelector:
+        name: pg-insights
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: redis
+  name: redis-dpl
+  namespace: insights
+spec:
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+      - args:
+        - /redis.conf
+        - --requirepass
+        - V434DbYua628UmgD8BHxiCuMNXxXu4kD
+        command:
+        - redis-server
+        image: crowddotdev/redis:1668671743.d99338c4
+        name: redis
+        ports:
+        - containerPort: 6379
+      nodeSelector:
+        name: pg-insights-redis
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: search-volume-worker
+  name: search-volume-worker-dpl
+  namespace: insights
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: search-volume-worker
+  template:
+    metadata:
+      labels:
+        app: search-volume-worker
+    spec:
+      containers:
+      - args:
+        - run
+        - start
+        command:
+        - pnpm
+        env:
+        - name: KUBE_HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
+        envFrom:
+        - configMapRef:
+            name: insights-config-map
+        image: sjc.ocir.io/axbydjxa5zuh/insights-search-volume-worker:1752680491.4e4905d
+        name: search-volume-worker
+        workingDir: /insights-search-volume-app/workers/temporal/search_volume_worker
+      imagePullSecrets:
+      - name: ocir-secret
+      nodeSelector:
+        name: pg-insights
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: letsencrypt-production
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/force-ssl-redirect: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$1
+    nginx.ingress.kubernetes.io/ssl-redirect: "true"
+  labels:
+    name: ingress
+  name: ingress
+  namespace: insights
+spec:
+  rules:
+  - host: insights.production.lfx.dev
+    http:
+      paths:
+      - backend:
+          service:
+            name: insights-app-svc
+            port:
+              number: 3000
+        path: /(.*)
+        pathType: Prefix
+  - host: insights.linuxfoundation.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: insights-app-svc
+            port:
+              number: 3000
+        path: /(.*)
+        pathType: Prefix
+  tls:
+  - hosts:
+    - insights.production.lfx.dev
+    - insights.linuxfoundation.org
+    secretName: letsencrypt-production

--- a/k8s/tests/cluster-diff.sh
+++ b/k8s/tests/cluster-diff.sh
@@ -1,0 +1,95 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# This script compares your kustomize manifests against the live cluster
+# to verify that applying them would not make any changes.
+#
+# Usage:
+#   ./cluster-diff.sh [overlay-name]
+#
+# Examples:
+#   ./cluster-diff.sh production
+#   ./cluster-diff.sh staging
+#
+# Exit codes:
+#   0 - No differences found (safe to apply)
+#   1 - Differences found or error occurred
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+K8S_DIR="$ROOT_DIR/k8s"
+OVERLAYS_DIR="$K8S_DIR/overlays"
+
+KUBECTL_BIN=${KUBECTL:-kubectl}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+if [ $# -eq 0 ]; then
+  echo "Usage: $0 <overlay-name>"
+  echo ""
+  echo "Available overlays:"
+  if [ -d "$OVERLAYS_DIR" ]; then
+    ls -1 "$OVERLAYS_DIR"
+  fi
+  exit 1
+fi
+
+OVERLAY_NAME=$1
+OVERLAY_PATH="$OVERLAYS_DIR/$OVERLAY_NAME"
+
+if [ ! -d "$OVERLAY_PATH" ]; then
+  echo -e "${RED}Error: Overlay '$OVERLAY_NAME' not found at $OVERLAY_PATH${NC}"
+  exit 1
+fi
+
+echo "=========================================="
+echo "Comparing manifests against live cluster"
+echo "Overlay: $OVERLAY_NAME"
+echo "=========================================="
+echo ""
+
+# Check if we can connect to the cluster
+if ! $KUBECTL_BIN cluster-info &> /dev/null; then
+  echo -e "${RED}Error: Cannot connect to Kubernetes cluster${NC}"
+  echo "Please ensure your kubeconfig is configured correctly"
+  exit 1
+fi
+
+echo "Connected to cluster: $($KUBECTL_BIN config current-context)"
+echo ""
+
+# Run kubectl diff
+echo "Running kubectl diff..."
+echo ""
+
+set +e
+DIFF_OUTPUT=$($KUBECTL_BIN diff -k "$OVERLAY_PATH" 2>&1)
+DIFF_EXIT_CODE=$?
+set -e
+
+# kubectl diff exit codes:
+# 0 - no differences
+# 1 - differences found
+# >1 - error occurred
+
+if [ $DIFF_EXIT_CODE -eq 0 ]; then
+  echo -e "${GREEN}✓ No differences found!${NC}"
+  echo "The manifests match what's currently deployed in the cluster."
+  echo "It is safe to apply these manifests."
+  exit 0
+elif [ $DIFF_EXIT_CODE -eq 1 ]; then
+  echo -e "${YELLOW}⚠ Differences found between manifests and cluster:${NC}"
+  echo ""
+  echo "$DIFF_OUTPUT"
+  echo ""
+  echo -e "${YELLOW}WARNING: Applying these manifests would modify the cluster!${NC}"
+  exit 1
+else
+  echo -e "${RED}✗ Error running kubectl diff (exit code: $DIFF_EXIT_CODE)${NC}"
+  echo ""
+  echo "$DIFF_OUTPUT"
+  exit 1
+fi

--- a/k8s/tests/overlay-expected.yaml
+++ b/k8s/tests/overlay-expected.yaml
@@ -1,0 +1,12 @@
+# Expected overlay differences relative to base manifests
+---
+overlay: staging
+notes:
+  - Ingress uses `letsencrypt-staging` issuer and `insights.staging.lfx.dev` host/TLS secret.
+  - SecretSync references staging Vault OCID `ocid1.vaultsecret.oc1..staging-placeholder`.
+  - Deployments and Redis consume the `insights-runtime` secret for runtime configuration.
+---
+overlay: production
+notes:
+  - SecretSync references production Vault OCID `ocid1.vaultsecret.oc1..production-placeholder`.
+  - Deployments and Redis consume the `insights-runtime` secret for runtime configuration.

--- a/k8s/tests/render-validate.sh
+++ b/k8s/tests/render-validate.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR=$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)
+K8S_DIR="$ROOT_DIR/k8s"
+BASE_DIR="$K8S_DIR/base"
+OVERLAYS_DIR="$K8S_DIR/overlays"
+TMP_DIR=${TMPDIR:-/tmp}/insights-k8s
+
+mkdir -p "$TMP_DIR"
+
+KUBECTL_BIN=${KUBECTL:-kubectl}
+KUBECONFORM_BIN=${KUBECONFORM:-kubeconform}
+CONFTEST_BIN=${CONFTEST:-conftest}
+POLICY_DIR=${POLICY_DIR:-"$K8S_DIR/policies"}
+
+run_render() {
+  local target=$1
+  local output=$2
+  echo "Rendering manifests for $target"
+  $KUBECTL_BIN kustomize "$target" > "$output"
+}
+
+run_kubeconform() {
+  local manifest=$1
+  echo "Validating schemas with kubeconform for $manifest"
+  $KUBECONFORM_BIN -summary -ignore-missing-schemas < "$manifest"
+}
+
+run_conftest() {
+  local target=$1
+  if [ -d "$POLICY_DIR" ]; then
+    echo "Running conftest policies for $target"
+    $CONFTEST_BIN test "$target" --policy "$POLICY_DIR"
+  else
+    echo "No policy directory found at $POLICY_DIR; skipping conftest"
+  fi
+}
+
+BASE_MANIFEST="$TMP_DIR/base.yaml"
+run_render "$BASE_DIR" "$BASE_MANIFEST"
+run_kubeconform "$BASE_MANIFEST"
+run_conftest "$BASE_DIR"
+
+declare -a overlays
+if [ -d "$OVERLAYS_DIR" ]; then
+  while IFS= read -r -d '' overlay; do
+    overlays+=("$overlay")
+  done < <(find "$OVERLAYS_DIR" -mindepth 1 -maxdepth 1 -type d -print0 | sort -z)
+fi
+
+for overlay in "${overlays[@]:-}"; do
+  name=$(basename "$overlay")
+  overlay_manifest="$TMP_DIR/${name}.yaml"
+  run_render "$overlay" "$overlay_manifest"
+  run_kubeconform "$overlay_manifest"
+  run_conftest "$overlay"
+  diff --unified "$BASE_MANIFEST" "$overlay_manifest" > "$TMP_DIR/${name}.diff" || true
+  echo "Overlay diff written to $TMP_DIR/${name}.diff"
+done
+
+echo "Render & validation complete. Artifacts stored in $TMP_DIR."

--- a/k8s/tests/secret-rotation.sh
+++ b/k8s/tests/secret-rotation.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<USAGE
+Usage: $0 --vault-secret-id <ocid> --secret-name <k8s-secret> [--namespace insights]
+
+Fetches the latest value from Oracle Cloud Secrets Vault (expected to be a JSON
+object of key/value pairs) and updates the corresponding Kubernetes Secret, then
+restarts dependent Deployments so the new value takes effect. Requires OCI CLI
+authenticated with read access and kubectl configured for the target cluster.
+USAGE
+}
+
+NAMESPACE="insights"
+VAULT_SECRET_ID=""
+SECRET_NAME="insights-runtime"
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --vault-secret-id)
+      VAULT_SECRET_ID="$2"
+      shift 2
+      ;;
+    --secret-name)
+      SECRET_NAME="$2"
+      shift 2
+      ;;
+    --namespace)
+      NAMESPACE="$2"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage
+      exit 1
+      ;;
+  esac
+done
+
+if [[ -z "$VAULT_SECRET_ID" ]]; then
+  echo "Error: --vault-secret-id is required" >&2
+  usage
+  exit 1
+fi
+
+echo "Fetching secret bundle $VAULT_SECRET_ID from OCI"
+SECRET_PAYLOAD=$(oci secrets secret-bundle get --secret-id "$VAULT_SECRET_ID" \
+  --stage CURRENT \
+  --query "data.'secret-bundle-content'.content" --raw-output)
+
+if [[ -z "$SECRET_PAYLOAD" ]]; then
+  echo "Error: received empty payload from OCI" >&2
+  exit 1
+fi
+
+echo "Decoding secret payload"
+SECRET_JSON=$(printf '%s' "$SECRET_PAYLOAD" | base64 --decode)
+KEY_VALUES=$(printf '%s' "$SECRET_JSON" | jq -r 'to_entries[] | "\(.key)=\(.value)"')
+
+if [[ -z "$KEY_VALUES" ]]; then
+  echo "Error: secret JSON did not contain key/value pairs" >&2
+  exit 1
+fi
+
+TMP_FILE=$(mktemp)
+trap 'rm -f "$TMP_FILE"' EXIT
+
+{
+  echo "apiVersion: v1"
+  echo "kind: Secret"
+  echo "metadata:"
+  echo "  name: $SECRET_NAME"
+  echo "  namespace: $NAMESPACE"
+  echo "stringData:"
+  while IFS='=' read -r KEY VALUE; do
+    printf '  %s: |\n' "$KEY"
+    printf '%s' "$VALUE" | sed 's/^/    /'
+    echo
+  done <<< "$KEY_VALUES"
+} > "$TMP_FILE"
+
+echo "Applying Kubernetes Secret $SECRET_NAME"
+kubectl apply -f "$TMP_FILE"
+
+echo "Restarting dependent Deployments"
+for deploy in insights-app-dpl package-downloads-worker-dpl search-volume-worker-dpl; do
+  kubectl -n "$NAMESPACE" rollout restart deployment "$deploy" || true
+  kubectl -n "$NAMESPACE" rollout status deployment "$deploy" --timeout=120s || true
+done
+
+echo "Secret rotation script completed successfully."


### PR DESCRIPTION
This introduces [Kustomize](https://kustomize.io/) to deploy Insights and at the same time uses OCI secrets instead of the environment variables from crowd-kube.

Kustomize is kind of like Helm but has a bunch of advantages, including being natively supported in kubectl.

This would allow us to get rid of the various prod/staging folders in crows-kube, and instead have a single set of files for both staging and production - and even local development, if we ever wanted to start using something like minikube or kind for local development.

My intention was to do it first on Insights because it's a simpler project, and then eventually we could also apply it to the crowd.dev repository. Maybe someone wants to pick it up where I left off.