### PR TITLE
fix: leaderboard card click propagation

### DIFF
--- a/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-decimal.vue
+++ b/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-decimal.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: MIT
       />
       <p
         :title="item.name"
-        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm project-link"
-        @click="navigateToProject(item.slug)"
+        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm"
+        @click.prevent.stop="navigateToProject(item.slug)"
       >
         {{ item.name }}
       </p>

--- a/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-duration.vue
+++ b/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-duration.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: MIT
       />
       <p
         :title="item.name"
-        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm project-link"
-        @click="navigateToProject(item.slug)"
+        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm"
+        @click.prevent.stop="navigateToProject(item.slug)"
       >
         {{ item.name }}
       </p>

--- a/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-integer.vue
+++ b/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-integer.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: MIT
       />
       <p
         :title="item.name"
-        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm project-link"
-        @click="navigateToProject(item.slug)"
+        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm"
+        @click.prevent.stop="navigateToProject(item.slug)"
       >
         {{ item.name }}
       </p>

--- a/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-timestamp.vue
+++ b/frontend/app/components/modules/leaderboards/components/minimize-row-displays/project-timestamp.vue
@@ -19,8 +19,8 @@ SPDX-License-Identifier: MIT
       />
       <p
         :title="item.name"
-        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm project-link"
-        @click="navigateToProject(item.slug)"
+        class="font-medium text-neutral-900 overflow-hidden text-ellipsis whitespace-nowrap max-w-full hover:underline cursor-pointer text-sm"
+        @click.prevent.stop="navigateToProject(item.slug)"
       >
         {{ item.name }}
       </p>

--- a/frontend/app/components/modules/leaderboards/components/sections/leaderboard-card.vue
+++ b/frontend/app/components/modules/leaderboards/components/sections/leaderboard-card.vue
@@ -121,7 +121,7 @@ const handleCardClick = (event: MouseEvent) => {
   if (window.innerWidth >= 640) {
     // Don't navigate if clicking on the share button
     const target = event.target as HTMLElement;
-    if (target.closest('button') || target.classList.contains('project-link')) {
+    if (target.closest('button')) {
       return;
     }
     navigateToLeaderboard();


### PR DESCRIPTION
## In this PR

Added check on the leaderboard card to prevent click propagation if the user clicks on the project name which should take the user to the project page.

## Ticket
[IN-945](https://linuxfoundation.atlassian.net/browse/IN-945)

[IN-945]: https://linuxfoundation.atlassian.net/browse/IN-945?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ