### PR TITLE
Fix missing computed import in error page

### DIFF
--- a/frontend/app/error.vue
+++ b/frontend/app/error.vue
@@ -56,7 +56,7 @@ const props = defineProps<{
 
 const route = useRoute();
 const { pageWidth } = useResponsive();
-
+import { computed } from 'vue'
 const notFound = computed(() => props.error?.statusCode === 404);
 
 watch(route, () => {


### PR DESCRIPTION
Adds missing `computed` import in the error page frontend component.