### PR TITLE
fix: open source index category error handling (IN-1059)

### DIFF
--- a/frontend/app/components/modules/open-source-index/views/open-source-index-category.vue
+++ b/frontend/app/components/modules/open-source-index/views/open-source-index-category.vue
@@ -10,10 +10,11 @@ SPDX-License-Identifier: MIT
   >
     <div class="flex items-center">
       <router-link
+        v-if="data?.categoryGroupSlug"
         :to="{
           name: LfxRoutes.OPENSOURCEINDEX_GROUP,
           params: {
-            slug: data?.categoryGroupSlug || '',
+            slug: data.categoryGroupSlug,
           },
           query: {
             sort,

--- a/frontend/app/pages/open-source-index/category/[slug].vue
+++ b/frontend/app/pages/open-source-index/category/[slug].vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: MIT
 <script setup lang="ts">
 import { computed, onServerPrefetch, ref } from 'vue';
 import { useRoute } from 'vue-router';
+import { createError, showError } from 'nuxt/app';
 import LfxOpenSourceIndexCategory from '~/components/modules/open-source-index/views/open-source-index-category.vue';
 import { OSS_INDEX_API_SERVICE, type SortType } from '~/components/modules/open-source-index/services/osi.api.service';
 
@@ -16,10 +17,17 @@ const route = useRoute();
 const slug = ref<string>((route.params.slug as string) || '');
 const sort = ref<SortType>((route.query.sort as SortType) || 'totalContributors');
 
-const { data, suspense } = OSS_INDEX_API_SERVICE.fetchOSSCollection(slug.value, sort);
+const { data, isError, suspense } = OSS_INDEX_API_SERVICE.fetchOSSCollection(slug.value, sort);
 
 onServerPrefetch(async () => {
   await suspense();
+  if (isError.value) {
+    if (import.meta.server) {
+      throw createError({ statusCode: 404, statusMessage: 'Category not found' });
+    } else {
+      showError({ statusCode: 404, statusMessage: 'Category not found' });
+    }
+  }
 });
 
 const title = computed(() => `${data.value?.name || 'Projects'} Projects | LFX Insights`);

--- a/frontend/server/api/ossindex/collections.ts
+++ b/frontend/server/api/ossindex/collections.ts
@@ -83,7 +83,10 @@ export default defineEventHandler(async (event): Promise<OSSIndexCategoryDetails
       page,
       pageSize,
     };
-  } catch (error) {
+  } catch (error: unknown) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
     console.error('Error fetching oss index collection list from TinyBird:', error);
     throw createError({ statusCode: 500, statusMessage: 'Internal Server Error' });
   }


### PR DESCRIPTION
This pull request enhances error handling and improves conditional rendering in the Open Source Index category pages. The main focus is on providing more robust and user-friendly error responses when a category is not found, and ensuring that navigation links are only rendered when appropriate data is available.

**Error handling improvements:**

* The API handler in `collections.ts` now checks if an error already contains a `statusCode` property and rethrows it, allowing for more accurate error propagation and avoiding unnecessary masking of upstream errors.
* The category page (`[slug].vue`) adds logic to detect errors after fetching a collection; if a category is not found, it throws or displays a 404 error depending on whether the code is running server-side or client-side. ([frontend/app/pages/open-source-index/category/[slug].vueR12-R30](diffhunk://#diff-413352401de8150b2ee56ddadff2565dd1bfd3eb2b5717b76206ebe024c3d3a6R12-R30))

**UI rendering improvements:**

* The category view component (`open-source-index-category.vue`) now only renders the group navigation link if `categoryGroupSlug` data is available, preventing broken or empty links.