### PR TITLE
Fix/component query type errors

### DIFF
--- a/frontend/app/components/modules/leaderboards/components/sections/leaderboard-search.vue
+++ b/frontend/app/components/modules/leaderboards/components/sections/leaderboard-search.vue
@@ -158,8 +158,7 @@ const {
 } = LEADERBOARD_API_SERVICE.fetchLeaderboardDetailSearch(searchParams);
 
 const items = computed(() => {
-  // @ts-expect-error - TanStack Query type inference issue with Vue
-  return searchData.value?.pages.flatMap((page: Pagination<Leaderboard>) => page.data) || [];
+  return searchData.value?.pages.flatMap((page) => page.data) || [];
 });
 
 const emit = defineEmits<{

--- a/frontend/app/components/modules/leaderboards/components/views/leaderboard-detail.vue
+++ b/frontend/app/components/modules/leaderboards/components/views/leaderboard-detail.vue
@@ -94,7 +94,6 @@ import { LEADERBOARD_API_SERVICE } from '../../services/leaderboard.api.service'
 import LfxTableHeader from '../sections/table-header.vue';
 import type { Leaderboard } from '~~/types/leaderboard/leaderboard';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
-import type { Pagination } from '~~/types/shared/pagination';
 import { LfxRoutes } from '~/components/shared/types/routes';
 import { useBannerStore } from '~/components/shared/store/banner.store';
 
@@ -120,8 +119,7 @@ const { data, isPending, isFetchingNextPage, fetchNextPage, hasNextPage } =
   LEADERBOARD_API_SERVICE.fetchLeaderboardDetails(params);
 
 const items = computed(() => {
-  // @ts-expect-error - TanStack Query type inference issue with Vue
-  const tmpList = data.value?.pages.flatMap((page: Pagination<Leaderboard>) => page.data) || [];
+  const tmpList = data.value?.pages.flatMap((page) => page.data) || [];
 
   return tmpList;
 });

--- a/frontend/app/components/modules/project/views/community-voice.vue
+++ b/frontend/app/components/modules/project/views/community-voice.vue
@@ -28,8 +28,6 @@ import { storeToRefs } from 'pinia';
 import LfxCommunityResultsArea from '../components/community/sections/results-area.vue';
 import LfxCommunityFilterArea from '../components/community/sections/filter-area.vue';
 import { PROJECT_COMMUNITY_API_SERVICE } from '~/components/modules/project/services/community.api.service';
-import type { CommunityMentions } from '~~/types/community/community';
-import type { Pagination } from '~~/types/shared/pagination';
 import useToastService from '~/components/uikit/toast/toast.service';
 import { ToastTypesEnum } from '~/components/uikit/toast/types/toast.types';
 import { useProjectStore } from '~~/app/components/modules/project/store/project.store';
@@ -58,8 +56,7 @@ const errorMessage = computed(() => {
 
 // Flatten all pages of data into a single array of mentions
 const mentions = computed(() => {
-  // @ts-expect-error - TanStack Query type inference issue with Vue
-  const tmpList = data.value?.pages.flatMap((page: Pagination<CommunityMentions>) => page.data) || [];
+  const tmpList = data.value?.pages.flatMap((page) => page.data) || [];
   return tmpList;
 });
 


### PR DESCRIPTION
# Description
Removes `@ts-expect-error` annotations from Vue components after improving TanStack Query type definitions in the underlying services.

## Changes
- **community-voice.vue**: Removed `@ts-expect-error` from the `mentions` computed property.
- **leaderboard-detail.vue**: Removed `@ts-expect-error` from the `items` computed property.
- **leaderboard-search.vue**: Removed `@ts-expect-error` from the `items` computed property.
- **Inference**: Leveraged the improved `InfiniteData` typing from services to allow TypeScript to correctly infer the structure of `data.value.pages`.

## Verification
- `pnpm tsc-check` passed with no errors in the [frontend](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend:0:0-0:0) directory.
- Verified that `mentions` and `items` are correctly typed in the IDE.