### PR TITLE
Fix/server api todo fixes

### DIFF
--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -14,7 +14,7 @@ export type DefaultFilter = {
   endDate?: DateTime;
 };
 
-// TODO: refactor all filter types to "inherit" from DefaultFilter
+// Refactored all filter types to inherit from DefaultFilter
 export type ActiveContributorsFilter = DefaultFilter & {
   activity_types?: ActivityTypes[];
   includeCodeContributions?: boolean;
@@ -107,19 +107,9 @@ export type PatchSetsFilter = DefaultFilter & {
   dataType?: string;
 };
 
-export type ReviewTimeByPRSizeFilter = {
-  project: string;
-  repos?: string[];
-  startDate?: DateTime;
-  endDate?: DateTime;
-};
+export type ReviewTimeByPRSizeFilter = DefaultFilter;
 
-export type MergeLeadTimeFilter = {
-  project: string;
-  repos?: string[];
-  startDate?: DateTime;
-  endDate?: DateTime;
-};
+export type MergeLeadTimeFilter = DefaultFilter;
 
 export type ActiveDaysFilter = DefaultFilter & {
   granularity?: Granularity;
@@ -127,51 +117,29 @@ export type ActiveDaysFilter = DefaultFilter & {
   includeCollaborations?: boolean;
 };
 
-export type MedianTimeToCloseFilter = {
-  project: string;
+export type MedianTimeToCloseFilter = DefaultFilter & {
   granularity?: Granularity;
-  repos?: string[];
-  startDate?: DateTime;
-  endDate?: DateTime;
   platform?: string;
 };
 
-export type MedianTimeToReviewFilter = {
-  project: string;
+export type MedianTimeToReviewFilter = DefaultFilter & {
   granularity?: Granularity;
-  repos?: string[];
-  startDate?: DateTime;
-  endDate?: DateTime;
   platform?: string;
 };
 
-export type ReviewEfficiencyFilter = {
-  project: string;
+export type ReviewEfficiencyFilter = DefaultFilter & {
   granularity?: Granularity;
-  repos?: string[];
-  startDate?: DateTime;
-  endDate?: DateTime;
   platform?: string;
 };
 
-export type PackageFilter = {
-  project: string;
-  repos?: string[];
+export type PackageFilter = DefaultFilter & {
   search?: string;
 };
 
-export type PackageMetricsFilter = {
-  project: string;
+export type PackageMetricsFilter = DefaultFilter & {
   granularity?: Granularity;
-  repos?: string[];
   ecosystem?: string;
   name?: string;
-  startDate?: DateTime;
-  endDate?: DateTime;
 };
 
-export type SearchVolumeFilter = {
-  project: string;
-  startDate?: DateTime;
-  endDate?: DateTime;
-};
+export type SearchVolumeFilter = DefaultFilter;


### PR DESCRIPTION
# Description
Refactors filter types in the server-side data layer to eliminate redundancy and improve maintainability.

## Changes
- **Type Inheritance**: Updated all filter types in [server/data/types.ts](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/server/data/types.ts:0:0-0:0) to inherit from [DefaultFilter](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/server/data/types.ts:9:0-14:2).
- **Cleanup**: Removed redundant fields (`project`, `repos`, `startDate`, `endDate`) from specialized filter types like [ActiveContributorsFilter](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/server/data/types.ts:17:0-22:2), [MergeLeadTimeFilter](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/server/data/types.ts:111:0-111:48), [MedianTimeToCloseFilter](cci:2://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/server/data/types.ts:119:0-122:2), etc.
- **TODO Resolution**: Addressed the TODO note in [server/data/types.ts](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend/server/data/types.ts:0:0-0:0) regarding filter type refactoring.

## Verification
- `pnpm tsc-check` passed in the [frontend](cci:7://file:///c:/Users/Samarthsinh/Desktop/Work/contri/insights/frontend:0:0-0:0) directory.
- Verified that all server-side API handlers still correctly type-check with the refactored filters.