### PR TITLE
fix: collection details url from open source index page

### DIFF
--- a/frontend/app/components/modules/open-source-index/services/osi.api.service.ts
+++ b/frontend/app/components/modules/open-source-index/services/osi.api.service.ts
@@ -175,7 +175,7 @@ class OssIndexApiService {
         link = `/${LfxRoutes.OPENSOURCEINDEX}/category`;
         break;
       default: // collection
-        link = '/collection';
+        link = '/collection/details';
     }
 
     const filteredData = this.filterDataByLimit(data);


### PR DESCRIPTION
## In this PR

Quick fix incorrect collection details url from open source index page

