### PR TITLE
Fix/leaderboard api type errors

### DIFF
--- a/frontend/app/components/modules/leaderboards/services/leaderboard.api.service.ts
+++ b/frontend/app/components/modules/leaderboards/services/leaderboard.api.service.ts
@@ -2,6 +2,7 @@
 // SPDX-License-Identifier: MIT
 import {
   type QueryFunction,
+  type InfiniteData,
   useInfiniteQuery,
   useQuery,
   useQueryClient,
@@ -29,25 +30,21 @@ class LeaderboardApiService {
       params.value.collectionSlug,
     ]);
 
-    const queryFn = computed<QueryFunction<Pagination<Leaderboard>>>(() =>
-      this.leaderboardDetailQueryFn(() => ({
-        leaderboardType: params.value.leaderboardType,
-        initialPageSize: params.value.initialPageSize,
-        search: params.value.search,
-        collectionSlug: params.value.collectionSlug,
-      })),
-    );
-
     return await queryClient.prefetchInfiniteQuery<
       Pagination<Leaderboard>,
       Error,
-      Pagination<Leaderboard>,
+      InfiniteData<Pagination<Leaderboard>>,
       readonly unknown[],
       number
     >({
       queryKey,
-      //@ts-expect-error - TanStack Query type inference issue with Vue
-      queryFn,
+      queryFn: (context) =>
+        this.leaderboardDetailQueryFn(() => ({
+          leaderboardType: params.value.leaderboardType,
+          initialPageSize: params.value.initialPageSize,
+          search: params.value.search,
+          collectionSlug: params.value.collectionSlug,
+        }))(context),
       getNextPageParam: this.getNextPageLeaderboardParam,
       initialPageParam: 0,
     });
@@ -71,25 +68,21 @@ class LeaderboardApiService {
       params.value.collectionSlug,
     ]);
 
-    const queryFn = computed<QueryFunction<Pagination<Leaderboard>>>(() =>
-      this.leaderboardDetailQueryFn(() => ({
-        leaderboardType: params.value.leaderboardType,
-        initialPageSize: params.value.initialPageSize,
-        search: params.value.search,
-        collectionSlug: params.value.collectionSlug,
-      })),
-    );
-
     return useInfiniteQuery<
       Pagination<Leaderboard>,
       Error,
-      Pagination<Leaderboard>,
+      InfiniteData<Pagination<Leaderboard>>,
       readonly unknown[],
       number
     >({
       queryKey,
-      //@ts-expect-error - TanStack Query type inference issue with Vue
-      queryFn,
+      queryFn: (context) =>
+        this.leaderboardDetailQueryFn(() => ({
+          leaderboardType: params.value.leaderboardType,
+          initialPageSize: params.value.initialPageSize,
+          search: params.value.search,
+          collectionSlug: params.value.collectionSlug,
+        }))(context),
       getNextPageParam: this.getNextPageLeaderboardParam,
       initialPageParam: 0,
     });
@@ -120,24 +113,20 @@ class LeaderboardApiService {
       params.value.search,
     ]);
 
-    const queryFn = computed<QueryFunction<Pagination<Leaderboard>>>(() =>
-      this.leaderboardDetailQueryFn(() => ({
-        leaderboardType: params.value.leaderboardType,
-        initialPageSize: 15,
-        search: params.value.search,
-      })),
-    );
-
     return useInfiniteQuery<
       Pagination<Leaderboard>,
       Error,
-      Pagination<Leaderboard>,
+      InfiniteData<Pagination<Leaderboard>>,
       readonly unknown[],
       number
     >({
       queryKey,
-      //@ts-expect-error - TanStack Query type inference issue with Vue
-      queryFn,
+      queryFn: (context) =>
+        this.leaderboardDetailQueryFn(() => ({
+          leaderboardType: params.value.leaderboardType,
+          initialPageSize: 15,
+          search: params.value.search,
+        }))(context),
       getNextPageParam: this.getNextPageLeaderboardParam,
       initialPageParam: 0,
       enabled: computed(() => !!params.value.search && params.value.search.trim().length > 0),

--- a/frontend/app/components/modules/project/services/community.api.service.ts
+++ b/frontend/app/components/modules/project/services/community.api.service.ts
@@ -1,8 +1,12 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { computed, type ComputedRef } from 'vue';
-import type { QueryFunction } from '@tanstack/vue-query';
-import { useInfiniteQuery, useQueryClient } from '@tanstack/vue-query';
+import {
+  type QueryFunction,
+  type InfiniteData,
+  useInfiniteQuery,
+  useQueryClient,
+} from '@tanstack/vue-query';
 import type { Project } from '~~/types/project';
 import type { User } from '~~/types/auth/auth-user.types';
 import { TanstackKey } from '~/components/shared/types/tanstack';
@@ -33,19 +37,18 @@ class ProjectCommunityApiService {
       params.value.endDate,
     ]);
 
-    const queryFn = this.fetchCommunityMentionsQueryFn(() => ({
-      ...params.value,
-    }));
-
     return await queryClient.prefetchInfiniteQuery<
       Pagination<CommunityMentions>,
       Error,
-      Pagination<CommunityMentions>,
+      InfiniteData<Pagination<CommunityMentions>>,
       readonly unknown[],
       number
     >({
       queryKey,
-      queryFn,
+      queryFn: (context) =>
+        this.fetchCommunityMentionsQueryFn(() => ({
+          ...params.value,
+        }))(context),
       initialPageParam: 0,
       getNextPageParam: this.getNextPageCollectionsParam,
     });
@@ -69,22 +72,18 @@ class ProjectCommunityApiService {
       params.value.endDate,
     ]);
 
-    const queryFn = computed<QueryFunction<Pagination<CommunityMentions>>>(() =>
-      this.fetchCommunityMentionsQueryFn(() => ({
-        ...params.value,
-      })),
-    );
-
     return useInfiniteQuery<
       Pagination<CommunityMentions>,
       Error,
-      Pagination<CommunityMentions>,
+      InfiniteData<Pagination<CommunityMentions>>,
       readonly unknown[],
       number
     >({
       queryKey,
-      //@ts-expect-error - TanStack Query type inference issue with Vue
-      queryFn,
+      queryFn: (context) =>
+        this.fetchCommunityMentionsQueryFn(() => ({
+          ...params.value,
+        }))(context),
       getNextPageParam: this.getNextPageCollectionsParam,
       initialPageParam: 0,
     });


### PR DESCRIPTION
# Description
Resolves several TanStack Query type mismatches and `@ts-expect-error` annotations in the Leaderboard and Project Community API services.

## Changes
- **LeaderboardApiService**: Removed computed [queryFn](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/explore/services/explore.api.service.ts:79:6-79:82) wrappers and implemented direct typed closures in [prefetchLeaderboardDetails](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/leaderboards/services/leaderboard.api.service.ts:24:2-50:3), [fetchLeaderboardDetails](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/leaderboards/services/leaderboard.api.service.ts:63:2-88:3), and [fetchLeaderboardDetailSearch](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/leaderboards/services/leaderboard.api.service.ts:108:2-133:3).
- **ProjectCommunityApiService**: Similar refactoring to use typed closures and explicit generics in [prefetchCommunityMentions](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/project/services/community.api.service.ts:26:2-54:3) and [fetchCommunityMentions](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/project/services/community.api.service.ts:62:2-89:3).
- **Type Safety**: Introduced `InfiniteData` from `@tanstack/vue-query` to correctly type the paginated response structures.
- **Standards**: Ensured `initialPageParam: 0` is present for all infinite query calls.

## Verification
- `pnpm tsc-check` passed in the [frontend](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend:0:0-0:0) directory.
- Verified all 3 modified files follow the updated pattern.