### PR TITLE
chore: disable KubeCon Europe 2026 banner

### DIFF
--- a/frontend/app/config/banner.config.ts
+++ b/frontend/app/config/banner.config.ts
@@ -7,5 +7,5 @@ export const bannerConfig = {
   link: 'https://events.linuxfoundation.org/kubecon-cloudnativecon-europe/register/?utm_source=lfx-insights&utm_medium=homepage&utm_campaign=18269725-KubeCon-EU-2026&utm_content=banner',
   validUntil: new Date('2026-03-23'),
   key: 'lfx-kubecon2026-banner',
-  enabled: true,
+  enabled: false,
 };


### PR DESCRIPTION
## Summary
- Disables the KubeCon + CloudNativeCon Europe 2026 promotional banner from the Insights app

## Test plan
- [ ] Verify banner no longer appears on the homepage