### PR TITLE
feat: hide security and best practice score if the project is archived

### DIFF
--- a/frontend/app/components/modules/project/components/overview/trust-score.vue
+++ b/frontend/app/components/modules/project/components/overview/trust-score.vue
@@ -101,7 +101,6 @@ SPDX-License-Identifier: MIT
 import { computed } from 'vue';
 import type { AsyncDataRequestStatus } from 'nuxt/app';
 import { storeToRefs } from 'pinia';
-import pluralize from 'pluralize';
 import LfxProjectTrustScoreDisplay from './trust-score/score-display.vue';
 import LfxProjectTrustScoreShareBadge from './trust-score/share-badge.vue';
 import { links } from '~/config/links';
@@ -123,22 +122,7 @@ const props = defineProps<{
 
 const overallScore = computed(() => Math.round(props.trustScoreSummary ? props.trustScoreSummary.overall : 0));
 const hideOverallScore = computed(() => Object.values(props.scoreDisplay).some((score) => !score));
-const { selectedRepositories, allArchived, archivedRepos, isProjectArchived } = storeToRefs(useProjectStore());
-
-const isArchived = computed(() => allArchived.value || isProjectArchived.value);
-
-const emptyStateTitle = computed(() => {
-  if (isProjectArchived.value) {
-    return 'Archived Project';
-  }
-  return pluralize('Archived Repository', archivedRepos.value.length);
-});
-
-const emptyStateDescription = computed(() => {
-  return `Archived ${isProjectArchived.value ? 'project' : 'repositories'} are excluded from 
-    Health Score and Security & Best practices. You can still access historical data of Contributors, 
-    Popularity, or Development metrics.`;
-});
+const { selectedRepositories, isArchived, emptyStateTitle, emptyStateDescription } = storeToRefs(useProjectStore());
 </script>
 <script lang="ts">
 export default {

--- a/frontend/app/components/modules/project/store/project.store.ts
+++ b/frontend/app/components/modules/project/store/project.store.ts
@@ -4,6 +4,7 @@ import { defineStore } from 'pinia';
 import { ref, computed } from 'vue';
 import { useRoute } from 'nuxt/app';
 import { DateTime } from 'luxon';
+import pluralize from 'pluralize';
 import {
   dateOptKeys,
   lfxProjectDateOptions,
@@ -121,6 +122,21 @@ export const useProjectStore = defineStore('project', () => {
   );
 
   const isProjectArchived = computed(() => project.value?.status === 'archived');
+  // If all repos are archived or the project is archived
+  const isArchived = computed(() => allArchived.value || isProjectArchived.value);
+
+  const emptyStateTitle = computed(() => {
+    if (isProjectArchived.value) {
+      return 'Archived Project';
+    }
+    return pluralize('Archived Repository', archivedRepos.value.length);
+  });
+
+  const emptyStateDescription = computed(() => {
+    return `Archived ${isProjectArchived.value ? 'project' : 'repositories'} are excluded from 
+      Health Score and Security & Best practices. You can still access historical data of Contributors, 
+      Popularity, or Development metrics.`;
+  });
 
   // If any selected repo is archived
   const hasSelectedArchivedRepos = computed(
@@ -148,5 +164,8 @@ export const useProjectStore = defineStore('project', () => {
     hasSelectedArchivedRepos,
     collaborationSet,
     isProjectArchived,
+    isArchived,
+    emptyStateTitle,
+    emptyStateDescription,
   };
 });

--- a/frontend/app/components/modules/project/views/security.vue
+++ b/frontend/app/components/modules/project/views/security.vue
@@ -19,7 +19,7 @@ SPDX-License-Identifier: MIT
         <div class="md:w-3/4 w-full md:border-r border-neutral-200 pr-6 sm:pr-8">
           <!-- Disclaimer for aggregated view -->
           <div
-            v-if="!isRepository"
+            v-if="!isRepository && !isArchived"
             class="p-3 bg-neutral-50 border-y border-neutral-100 flex items-center gap-1.5 rounded-md"
           >
             <lfx-icon
@@ -55,11 +55,10 @@ SPDX-License-Identifier: MIT
 
             <!-- show if all repos are archived -->
             <lfx-empty-state
-              v-else-if="allArchived"
+              v-else-if="isArchived"
               icon="archive"
-              :title="pluralize('Archived Repository', archivedRepos.length)"
-              description="Archived repositories are excluded from Health Score and Security & Best practices.
-                    You can still access historical data of Contributors, Popularity, or Development metrics."
+              :title="emptyStateTitle"
+              :description="emptyStateDescription"
             />
 
             <!-- Show if no data available -->
@@ -147,7 +146,6 @@ SPDX-License-Identifier: MIT
 <script setup lang="ts">
 import { useRoute } from 'nuxt/app';
 import { computed, onServerPrefetch, ref } from 'vue';
-import pluralize from 'pluralize';
 import { storeToRefs } from 'pinia';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
@@ -173,7 +171,8 @@ const isSearchRepoModalOpen = ref(false);
 const route = useRoute();
 const { name } = route.params;
 
-const { selectedReposValues, allArchived, archivedRepos, hasSelectedArchivedRepos } = storeToRefs(useProjectStore());
+const { selectedReposValues, isArchived, emptyStateTitle, emptyStateDescription, hasSelectedArchivedRepos } =
+  storeToRefs(useProjectStore());
 
 const isRepository = computed(() => !!name);
 const isReposEvalModalOpen = ref(false);


### PR DESCRIPTION
##  In this PR

This is a follow up PR to hide the security and best practices if a project is archived. 

## Ticket
[IN-972](https://linuxfoundation.atlassian.net/browse/IN-972)

[IN-972]: https://linuxfoundation.atlassian.net/browse/IN-972?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ