### PR TITLE
fix: placement of the archive tag in the collections details view

### DIFF
--- a/frontend/app/components/modules/collection/components/details/collection-project-item.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-project-item.vue
@@ -13,13 +13,13 @@ SPDX-License-Identifier: MIT
         :is-lf="props.project.isLF"
         :alt="props.project.name"
       />
+      {{ props.project.name }}
       <lfx-archived-tag
         v-if="props.project.status === 'archived'"
         :archived="true"
         label="Archived"
         type="project"
       />
-      {{ props.project.name }}
     </div>
     <div class="w-1/5">
       {{ formatNumber(props.project.contributorCount) }}


### PR DESCRIPTION
## In this PR

Quick fix for the placement of the archive tag in the projects list in the collections details view

## Ticket
[N-1000](https://linuxfoundation.atlassian.net/browse/IN-1000)