### PR TITLE
Fix/contributors api type errors

### DIFF
--- a/frontend/app/components/modules/widget/services/contributors.api.service.ts
+++ b/frontend/app/components/modules/widget/services/contributors.api.service.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import type { QueryFunction } from '@tanstack/vue-query';
+import { type QueryFunction, type InfiniteData } from '@tanstack/vue-query';
 import { type ComputedRef, computed } from 'vue';
 import { useInfiniteQuery, useQuery } from '@tanstack/vue-query';
 import { TanstackKey } from '~/components/shared/types/tanstack';
@@ -50,27 +50,30 @@ class ContributorsApiService {
       params.value.endDate,
       params.value.includeCollaborations,
     ]);
-    const queryFn = computed<QueryFunction<ContributorLeaderboard>>(() =>
-      this.contributorLeaderboardQueryFn(() => ({
-        projectSlug: params.value.projectSlug,
-        platform: params.value.platform,
-        activityType: params.value.activityType,
-        repos: params.value.repos,
-        startDate: params.value.startDate,
-        endDate: params.value.endDate,
-        includeCollaborations: params.value.includeCollaborations,
-      })),
-    );
-
-    return useInfiniteQuery<ContributorLeaderboard>({
+    return useInfiniteQuery<
+      ContributorLeaderboard,
+      Error,
+      InfiniteData<ContributorLeaderboard>,
+      readonly unknown[],
+      number
+    >({
       queryKey,
-      // @ts-expect-error - queryFn is a computed ref
-      queryFn,
+      queryFn: (context) =>
+        this.contributorLeaderboardQueryFn(() => ({
+          projectSlug: params.value.projectSlug,
+          platform: params.value.platform,
+          activityType: params.value.activityType,
+          repos: params.value.repos,
+          startDate: params.value.startDate,
+          endDate: params.value.endDate,
+          includeCollaborations: params.value.includeCollaborations,
+        }))(context),
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.meta.offset + lastPage.meta.limit;
         const totalRows = lastPage.meta.total;
         return nextPage < totalRows ? nextPage : undefined;
       },
+      initialPageParam: 0,
     });
   }
 
@@ -115,27 +118,30 @@ class ContributorsApiService {
       params.value.endDate,
       params.value.includeCollaborations,
     ]);
-    const queryFn = computed<QueryFunction<OrganizationLeaderboard>>(() =>
-      this.organizationLeaderboardQueryFn(() => ({
-        projectSlug: params.value.projectSlug,
-        platform: params.value.platform,
-        activityType: params.value.activityType,
-        repos: params.value.repos,
-        startDate: params.value.startDate,
-        endDate: params.value.endDate,
-        includeCollaborations: params.value.includeCollaborations,
-      })),
-    );
-
-    return useInfiniteQuery<OrganizationLeaderboard>({
+    return useInfiniteQuery<
+      OrganizationLeaderboard,
+      Error,
+      InfiniteData<OrganizationLeaderboard>,
+      readonly unknown[],
+      number
+    >({
       queryKey,
-      // @ts-expect-error - queryFn is a computed ref
-      queryFn,
+      queryFn: (context) =>
+        this.organizationLeaderboardQueryFn(() => ({
+          projectSlug: params.value.projectSlug,
+          platform: params.value.platform,
+          activityType: params.value.activityType,
+          repos: params.value.repos,
+          startDate: params.value.startDate,
+          endDate: params.value.endDate,
+          includeCollaborations: params.value.includeCollaborations,
+        }))(context),
       getNextPageParam: (lastPage) => {
         const nextPage = lastPage.meta.offset + lastPage.meta.limit;
         const totalRows = lastPage.meta.total;
         return nextPage < totalRows ? nextPage : undefined;
       },
+      initialPageParam: 0,
     });
   }
 


### PR DESCRIPTION
# Description
Fixes TanStack Query type errors in the [ContributorsApiService](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/widget/services/contributors.api.service.ts:40:0-481:1) and removes `@ts-expect-error` annotations.

## Changes
- **ContributorsApiService**: Refactored [fetchContributorLeaderboard](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/widget/services/contributors.api.service.ts:41:2-77:3) and [fetchOrganizationLeaderboard](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/widget/services/contributors.api.service.ts:109:2-145:3) to use direct typed closures instead of computed refs for [queryFn](cci:1://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/app/components/modules/explore/services/explore.api.service.ts:79:6-79:82).
- **Type Safety**: Added explicit generics to `useInfiniteQuery` including `InfiniteData` for correct pagination typing.
- **Modern API Standards**: Added `initialPageParam: 0` to infinite query configurations.
- **Imports**: Added `InfiniteData` import from `@tanstack/vue-query`.

## Verification
- `pnpm tsc-check` passed in the [frontend](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend:0:0-0:0) directory.
- Verified both modified methods follow the project's updated type-safe pattern.