### PR TITLE
feat: always display tooltip healthscore tab

### DIFF
--- a/frontend/app/components/modules/project/components/overview/score-details/score-tab-view.vue
+++ b/frontend/app/components/modules/project/components/overview/score-details/score-tab-view.vue
@@ -9,13 +9,24 @@ SPDX-License-Identifier: MIT
       :tabs="tabsOptions"
     >
       <template #slotItem="{ option }">
-        <lfx-tooltip
-          v-if="!scoreDisplay[option.value as keyof typeof scoreDisplay]"
-          class="!w-full"
-        >
+        <lfx-tooltip class="!w-full">
           <template #content>
-            <p class="max-w-60">
+            <p
+              v-if="!scoreDisplay[option.value as keyof typeof scoreDisplay]"
+              class="max-w-60"
+            >
               {{ option.label }} metrics are unavailable because the required data isn't available for this project.
+              <a
+                :href="links.securityScore"
+                target="_blank"
+                class="text-brand-500"
+                >Learn more</a
+              >
+            </p>
+            <p
+              v-else
+              class="max-w-60"
+            >
               <a
                 :href="links.securityScore"
                 target="_blank"
@@ -25,7 +36,13 @@ SPDX-License-Identifier: MIT
             </p>
           </template>
           <div class="flex flex-col gap-2 items-start cursor-not-allowed">
-            <div class="text-sm tab-label text-neutral-400">
+            <div
+              class="text-sm tab-label"
+              :class="{
+                'text-neutral-400': !scoreDisplay[option.value as keyof typeof scoreDisplay],
+                'text-neutral-900': scoreDisplay[option.value as keyof typeof scoreDisplay],
+              }"
+            >
               {{ option.label }}
             </div>
             <div class="text-sm text-gray-500 w-full">
@@ -43,27 +60,6 @@ SPDX-License-Identifier: MIT
             </div>
           </div>
         </lfx-tooltip>
-        <div
-          v-else
-          class="flex flex-col gap-2 items-start"
-        >
-          <div class="text-sm tab-label text-neutral-900">
-            {{ option.label }}
-          </div>
-          <div class="text-sm text-gray-500 w-full">
-            <lfx-skeleton-state
-              :status="status"
-              height=".188rem"
-              width="100%"
-            >
-              <lfx-progress-bar
-                size="small"
-                :values="[getValues(option.value)]"
-                :color="getColor(getValues(option.value))"
-              />
-            </lfx-skeleton-state>
-          </div>
-        </div>
       </template>
     </lfx-tabs>
     <template


### PR DESCRIPTION
## In this PR

Quick fix to always display tooltip on the health score tabs instead of only showing them when disabled

## Ticket
[IN-900](https://linuxfoundation.atlassian.net/browse/IN-900)

Note: this was requested via slack

[IN-900]: https://linuxfoundation.atlassian.net/browse/IN-900?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ