### PR TITLE
fix: refresh agentic-ai-momentum data and add vintage badge

### DIFF
--- a/frontend/app/components/modules/report/agentic-ai-momentum/views/agentic-ai-momentum-report.vue
+++ b/frontend/app/components/modules/report/agentic-ai-momentum/views/agentic-ai-momentum-report.vue
@@ -13,6 +13,16 @@ SPDX-License-Identifier: MIT
         <p class="text-body-2 md:text-body-1 text-neutral-600">
           Tracking the most critical agentic AI projects across the ecosystem
         </p>
+        <span
+          v-if="vintageDate"
+          class="inline-flex items-center gap-1.5 bg-neutral-100 text-neutral-600 rounded-full px-2.5 py-1 text-xs font-medium mt-2"
+        >
+          <lfx-icon
+            name="calendar-days"
+            :size="12"
+          />
+          Updated: {{ vintageDate }}
+        </span>
       </div>
       <a
         href="https://aaif.io/"
@@ -152,6 +162,8 @@ import LfxAgenticMetricExplorer from '../components/metric-explorer.vue';
 import { AGENTIC_AI_MOMENTUM_API_SERVICE } from '../services/agentic-ai-momentum.api.service';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxTabs from '~/components/uikit/tabs/tabs.vue';
+import LfxIcon from '~/components/uikit/icon/icon.vue';
+import { formatDate } from '~/components/shared/utils/formatter';
 
 // Fetch all data
 const { data: projectsResponse, status: projectsStatus } = AGENTIC_AI_MOMENTUM_API_SERVICE.fetchProjects();
@@ -197,6 +209,9 @@ const issueResponseTimeData = computed(() => issueResponseTimeResponse.value?.da
 const noResponseShareData = computed(() => noResponseShareResponse.value?.data ?? []);
 const prTimeToResolveData = computed(() => prTimeToResolveResponse.value?.data ?? []);
 const totalVulnerabilitiesData = computed(() => totalVulnerabilitiesResponse.value?.data ?? []);
+
+// Data vintage date (formatted from metadata.fetched_at of the projects dataset)
+const vintageDate = computed(() => formatDate(projectsResponse.value?.metadata?.fetched_at ?? '', 'MMMM yyyy'));
 
 // Loading states
 const isLoading = computed(

--- a/frontend/public/data/agentic-ai-momentum/closed_issues_count.json
+++ b/frontend/public/data/agentic-ai-momentum/closed_issues_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:21.216010",
+    "fetched_at": "2026-04-01T07:13:57.061619",
     "schema": {
       "name": "closed_issues_count",
       "description": "Monthly count of issues closed for tracked repositories.",
@@ -155,17 +155,22 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 8
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-05-01",
+      "closed_issues_count": 1
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 3
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
@@ -180,87 +185,87 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "closed_issues_count": 15
+      "closed_issues_count": 16
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "closed_issues_count": 2
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "closed_issues_count": 2
+      "closed_issues_count": 3
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 13
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "closed_issues_count": 14
+      "closed_issues_count": 21
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 5
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 5
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "closed_issues_count": 2
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-09-01",
-      "closed_issues_count": 5
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-10-01",
-      "closed_issues_count": 5
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-11-01",
       "closed_issues_count": 3
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-12-01",
+      "month": "2025-09-01",
       "closed_issues_count": 9
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-10-01",
+      "closed_issues_count": 6
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-11-01",
+      "closed_issues_count": 4
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-12-01",
+      "closed_issues_count": 12
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -355,7 +360,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-09-01",
-      "closed_issues_count": 189
+      "closed_issues_count": 188
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -380,7 +385,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "closed_issues_count": 297
+      "closed_issues_count": 298
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -410,42 +415,42 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "closed_issues_count": 10
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2024-10-01",
-      "closed_issues_count": 9
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2024-11-01",
-      "closed_issues_count": 6
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2024-12-01",
-      "closed_issues_count": 30
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-01-01",
-      "closed_issues_count": 30
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-02-01",
-      "closed_issues_count": 64
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-03-01",
       "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2024-10-01",
+      "closed_issues_count": 20
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2024-11-01",
+      "closed_issues_count": 7
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2024-12-01",
+      "closed_issues_count": 31
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-01-01",
+      "closed_issues_count": 31
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-02-01",
+      "closed_issues_count": 66
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-03-01",
+      "closed_issues_count": 12
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "closed_issues_count": 14
+      "closed_issues_count": 15
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -465,7 +470,7 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 17
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -475,27 +480,27 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "closed_issues_count": 65
+      "closed_issues_count": 70
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 9
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "closed_issues_count": 8
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -720,7 +725,7 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-12-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -735,122 +740,122 @@
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "closed_issues_count": 133
+      "closed_issues_count": 152
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "closed_issues_count": 397
+      "closed_issues_count": 468
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "closed_issues_count": 161
+      "closed_issues_count": 172
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "closed_issues_count": 83
+      "closed_issues_count": 112
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "closed_issues_count": 64
+      "closed_issues_count": 92
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "closed_issues_count": 57
+      "closed_issues_count": 59
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "closed_issues_count": 63
+      "closed_issues_count": 68
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "closed_issues_count": 58
+      "closed_issues_count": 70
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "closed_issues_count": 118
+      "closed_issues_count": 135
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "closed_issues_count": 114
+      "closed_issues_count": 151
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "closed_issues_count": 81
+      "closed_issues_count": 115
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "closed_issues_count": 60
+      "closed_issues_count": 90
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "closed_issues_count": 69
+      "closed_issues_count": 87
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "closed_issues_count": 61
+      "closed_issues_count": 68
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "closed_issues_count": 75
+      "closed_issues_count": 85
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "closed_issues_count": 78
+      "closed_issues_count": 85
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "closed_issues_count": 57
+      "closed_issues_count": 71
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "closed_issues_count": 64
+      "closed_issues_count": 78
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "closed_issues_count": 37
+      "closed_issues_count": 43
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "closed_issues_count": 45
+      "closed_issues_count": 55
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "closed_issues_count": 33
+      "closed_issues_count": 48
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "closed_issues_count": 61
+      "closed_issues_count": 65
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "closed_issues_count": 57
+      "closed_issues_count": 62
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "closed_issues_count": 25
+      "closed_issues_count": 39
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -980,7 +985,7 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "closed_issues_count": 11
+      "closed_issues_count": 13
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -990,12 +995,12 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1010,17 +1015,17 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 13
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1030,32 +1035,32 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "closed_issues_count": 19
+      "closed_issues_count": 22
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "closed_issues_count": 13
+      "closed_issues_count": 15
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "closed_issues_count": 8
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1550,82 +1555,82 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "closed_issues_count": 38
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-02-01",
-      "closed_issues_count": 74
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-03-01",
-      "closed_issues_count": 56
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-04-01",
-      "closed_issues_count": 62
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-05-01",
-      "closed_issues_count": 122
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-06-01",
-      "closed_issues_count": 41
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-07-01",
-      "closed_issues_count": 44
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-08-01",
-      "closed_issues_count": 104
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-09-01",
-      "closed_issues_count": 326
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-10-01",
-      "closed_issues_count": 24
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-11-01",
       "closed_issues_count": 40
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-02-01",
+      "closed_issues_count": 83
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-03-01",
+      "closed_issues_count": 62
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-04-01",
+      "closed_issues_count": 71
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-05-01",
+      "closed_issues_count": 133
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-06-01",
+      "closed_issues_count": 45
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-07-01",
+      "closed_issues_count": 59
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-08-01",
+      "closed_issues_count": 116
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-09-01",
+      "closed_issues_count": 391
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-10-01",
+      "closed_issues_count": 28
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-11-01",
+      "closed_issues_count": 52
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "closed_issues_count": 14
+      "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "closed_issues_count": 22
+      "closed_issues_count": 32
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "closed_issues_count": 21
+      "closed_issues_count": 32
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-03-01",
-      "closed_issues_count": 11
+      "closed_issues_count": 13
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1635,17 +1640,17 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "closed_issues_count": 17
+      "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "closed_issues_count": 24
+      "closed_issues_count": 26
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "closed_issues_count": 30
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1660,87 +1665,87 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "closed_issues_count": 40
+      "closed_issues_count": 43
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "closed_issues_count": 35
+      "closed_issues_count": 38
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "closed_issues_count": 50
+      "closed_issues_count": 51
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "closed_issues_count": 26
+      "closed_issues_count": 30
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "closed_issues_count": 46
+      "closed_issues_count": 48
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "closed_issues_count": 80
+      "closed_issues_count": 85
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "closed_issues_count": 52
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-05-01",
-      "closed_issues_count": 68
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-06-01",
       "closed_issues_count": 58
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-05-01",
+      "closed_issues_count": 72
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-06-01",
+      "closed_issues_count": 63
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "closed_issues_count": 28
+      "closed_issues_count": 32
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "closed_issues_count": 25
+      "closed_issues_count": 28
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "closed_issues_count": 27
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "closed_issues_count": 37
+      "closed_issues_count": 48
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "closed_issues_count": 15
+      "closed_issues_count": 29
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "closed_issues_count": 24
+      "closed_issues_count": 32
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "closed_issues_count": 212
+      "closed_issues_count": 225
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -1960,7 +1965,7 @@
     {
       "repo": "https://github.com/cline/cline",
       "month": "2026-02-01",
-      "closed_issues_count": 189
+      "closed_issues_count": 190
     },
     {
       "repo": "https://github.com/comet-ml/opik",
@@ -1975,92 +1980,92 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "closed_issues_count": 35
+      "closed_issues_count": 38
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "closed_issues_count": 14
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-01-01",
-      "closed_issues_count": 15
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-02-01",
-      "closed_issues_count": 24
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-03-01",
-      "closed_issues_count": 19
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-04-01",
-      "closed_issues_count": 15
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-05-01",
-      "closed_issues_count": 29
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-06-01",
-      "closed_issues_count": 16
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-07-01",
-      "closed_issues_count": 18
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-08-01",
-      "closed_issues_count": 17
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-09-01",
       "closed_issues_count": 21
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-10-01",
-      "closed_issues_count": 25
+      "month": "2025-01-01",
+      "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-11-01",
-      "closed_issues_count": 27
+      "month": "2025-02-01",
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-12-01",
+      "month": "2025-03-01",
+      "closed_issues_count": 30
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-04-01",
+      "closed_issues_count": 18
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-05-01",
+      "closed_issues_count": 40
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-06-01",
+      "closed_issues_count": 21
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-07-01",
+      "closed_issues_count": 32
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-08-01",
       "closed_issues_count": 26
     },
     {
       "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-09-01",
+      "closed_issues_count": 30
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-10-01",
+      "closed_issues_count": 31
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-11-01",
+      "closed_issues_count": 44
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-12-01",
+      "closed_issues_count": 44
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "closed_issues_count": 20
+      "closed_issues_count": 24
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 8
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2070,7 +2075,7 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2085,17 +2090,17 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 8
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-10-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 19
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2105,7 +2110,7 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2115,22 +2120,22 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "closed_issues_count": 7
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-03-01",
       "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-03-01",
+      "closed_issues_count": 11
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "closed_issues_count": 14
+      "closed_issues_count": 17
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2140,42 +2145,42 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "closed_issues_count": 12
+      "closed_issues_count": 16
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "closed_issues_count": 11
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "closed_issues_count": 28
+      "closed_issues_count": 34
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 9
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 17
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2235,7 +2240,7 @@
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-02-01",
-      "closed_issues_count": 179
+      "closed_issues_count": 180
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2420,7 +2425,7 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "closed_issues_count": 101
+      "closed_issues_count": 105
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
@@ -2430,107 +2435,112 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "closed_issues_count": 63
+      "closed_issues_count": 66
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "closed_issues_count": 38
+      "closed_issues_count": 42
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "closed_issues_count": 48
+      "closed_issues_count": 51
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "closed_issues_count": 44
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2024-09-01",
-      "closed_issues_count": 59
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2024-10-01",
       "closed_issues_count": 47
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
+      "month": "2024-09-01",
+      "closed_issues_count": 63
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2024-10-01",
+      "closed_issues_count": 48
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "closed_issues_count": 24
+      "closed_issues_count": 29
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "closed_issues_count": 24
+      "closed_issues_count": 27
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "closed_issues_count": 21
+      "closed_issues_count": 22
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "closed_issues_count": 4
+      "closed_issues_count": 5
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-03-01",
+      "closed_issues_count": 1
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "closed_issues_count": 71
+      "closed_issues_count": 81
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "closed_issues_count": 17
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-06-01",
-      "closed_issues_count": 20
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-07-01",
-      "closed_issues_count": 9
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-08-01",
-      "closed_issues_count": 8
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-09-01",
-      "closed_issues_count": 7
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-10-01",
-      "closed_issues_count": 26
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-11-01",
-      "closed_issues_count": 21
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-12-01",
-      "closed_issues_count": 7
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2026-01-01",
       "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-06-01",
+      "closed_issues_count": 23
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-07-01",
+      "closed_issues_count": 11
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-08-01",
+      "closed_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-09-01",
+      "closed_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-10-01",
+      "closed_issues_count": 36
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-11-01",
+      "closed_issues_count": 24
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-12-01",
+      "closed_issues_count": 8
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2026-01-01",
+      "closed_issues_count": 28
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 22
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2684,6 +2694,11 @@
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2024-10-01",
+      "closed_issues_count": 1
+    },
+    {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-11-01",
       "closed_issues_count": 1
     },
@@ -2740,67 +2755,67 @@
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "closed_issues_count": 86
+      "closed_issues_count": 129
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "closed_issues_count": 141
+      "closed_issues_count": 221
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "closed_issues_count": 42
+      "closed_issues_count": 62
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "closed_issues_count": 49
+      "closed_issues_count": 90
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "closed_issues_count": 63
+      "closed_issues_count": 160
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "closed_issues_count": 23
+      "closed_issues_count": 40
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "closed_issues_count": 72
+      "closed_issues_count": 262
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "closed_issues_count": 126
+      "closed_issues_count": 203
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "closed_issues_count": 20
+      "closed_issues_count": 86
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "closed_issues_count": 25
+      "closed_issues_count": 75
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "closed_issues_count": 25
+      "closed_issues_count": 105
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "closed_issues_count": 8
+      "closed_issues_count": 9
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2815,17 +2830,17 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "closed_issues_count": 18
+      "closed_issues_count": 20
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "closed_issues_count": 4
+      "closed_issues_count": 5
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2835,7 +2850,7 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2845,7 +2860,7 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "closed_issues_count": 2
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2855,12 +2870,17 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 3
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
       "closed_issues_count": 3
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-05-01",
+      "closed_issues_count": 1
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2870,7 +2890,7 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "closed_issues_count": 2
+      "closed_issues_count": 3
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2880,17 +2900,17 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 6
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2925,7 +2945,7 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-04-01",
-      "closed_issues_count": 41
+      "closed_issues_count": 42
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -3035,7 +3055,7 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "closed_issues_count": 108
+      "closed_issues_count": 107
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3331,6 +3351,11 @@
       "repo": "https://github.com/janhq/jan",
       "month": "2026-02-01",
       "closed_issues_count": 31
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-07-01",
+      "closed_issues_count": 1
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -3775,7 +3800,7 @@
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2025-07-01",
-      "closed_issues_count": 110
+      "closed_issues_count": 111
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
@@ -3935,27 +3960,27 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 5
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "closed_issues_count": 18
+      "closed_issues_count": 20
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "closed_issues_count": 13
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 20
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "closed_issues_count": 15
+      "closed_issues_count": 20
     },
     {
       "repo": "https://github.com/livekit/agents",
@@ -3965,87 +3990,87 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "closed_issues_count": 46
+      "closed_issues_count": 51
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "closed_issues_count": 27
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-12-01",
-      "closed_issues_count": 25
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-01-01",
       "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/livekit/agents",
+      "month": "2024-12-01",
+      "closed_issues_count": 28
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-01-01",
+      "closed_issues_count": 34
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "closed_issues_count": 18
+      "closed_issues_count": 21
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "closed_issues_count": 40
+      "closed_issues_count": 47
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "closed_issues_count": 56
+      "closed_issues_count": 69
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "closed_issues_count": 84
+      "closed_issues_count": 110
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "closed_issues_count": 67
+      "closed_issues_count": 79
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "closed_issues_count": 50
+      "closed_issues_count": 60
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "closed_issues_count": 59
+      "closed_issues_count": 68
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "closed_issues_count": 64
+      "closed_issues_count": 75
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "closed_issues_count": 50
+      "closed_issues_count": 62
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "closed_issues_count": 44
+      "closed_issues_count": 57
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "closed_issues_count": 56
+      "closed_issues_count": 75
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "closed_issues_count": 29
+      "closed_issues_count": 40
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "closed_issues_count": 36
+      "closed_issues_count": 41
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4070,62 +4095,62 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "closed_issues_count": 87
+      "closed_issues_count": 89
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "closed_issues_count": 74
+      "closed_issues_count": 77
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "closed_issues_count": 117
+      "closed_issues_count": 119
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "closed_issues_count": 270
+      "closed_issues_count": 276
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "closed_issues_count": 256
+      "closed_issues_count": 263
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "closed_issues_count": 201
+      "closed_issues_count": 204
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "closed_issues_count": 356
+      "closed_issues_count": 364
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "closed_issues_count": 350
+      "closed_issues_count": 364
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "closed_issues_count": 198
+      "closed_issues_count": 358
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "closed_issues_count": 155
+      "closed_issues_count": 322
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "closed_issues_count": 113
+      "closed_issues_count": 242
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "closed_issues_count": 96
+      "closed_issues_count": 221
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4150,17 +4175,17 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "closed_issues_count": 22
+      "closed_issues_count": 26
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "closed_issues_count": 4
+      "closed_issues_count": 6
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 3
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4183,39 +4208,49 @@
       "closed_issues_count": 1
     },
     {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-10-01",
+      "closed_issues_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-12-01",
+      "closed_issues_count": 1
+    },
+    {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "closed_issues_count": 24
+      "closed_issues_count": 28
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 17
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 8
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 6
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4230,7 +4265,12 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 6
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-02-01",
+      "closed_issues_count": 1
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4240,7 +4280,7 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-09-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -4365,27 +4405,27 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "closed_issues_count": 171
+      "closed_issues_count": 199
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "closed_issues_count": 71
+      "closed_issues_count": 85
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "closed_issues_count": 19
+      "closed_issues_count": 24
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "closed_issues_count": 14
+      "closed_issues_count": 15
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "closed_issues_count": 18
+      "closed_issues_count": 19
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
@@ -4395,22 +4435,22 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "closed_issues_count": 17
+      "closed_issues_count": 19
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "closed_issues_count": 47
+      "closed_issues_count": 53
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "closed_issues_count": 21
+      "closed_issues_count": 30
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 19
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
@@ -4420,47 +4460,47 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "closed_issues_count": 27
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "closed_issues_count": 2
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "closed_issues_count": 38
+      "closed_issues_count": 49
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "closed_issues_count": 8
+      "closed_issues_count": 12
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "closed_issues_count": 36
+      "closed_issues_count": 44
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "closed_issues_count": 7
+      "closed_issues_count": 13
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "closed_issues_count": 15
+      "closed_issues_count": 22
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -4585,112 +4625,112 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "closed_issues_count": 226
+      "closed_issues_count": 248
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "closed_issues_count": 124
+      "closed_issues_count": 133
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "closed_issues_count": 92
+      "closed_issues_count": 101
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "closed_issues_count": 149
+      "closed_issues_count": 164
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "closed_issues_count": 121
+      "closed_issues_count": 130
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "closed_issues_count": 85
+      "closed_issues_count": 95
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "closed_issues_count": 98
+      "closed_issues_count": 102
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "closed_issues_count": 100
+      "closed_issues_count": 112
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "closed_issues_count": 160
+      "closed_issues_count": 178
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "closed_issues_count": 121
+      "closed_issues_count": 174
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "closed_issues_count": 98
+      "closed_issues_count": 112
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "closed_issues_count": 86
+      "closed_issues_count": 101
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "closed_issues_count": 93
+      "closed_issues_count": 107
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "closed_issues_count": 123
+      "closed_issues_count": 152
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "closed_issues_count": 117
+      "closed_issues_count": 141
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "closed_issues_count": 84
+      "closed_issues_count": 106
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "closed_issues_count": 59
+      "closed_issues_count": 68
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "closed_issues_count": 39
+      "closed_issues_count": 54
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "closed_issues_count": 20
+      "closed_issues_count": 24
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "closed_issues_count": 33
+      "closed_issues_count": 41
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "closed_issues_count": 11
+      "closed_issues_count": 15
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
@@ -4700,7 +4740,7 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "closed_issues_count": 20
+      "closed_issues_count": 25
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -4855,7 +4895,7 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-02-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 2
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
@@ -5145,7 +5185,7 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "closed_issues_count": 221
+      "closed_issues_count": 222
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -5290,7 +5330,7 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-06-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -5395,62 +5435,62 @@
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "closed_issues_count": 101
+      "closed_issues_count": 108
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "closed_issues_count": 61
+      "closed_issues_count": 72
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "closed_issues_count": 17
+      "closed_issues_count": 19
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "closed_issues_count": 54
+      "closed_issues_count": 67
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "closed_issues_count": 63
+      "closed_issues_count": 77
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "closed_issues_count": 84
+      "closed_issues_count": 95
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "closed_issues_count": 59
+      "closed_issues_count": 72
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "closed_issues_count": 42
+      "closed_issues_count": 51
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "closed_issues_count": 21
+      "closed_issues_count": 27
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "closed_issues_count": 28
+      "closed_issues_count": 30
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "closed_issues_count": 79
+      "closed_issues_count": 93
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "closed_issues_count": 31
+      "closed_issues_count": 39
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5470,7 +5510,7 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "closed_issues_count": 7637
+      "closed_issues_count": 7641
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5485,7 +5525,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5520,7 +5560,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5535,7 +5575,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "closed_issues_count": 5
+      "closed_issues_count": 6
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5550,7 +5590,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-10-01",
-      "closed_issues_count": 8
+      "closed_issues_count": 9
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5560,7 +5600,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-12-01",
-      "closed_issues_count": 17
+      "closed_issues_count": 20
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5570,7 +5610,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "closed_issues_count": 6
+      "closed_issues_count": 7
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -5595,12 +5635,12 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 11
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "closed_issues_count": 16
+      "closed_issues_count": 17
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -5610,87 +5650,87 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "closed_issues_count": 19
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2024-11-01",
       "closed_issues_count": 22
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2024-11-01",
+      "closed_issues_count": 23
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "closed_issues_count": 21
+      "closed_issues_count": 23
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "closed_issues_count": 62
+      "closed_issues_count": 70
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "closed_issues_count": 34
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-03-01",
-      "closed_issues_count": 39
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-04-01",
-      "closed_issues_count": 41
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-05-01",
       "closed_issues_count": 38
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-03-01",
+      "closed_issues_count": 43
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-04-01",
+      "closed_issues_count": 47
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-05-01",
+      "closed_issues_count": 41
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "closed_issues_count": 18
+      "closed_issues_count": 22
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "closed_issues_count": 39
+      "closed_issues_count": 46
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "closed_issues_count": 32
+      "closed_issues_count": 39
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "closed_issues_count": 37
+      "closed_issues_count": 45
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "closed_issues_count": 15
+      "closed_issues_count": 19
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "closed_issues_count": 25
+      "closed_issues_count": 34
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "closed_issues_count": 36
+      "closed_issues_count": 41
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "closed_issues_count": 57
+      "closed_issues_count": 72
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "closed_issues_count": 40
+      "closed_issues_count": 47
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -5885,7 +5925,7 @@
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2026-01-01",
-      "closed_issues_count": 65
+      "closed_issues_count": 66
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
@@ -6135,7 +6175,7 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "closed_issues_count": 29
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6170,7 +6210,7 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "closed_issues_count": 26
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6195,62 +6235,62 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "closed_issues_count": 46
+      "closed_issues_count": 51
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "closed_issues_count": 65
+      "closed_issues_count": 87
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "closed_issues_count": 62
+      "closed_issues_count": 68
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "closed_issues_count": 39
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-07-01",
-      "closed_issues_count": 45
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-08-01",
-      "closed_issues_count": 64
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-09-01",
-      "closed_issues_count": 61
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-10-01",
       "closed_issues_count": 41
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-07-01",
+      "closed_issues_count": 50
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-08-01",
+      "closed_issues_count": 71
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-09-01",
+      "closed_issues_count": 68
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-10-01",
+      "closed_issues_count": 44
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "closed_issues_count": 31
+      "closed_issues_count": 35
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "closed_issues_count": 22
+      "closed_issues_count": 27
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "closed_issues_count": 30
+      "closed_issues_count": 31
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "closed_issues_count": 14
+      "closed_issues_count": 15
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -6380,22 +6420,27 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "closed_issues_count": 36
+      "closed_issues_count": 37
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "closed_issues_count": 38
+      "closed_issues_count": 39
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 5
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-03-01",
       "closed_issues_count": 51
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-05-01",
+      "closed_issues_count": 1
     },
     {
       "repo": "https://github.com/sweepai/sweep",
@@ -6525,7 +6570,7 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "closed_issues_count": 9
+      "closed_issues_count": 10
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6545,47 +6590,47 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "closed_issues_count": 19
+      "closed_issues_count": 20
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "closed_issues_count": 43
+      "closed_issues_count": 49
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "closed_issues_count": 35
+      "closed_issues_count": 39
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "closed_issues_count": 33
+      "closed_issues_count": 42
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "closed_issues_count": 91
+      "closed_issues_count": 107
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "closed_issues_count": 19
+      "closed_issues_count": 26
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "closed_issues_count": 36
+      "closed_issues_count": 46
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "closed_issues_count": 28
+      "closed_issues_count": 38
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "closed_issues_count": 33
+      "closed_issues_count": 39
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6595,27 +6640,27 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "closed_issues_count": 48
+      "closed_issues_count": 55
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "closed_issues_count": 36
+      "closed_issues_count": 43
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "closed_issues_count": 10
+      "closed_issues_count": 14
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "closed_issues_count": 22
+      "closed_issues_count": 24
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "closed_issues_count": 21
+      "closed_issues_count": 28
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6630,12 +6675,12 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "closed_issues_count": 8
+      "closed_issues_count": 9
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-03-01",
-      "closed_issues_count": 17
+      "closed_issues_count": 18
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -6770,7 +6815,7 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "closed_issues_count": 2
+      "closed_issues_count": 6
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -6805,7 +6850,7 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 4
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -6840,12 +6885,12 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "closed_issues_count": 3
+      "closed_issues_count": 5
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "closed_issues_count": 1
+      "closed_issues_count": 2
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",

--- a/frontend/public/data/agentic-ai-momentum/commit_count.json
+++ b/frontend/public/data/agentic-ai-momentum/commit_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:03.757180",
+    "fetched_at": "2026-04-01T07:13:38.773922",
     "schema": {
       "name": "commit_count",
       "description": "Cumulative monthly commit counts for tracked repositories.",
@@ -150,122 +150,122 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "cumulative_commits": 296
+      "cumulative_commits": 666
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "cumulative_commits": 490
+      "cumulative_commits": 1035
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-05-01",
-      "cumulative_commits": 655
+      "cumulative_commits": 1351
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "cumulative_commits": 866
+      "cumulative_commits": 1636
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "cumulative_commits": 1017
+      "cumulative_commits": 1866
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "cumulative_commits": 1144
+      "cumulative_commits": 2132
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "cumulative_commits": 1429
+      "cumulative_commits": 2478
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "cumulative_commits": 1686
+      "cumulative_commits": 2893
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "cumulative_commits": 1857
+      "cumulative_commits": 3178
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "cumulative_commits": 1970
+      "cumulative_commits": 3459
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "cumulative_commits": 2019
+      "cumulative_commits": 3686
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "cumulative_commits": 2150
+      "cumulative_commits": 3941
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "cumulative_commits": 2486
+      "cumulative_commits": 4454
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "cumulative_commits": 2602
+      "cumulative_commits": 4724
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "cumulative_commits": 2643
+      "cumulative_commits": 4867
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "cumulative_commits": 2795
+      "cumulative_commits": 5110
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "cumulative_commits": 2883
+      "cumulative_commits": 5339
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "cumulative_commits": 2959
+      "cumulative_commits": 5610
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "cumulative_commits": 3022
+      "cumulative_commits": 5787
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "cumulative_commits": 3153
+      "cumulative_commits": 6108
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "cumulative_commits": 3285
+      "cumulative_commits": 6442
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "cumulative_commits": 3543
+      "cumulative_commits": 7038
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "cumulative_commits": 3673
+      "cumulative_commits": 7411
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "cumulative_commits": 4028
+      "cumulative_commits": 7877
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -385,7 +385,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "cumulative_commits": 73502
+      "cumulative_commits": 73510
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -395,117 +395,117 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-04-01",
-      "cumulative_commits": 400
+      "cumulative_commits": 403
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-05-01",
-      "cumulative_commits": 890
+      "cumulative_commits": 893
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-06-01",
-      "cumulative_commits": 1777
+      "cumulative_commits": 1782
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-07-01",
-      "cumulative_commits": 2630
+      "cumulative_commits": 2642
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-08-01",
-      "cumulative_commits": 3060
+      "cumulative_commits": 3102
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "cumulative_commits": 3411
+      "cumulative_commits": 3455
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "cumulative_commits": 3838
+      "cumulative_commits": 3883
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "cumulative_commits": 4291
+      "cumulative_commits": 4339
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "cumulative_commits": 5243
+      "cumulative_commits": 5291
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "cumulative_commits": 5774
+      "cumulative_commits": 5822
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "cumulative_commits": 6064
+      "cumulative_commits": 6112
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "cumulative_commits": 6416
+      "cumulative_commits": 6465
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "cumulative_commits": 6669
+      "cumulative_commits": 6724
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-05-01",
-      "cumulative_commits": 6969
+      "cumulative_commits": 7029
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "cumulative_commits": 7459
+      "cumulative_commits": 7657
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "cumulative_commits": 7708
+      "cumulative_commits": 7961
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "cumulative_commits": 7869
+      "cumulative_commits": 8134
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "cumulative_commits": 8260
+      "cumulative_commits": 8538
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "cumulative_commits": 8588
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-11-01",
       "cumulative_commits": 8881
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-11-01",
+      "cumulative_commits": 9183
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "cumulative_commits": 9425
+      "cumulative_commits": 9769
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "cumulative_commits": 10962
+      "cumulative_commits": 11361
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "cumulative_commits": 12445
+      "cumulative_commits": 12966
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -590,7 +590,7 @@
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-02-01",
-      "cumulative_commits": 12213
+      "cumulative_commits": 12216
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
@@ -715,272 +715,287 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "cumulative_commits": 7
+      "cumulative_commits": 24
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "cumulative_commits": 13
+      "cumulative_commits": 32
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2024-10-01",
-      "cumulative_commits": 14
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2024-12-01",
-      "cumulative_commits": 15
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-02-01",
-      "cumulative_commits": 22
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-03-01",
-      "cumulative_commits": 31
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-04-01",
+      "month": "2024-09-01",
       "cumulative_commits": 43
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-10-01",
+      "cumulative_commits": 55
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-11-01",
+      "cumulative_commits": 58
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-12-01",
+      "cumulative_commits": 64
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-02-01",
+      "cumulative_commits": 71
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-03-01",
+      "cumulative_commits": 82
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-04-01",
+      "cumulative_commits": 94
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-05-01",
-      "cumulative_commits": 49
+      "cumulative_commits": 100
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-07-01",
+      "cumulative_commits": 102
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-11-01",
-      "cumulative_commits": 50
+      "cumulative_commits": 103
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "cumulative_commits": 982
+      "cumulative_commits": 1035
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "cumulative_commits": 3338
+      "cumulative_commits": 3476
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "cumulative_commits": 6079
+      "cumulative_commits": 6265
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "cumulative_commits": 7636
+      "cumulative_commits": 7889
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "cumulative_commits": 9459
+      "cumulative_commits": 9773
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "cumulative_commits": 10883
+      "cumulative_commits": 11280
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "cumulative_commits": 12316
+      "cumulative_commits": 12808
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "cumulative_commits": 14398
+      "cumulative_commits": 14965
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "cumulative_commits": 16407
+      "cumulative_commits": 17086
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "cumulative_commits": 18806
+      "cumulative_commits": 19576
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "cumulative_commits": 21003
+      "cumulative_commits": 21903
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "cumulative_commits": 22982
+      "cumulative_commits": 24010
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "cumulative_commits": 25629
+      "cumulative_commits": 26828
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "cumulative_commits": 28956
+      "cumulative_commits": 30371
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "cumulative_commits": 32014
+      "cumulative_commits": 33588
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "cumulative_commits": 34412
+      "cumulative_commits": 36171
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "cumulative_commits": 36530
+      "cumulative_commits": 38467
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "cumulative_commits": 39625
+      "cumulative_commits": 41711
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "cumulative_commits": 41201
+      "cumulative_commits": 43535
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "cumulative_commits": 42683
+      "cumulative_commits": 45191
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "cumulative_commits": 43620
+      "cumulative_commits": 46224
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "cumulative_commits": 44996
+      "cumulative_commits": 47688
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "cumulative_commits": 46388
+      "cumulative_commits": 49206
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "cumulative_commits": 47820
+      "cumulative_commits": 50941
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-03-01",
-      "cumulative_commits": 1345
+      "cumulative_commits": 3372
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-04-01",
-      "cumulative_commits": 1438
+      "cumulative_commits": 3549
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-05-01",
-      "cumulative_commits": 1504
+      "cumulative_commits": 3649
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-06-01",
-      "cumulative_commits": 1584
+      "cumulative_commits": 3807
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-07-01",
-      "cumulative_commits": 1698
+      "cumulative_commits": 4016
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-08-01",
-      "cumulative_commits": 1838
+      "cumulative_commits": 4241
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-09-01",
-      "cumulative_commits": 1876
+      "cumulative_commits": 4298
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-10-01",
-      "cumulative_commits": 1931
+      "cumulative_commits": 4395
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-11-01",
-      "cumulative_commits": 1999
+      "cumulative_commits": 4463
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-12-01",
-      "cumulative_commits": 2036
+      "cumulative_commits": 4500
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-01-01",
-      "cumulative_commits": 2057
+      "cumulative_commits": 4521
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-02-01",
-      "cumulative_commits": 2066
+      "cumulative_commits": 4530
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-03-01",
-      "cumulative_commits": 2106
+      "cumulative_commits": 4571
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-04-01",
-      "cumulative_commits": 2109
+      "cumulative_commits": 4577
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-07-01",
-      "cumulative_commits": 2114
+      "cumulative_commits": 4584
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-08-01",
-      "cumulative_commits": 2116
+      "cumulative_commits": 4594
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-10-01",
-      "cumulative_commits": 2145
+      "cumulative_commits": 4630
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-11-01",
-      "cumulative_commits": 2173
+      "cumulative_commits": 4660
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-12-01",
-      "cumulative_commits": 2179
+      "cumulative_commits": 4667
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-01-01",
-      "cumulative_commits": 2197
+      "cumulative_commits": 4685
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-02-01",
-      "cumulative_commits": 2201
+      "cumulative_commits": 4691
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1105,122 +1120,122 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "cumulative_commits": 604
+      "cumulative_commits": 721
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "cumulative_commits": 994
+      "cumulative_commits": 1144
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "cumulative_commits": 1137
+      "cumulative_commits": 1309
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "cumulative_commits": 1226
+      "cumulative_commits": 1408
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "cumulative_commits": 1544
+      "cumulative_commits": 1734
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "cumulative_commits": 1753
+      "cumulative_commits": 1958
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "cumulative_commits": 1914
+      "cumulative_commits": 2126
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "cumulative_commits": 2156
+      "cumulative_commits": 2453
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "cumulative_commits": 2415
+      "cumulative_commits": 2779
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "cumulative_commits": 2606
+      "cumulative_commits": 3009
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "cumulative_commits": 2682
+      "cumulative_commits": 3099
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "cumulative_commits": 2743
+      "cumulative_commits": 3174
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "cumulative_commits": 2858
+      "cumulative_commits": 3299
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "cumulative_commits": 3031
+      "cumulative_commits": 3492
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "cumulative_commits": 3073
+      "cumulative_commits": 3545
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "cumulative_commits": 3251
+      "cumulative_commits": 3758
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "cumulative_commits": 3329
+      "cumulative_commits": 3872
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "cumulative_commits": 3377
+      "cumulative_commits": 3926
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-09-01",
-      "cumulative_commits": 3429
+      "cumulative_commits": 4018
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-10-01",
-      "cumulative_commits": 3517
+      "cumulative_commits": 4169
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "cumulative_commits": 3582
+      "cumulative_commits": 4250
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-12-01",
-      "cumulative_commits": 3623
+      "cumulative_commits": 4295
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "cumulative_commits": 3633
+      "cumulative_commits": 4310
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "cumulative_commits": 3646
+      "cumulative_commits": 4324
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -1340,7 +1355,7 @@
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "cumulative_commits": 35448
+      "cumulative_commits": 35449
     },
     {
       "repo": "https://github.com/agntcy/acp-spec",
@@ -1705,7 +1720,7 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "cumulative_commits": 20608
+      "cumulative_commits": 20610
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
@@ -1715,202 +1730,202 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "cumulative_commits": 564
+      "cumulative_commits": 567
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "cumulative_commits": 886
+      "cumulative_commits": 890
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "cumulative_commits": 1256
+      "cumulative_commits": 1320
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "cumulative_commits": 1825
+      "cumulative_commits": 1944
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "cumulative_commits": 2619
+      "cumulative_commits": 2819
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "cumulative_commits": 3462
+      "cumulative_commits": 3740
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "cumulative_commits": 4913
+      "cumulative_commits": 5295
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "cumulative_commits": 6820
+      "cumulative_commits": 7265
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "cumulative_commits": 8512
+      "cumulative_commits": 9079
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-08-01",
-      "cumulative_commits": 9935
+      "cumulative_commits": 10551
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-09-01",
-      "cumulative_commits": 10880
+      "cumulative_commits": 11622
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-10-01",
-      "cumulative_commits": 12179
+      "cumulative_commits": 13046
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "cumulative_commits": 12919
+      "cumulative_commits": 13875
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "cumulative_commits": 13208
+      "cumulative_commits": 14182
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "cumulative_commits": 13571
+      "cumulative_commits": 14636
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "cumulative_commits": 14197
+      "cumulative_commits": 15403
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-03-01",
-      "cumulative_commits": 2409
+      "cumulative_commits": 2505
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "cumulative_commits": 2602
+      "cumulative_commits": 2713
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "cumulative_commits": 2989
+      "cumulative_commits": 3133
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "cumulative_commits": 3316
+      "cumulative_commits": 3536
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "cumulative_commits": 3703
+      "cumulative_commits": 3971
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "cumulative_commits": 4011
+      "cumulative_commits": 4349
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "cumulative_commits": 4287
+      "cumulative_commits": 4686
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "cumulative_commits": 4722
+      "cumulative_commits": 5208
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "cumulative_commits": 5069
+      "cumulative_commits": 5620
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "cumulative_commits": 5595
+      "cumulative_commits": 6262
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "cumulative_commits": 6069
+      "cumulative_commits": 6836
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "cumulative_commits": 6591
+      "cumulative_commits": 7426
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "cumulative_commits": 7912
+      "cumulative_commits": 8946
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "cumulative_commits": 8580
+      "cumulative_commits": 9767
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "cumulative_commits": 9260
+      "cumulative_commits": 10652
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-06-01",
-      "cumulative_commits": 10044
+      "cumulative_commits": 11813
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "cumulative_commits": 10632
+      "cumulative_commits": 12611
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "cumulative_commits": 10979
+      "cumulative_commits": 13051
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "cumulative_commits": 11286
+      "cumulative_commits": 13504
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "cumulative_commits": 11578
+      "cumulative_commits": 13913
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "cumulative_commits": 11899
+      "cumulative_commits": 14375
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "cumulative_commits": 12243
+      "cumulative_commits": 14888
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "cumulative_commits": 12576
+      "cumulative_commits": 15371
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "cumulative_commits": 12862
+      "cumulative_commits": 15799
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -2160,212 +2175,212 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-09-01",
-      "cumulative_commits": 1268
+      "cumulative_commits": 1445
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "cumulative_commits": 1728
+      "cumulative_commits": 2041
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "cumulative_commits": 2215
+      "cumulative_commits": 2711
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "cumulative_commits": 2617
+      "cumulative_commits": 3234
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "cumulative_commits": 3099
+      "cumulative_commits": 3873
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "cumulative_commits": 3627
+      "cumulative_commits": 4537
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "cumulative_commits": 4192
+      "cumulative_commits": 5315
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "cumulative_commits": 4865
+      "cumulative_commits": 6205
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "cumulative_commits": 5808
+      "cumulative_commits": 7377
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "cumulative_commits": 6434
+      "cumulative_commits": 8238
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "cumulative_commits": 6980
+      "cumulative_commits": 8983
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "cumulative_commits": 7541
+      "cumulative_commits": 9856
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "cumulative_commits": 8682
+      "cumulative_commits": 11292
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "cumulative_commits": 10046
+      "cumulative_commits": 13141
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "cumulative_commits": 12245
+      "cumulative_commits": 15827
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "cumulative_commits": 13315
+      "cumulative_commits": 17361
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "cumulative_commits": 14820
+      "cumulative_commits": 19369
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "cumulative_commits": 16442
+      "cumulative_commits": 21465
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "cumulative_commits": 2270
+      "cumulative_commits": 4162
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "cumulative_commits": 2427
+      "cumulative_commits": 4510
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "cumulative_commits": 2518
+      "cumulative_commits": 4721
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "cumulative_commits": 2618
+      "cumulative_commits": 4951
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "cumulative_commits": 2730
+      "cumulative_commits": 5209
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "cumulative_commits": 2828
+      "cumulative_commits": 5449
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "cumulative_commits": 2903
+      "cumulative_commits": 5655
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-10-01",
-      "cumulative_commits": 2994
+      "cumulative_commits": 5891
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "cumulative_commits": 3076
+      "cumulative_commits": 6103
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "cumulative_commits": 3156
+      "cumulative_commits": 6241
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "cumulative_commits": 3365
+      "cumulative_commits": 6600
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "cumulative_commits": 3469
+      "cumulative_commits": 6859
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "cumulative_commits": 3599
+      "cumulative_commits": 7119
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "cumulative_commits": 3750
+      "cumulative_commits": 7438
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "cumulative_commits": 3922
+      "cumulative_commits": 7737
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "cumulative_commits": 4263
+      "cumulative_commits": 8216
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "cumulative_commits": 5048
+      "cumulative_commits": 9300
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "cumulative_commits": 5807
+      "cumulative_commits": 10371
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "cumulative_commits": 6590
+      "cumulative_commits": 11422
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "cumulative_commits": 7552
+      "cumulative_commits": 12672
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "cumulative_commits": 7756
+      "cumulative_commits": 12993
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "cumulative_commits": 8198
+      "cumulative_commits": 13800
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "cumulative_commits": 8505
+      "cumulative_commits": 14288
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "cumulative_commits": 8681
+      "cumulative_commits": 14598
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2485,7 +2500,7 @@
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
-      "cumulative_commits": 39699
+      "cumulative_commits": 39700
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
@@ -2610,117 +2625,117 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "cumulative_commits": 642
+      "cumulative_commits": 696
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "cumulative_commits": 773
+      "cumulative_commits": 840
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "cumulative_commits": 963
+      "cumulative_commits": 1059
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "cumulative_commits": 1153
+      "cumulative_commits": 1261
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "cumulative_commits": 1335
+      "cumulative_commits": 1454
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "cumulative_commits": 1547
+      "cumulative_commits": 1685
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "cumulative_commits": 1738
+      "cumulative_commits": 1912
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "cumulative_commits": 1965
+      "cumulative_commits": 2180
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "cumulative_commits": 2130
+      "cumulative_commits": 2358
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "cumulative_commits": 2665
+      "cumulative_commits": 3055
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "cumulative_commits": 2825
+      "cumulative_commits": 3257
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "cumulative_commits": 2834
+      "cumulative_commits": 3266
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "cumulative_commits": 2904
+      "cumulative_commits": 3344
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "cumulative_commits": 3146
+      "cumulative_commits": 3622
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "cumulative_commits": 3329
+      "cumulative_commits": 3832
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "cumulative_commits": 3615
+      "cumulative_commits": 4156
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "cumulative_commits": 3817
+      "cumulative_commits": 4376
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "cumulative_commits": 4090
+      "cumulative_commits": 4687
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "cumulative_commits": 4339
+      "cumulative_commits": 4970
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "cumulative_commits": 4656
+      "cumulative_commits": 5336
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "cumulative_commits": 4998
+      "cumulative_commits": 5726
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "cumulative_commits": 5615
+      "cumulative_commits": 6418
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "cumulative_commits": 6242
+      "cumulative_commits": 7139
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2955,177 +2970,177 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-02-01",
-      "cumulative_commits": 1294
+      "cumulative_commits": 1295
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "cumulative_commits": 363
+      "cumulative_commits": 419
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "cumulative_commits": 1135
+      "cumulative_commits": 1500
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "cumulative_commits": 1823
+      "cumulative_commits": 2395
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "cumulative_commits": 2473
+      "cumulative_commits": 3308
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "cumulative_commits": 3179
+      "cumulative_commits": 4231
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "cumulative_commits": 3602
+      "cumulative_commits": 4804
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "cumulative_commits": 4145
+      "cumulative_commits": 5605
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "cumulative_commits": 4863
+      "cumulative_commits": 6671
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "cumulative_commits": 5436
+      "cumulative_commits": 7464
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "cumulative_commits": 6081
+      "cumulative_commits": 8426
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "cumulative_commits": 6757
+      "cumulative_commits": 9344
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "cumulative_commits": 3090
+      "cumulative_commits": 3367
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "cumulative_commits": 3238
+      "cumulative_commits": 3526
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-05-01",
-      "cumulative_commits": 3579
+      "cumulative_commits": 4043
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-06-01",
-      "cumulative_commits": 4046
+      "cumulative_commits": 4837
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "cumulative_commits": 4591
+      "cumulative_commits": 5552
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "cumulative_commits": 4845
+      "cumulative_commits": 5902
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "cumulative_commits": 5068
+      "cumulative_commits": 6201
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "cumulative_commits": 5257
+      "cumulative_commits": 6414
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "cumulative_commits": 5296
+      "cumulative_commits": 6478
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "cumulative_commits": 5336
+      "cumulative_commits": 6521
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "cumulative_commits": 5368
+      "cumulative_commits": 6560
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "cumulative_commits": 5399
+      "cumulative_commits": 6594
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "cumulative_commits": 5435
+      "cumulative_commits": 6650
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "cumulative_commits": 5449
+      "cumulative_commits": 6674
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-05-01",
-      "cumulative_commits": 5459
+      "cumulative_commits": 6684
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "cumulative_commits": 5468
+      "cumulative_commits": 6693
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "cumulative_commits": 5471
+      "cumulative_commits": 6696
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-09-01",
-      "cumulative_commits": 5543
+      "cumulative_commits": 6814
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "cumulative_commits": 5607
+      "cumulative_commits": 6901
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "cumulative_commits": 5641
+      "cumulative_commits": 6945
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "cumulative_commits": 5656
+      "cumulative_commits": 6968
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-01-01",
-      "cumulative_commits": 5680
+      "cumulative_commits": 6995
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "cumulative_commits": 5778
+      "cumulative_commits": 7135
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -3195,12 +3210,12 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-01-01",
-      "cumulative_commits": 5132
+      "cumulative_commits": 5133
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "cumulative_commits": 5190
+      "cumulative_commits": 5191
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3320,57 +3335,57 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2026-02-01",
-      "cumulative_commits": 169498
+      "cumulative_commits": 169499
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-05-01",
-      "cumulative_commits": 107
+      "cumulative_commits": 118
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-06-01",
-      "cumulative_commits": 829
+      "cumulative_commits": 957
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-07-01",
-      "cumulative_commits": 1492
+      "cumulative_commits": 1873
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-08-01",
-      "cumulative_commits": 2542
+      "cumulative_commits": 3192
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-09-01",
-      "cumulative_commits": 3357
+      "cumulative_commits": 4251
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-10-01",
-      "cumulative_commits": 4069
+      "cumulative_commits": 5133
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-11-01",
-      "cumulative_commits": 4416
+      "cumulative_commits": 6010
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-12-01",
-      "cumulative_commits": 5075
+      "cumulative_commits": 6875
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-01-01",
-      "cumulative_commits": 6362
+      "cumulative_commits": 8466
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-02-01",
-      "cumulative_commits": 8491
+      "cumulative_commits": 11276
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -3615,82 +3630,92 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-03-01",
-      "cumulative_commits": 64
+      "cumulative_commits": 98
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "cumulative_commits": 68
+      "cumulative_commits": 104
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "cumulative_commits": 139
+      "cumulative_commits": 175
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-06-01",
-      "cumulative_commits": 150
+      "cumulative_commits": 186
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-07-01",
-      "cumulative_commits": 191
+      "cumulative_commits": 227
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-08-01",
-      "cumulative_commits": 214
+      "cumulative_commits": 252
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
-      "cumulative_commits": 231
+      "cumulative_commits": 272
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "cumulative_commits": 269
+      "cumulative_commits": 333
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "cumulative_commits": 292
+      "cumulative_commits": 356
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-12-01",
-      "cumulative_commits": 295
+      "cumulative_commits": 359
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-01-01",
-      "cumulative_commits": 314
+      "cumulative_commits": 378
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-02-01",
-      "cumulative_commits": 340
+      "cumulative_commits": 414
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-03-01",
-      "cumulative_commits": 358
+      "cumulative_commits": 438
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-04-01",
-      "cumulative_commits": 370
+      "cumulative_commits": 451
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-05-01",
-      "cumulative_commits": 396
+      "cumulative_commits": 494
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-08-01",
+      "cumulative_commits": 519
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-09-01",
+      "cumulative_commits": 565
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "cumulative_commits": 431
+      "cumulative_commits": 602
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -3770,47 +3795,47 @@
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-06-01",
-      "cumulative_commits": 15065
+      "cumulative_commits": 15066
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-07-01",
-      "cumulative_commits": 15849
+      "cumulative_commits": 15850
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-08-01",
-      "cumulative_commits": 16155
+      "cumulative_commits": 16156
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-09-01",
-      "cumulative_commits": 16632
+      "cumulative_commits": 16633
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-10-01",
-      "cumulative_commits": 17201
+      "cumulative_commits": 17202
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-11-01",
-      "cumulative_commits": 17619
+      "cumulative_commits": 17624
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-12-01",
-      "cumulative_commits": 18120
+      "cumulative_commits": 18125
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2026-01-01",
-      "cumulative_commits": 18963
+      "cumulative_commits": 18968
     },
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2026-02-01",
-      "cumulative_commits": 19910
+      "cumulative_commits": 19944
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -3930,7 +3955,7 @@
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2026-02-01",
-      "cumulative_commits": 91912
+      "cumulative_commits": 91913
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
@@ -4295,217 +4320,217 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-03-01",
-      "cumulative_commits": 759
+      "cumulative_commits": 937
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "cumulative_commits": 959
+      "cumulative_commits": 1153
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "cumulative_commits": 1160
+      "cumulative_commits": 1367
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "cumulative_commits": 1355
+      "cumulative_commits": 1572
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "cumulative_commits": 1834
+      "cumulative_commits": 2118
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "cumulative_commits": 2303
+      "cumulative_commits": 2659
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "cumulative_commits": 2637
+      "cumulative_commits": 3041
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "cumulative_commits": 3053
+      "cumulative_commits": 3597
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "cumulative_commits": 3522
+      "cumulative_commits": 4121
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "cumulative_commits": 4171
+      "cumulative_commits": 4813
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "cumulative_commits": 4609
+      "cumulative_commits": 5288
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "cumulative_commits": 5148
+      "cumulative_commits": 5858
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "cumulative_commits": 6413
+      "cumulative_commits": 7314
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "cumulative_commits": 7529
+      "cumulative_commits": 8528
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "cumulative_commits": 8152
+      "cumulative_commits": 9217
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "cumulative_commits": 8895
+      "cumulative_commits": 10071
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "cumulative_commits": 9544
+      "cumulative_commits": 10839
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "cumulative_commits": 10038
+      "cumulative_commits": 11393
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "cumulative_commits": 10473
+      "cumulative_commits": 11891
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "cumulative_commits": 11001
+      "cumulative_commits": 12522
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "cumulative_commits": 11526
+      "cumulative_commits": 13324
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "cumulative_commits": 12053
+      "cumulative_commits": 14070
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "cumulative_commits": 12574
+      "cumulative_commits": 14835
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "cumulative_commits": 13307
+      "cumulative_commits": 15796
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-08-01",
-      "cumulative_commits": 1336
+      "cumulative_commits": 1594
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-09-01",
-      "cumulative_commits": 2399
+      "cumulative_commits": 2905
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-10-01",
-      "cumulative_commits": 3615
+      "cumulative_commits": 4309
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-11-01",
-      "cumulative_commits": 5139
+      "cumulative_commits": 6107
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-12-01",
-      "cumulative_commits": 7931
+      "cumulative_commits": 9143
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-01-01",
-      "cumulative_commits": 10010
+      "cumulative_commits": 11423
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "cumulative_commits": 11792
+      "cumulative_commits": 13250
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "cumulative_commits": 14243
+      "cumulative_commits": 15755
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "cumulative_commits": 16985
+      "cumulative_commits": 18596
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "cumulative_commits": 19285
+      "cumulative_commits": 20992
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "cumulative_commits": 21496
+      "cumulative_commits": 23275
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "cumulative_commits": 24701
+      "cumulative_commits": 26651
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "cumulative_commits": 27705
+      "cumulative_commits": 29736
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "cumulative_commits": 31169
+      "cumulative_commits": 33304
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "cumulative_commits": 36011
+      "cumulative_commits": 38341
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "cumulative_commits": 40117
+      "cumulative_commits": 42603
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "cumulative_commits": 43004
+      "cumulative_commits": 45564
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "cumulative_commits": 47592
+      "cumulative_commits": 50318
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "cumulative_commits": 52152
+      "cumulative_commits": 55008
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4515,152 +4540,187 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "cumulative_commits": 112
+      "cumulative_commits": 117
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "cumulative_commits": 159
+      "cumulative_commits": 164
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "cumulative_commits": 171
+      "cumulative_commits": 176
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "cumulative_commits": 200
+      "cumulative_commits": 229
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "cumulative_commits": 271
+      "cumulative_commits": 347
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "cumulative_commits": 303
+      "cumulative_commits": 380
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "cumulative_commits": 312
+      "cumulative_commits": 389
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-05-01",
-      "cumulative_commits": 340
+      "cumulative_commits": 417
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-06-01",
-      "cumulative_commits": 342
+      "cumulative_commits": 419
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-07-01",
-      "cumulative_commits": 343
+      "cumulative_commits": 421
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-08-01",
-      "cumulative_commits": 357
+      "cumulative_commits": 435
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-09-01",
-      "cumulative_commits": 367
+      "cumulative_commits": 445
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-10-01",
+      "cumulative_commits": 448
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-12-01",
+      "cumulative_commits": 449
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "cumulative_commits": 371
+      "cumulative_commits": 457
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2026-02-01",
+      "cumulative_commits": 458
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "cumulative_commits": 753
+      "cumulative_commits": 993
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "cumulative_commits": 832
+      "cumulative_commits": 1092
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "cumulative_commits": 895
+      "cumulative_commits": 1170
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "cumulative_commits": 913
+      "cumulative_commits": 1192
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "cumulative_commits": 931
+      "cumulative_commits": 1216
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-08-01",
-      "cumulative_commits": 940
+      "cumulative_commits": 1232
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "cumulative_commits": 968
+      "cumulative_commits": 1269
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "cumulative_commits": 977
+      "cumulative_commits": 1282
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-11-01",
-      "cumulative_commits": 981
+      "cumulative_commits": 1286
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-12-01",
-      "cumulative_commits": 990
+      "cumulative_commits": 1297
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "cumulative_commits": 1003
+      "cumulative_commits": 1311
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-02-01",
-      "cumulative_commits": 1007
+      "cumulative_commits": 1316
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-03-01",
-      "cumulative_commits": 1026
+      "cumulative_commits": 1348
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-04-01",
+      "cumulative_commits": 1350
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-05-01",
-      "cumulative_commits": 1030
+      "cumulative_commits": 1361
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-08-01",
+      "cumulative_commits": 1364
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-09-01",
+      "cumulative_commits": 1365
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-11-01",
+      "cumulative_commits": 1367
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-12-01",
-      "cumulative_commits": 1032
+      "cumulative_commits": 1376
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-01-01",
-      "cumulative_commits": 1050
+      "cumulative_commits": 1408
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-02-01",
-      "cumulative_commits": 1052
+      "cumulative_commits": 1413
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -4790,117 +4850,117 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-04-01",
-      "cumulative_commits": 655
+      "cumulative_commits": 662
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-05-01",
-      "cumulative_commits": 804
+      "cumulative_commits": 830
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-06-01",
-      "cumulative_commits": 933
+      "cumulative_commits": 968
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "cumulative_commits": 1314
+      "cumulative_commits": 1390
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "cumulative_commits": 1749
+      "cumulative_commits": 1902
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "cumulative_commits": 2159
+      "cumulative_commits": 2370
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "cumulative_commits": 2662
+      "cumulative_commits": 2929
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "cumulative_commits": 2975
+      "cumulative_commits": 3289
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "cumulative_commits": 3252
+      "cumulative_commits": 3622
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "cumulative_commits": 3526
+      "cumulative_commits": 3987
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "cumulative_commits": 3825
+      "cumulative_commits": 4318
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "cumulative_commits": 3909
+      "cumulative_commits": 4417
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "cumulative_commits": 4003
+      "cumulative_commits": 4548
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "cumulative_commits": 4079
+      "cumulative_commits": 4639
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "cumulative_commits": 4140
+      "cumulative_commits": 4704
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "cumulative_commits": 4189
+      "cumulative_commits": 4753
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "cumulative_commits": 4252
+      "cumulative_commits": 4818
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "cumulative_commits": 4353
+      "cumulative_commits": 4924
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "cumulative_commits": 4510
+      "cumulative_commits": 5081
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "cumulative_commits": 4578
+      "cumulative_commits": 5149
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "cumulative_commits": 4653
+      "cumulative_commits": 5225
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "cumulative_commits": 4764
+      "cumulative_commits": 5338
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "cumulative_commits": 4895
+      "cumulative_commits": 5486
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -5025,122 +5085,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "cumulative_commits": 19348
+      "cumulative_commits": 22525
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "cumulative_commits": 21031
+      "cumulative_commits": 24280
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "cumulative_commits": 22463
+      "cumulative_commits": 25771
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "cumulative_commits": 23724
+      "cumulative_commits": 27135
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "cumulative_commits": 25234
+      "cumulative_commits": 28872
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "cumulative_commits": 26314
+      "cumulative_commits": 30083
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "cumulative_commits": 27408
+      "cumulative_commits": 31320
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "cumulative_commits": 28676
+      "cumulative_commits": 32808
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "cumulative_commits": 29773
+      "cumulative_commits": 33994
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "cumulative_commits": 30153
+      "cumulative_commits": 34395
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "cumulative_commits": 30775
+      "cumulative_commits": 35084
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "cumulative_commits": 31887
+      "cumulative_commits": 36268
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "cumulative_commits": 33092
+      "cumulative_commits": 37687
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "cumulative_commits": 34386
+      "cumulative_commits": 39230
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "cumulative_commits": 35738
+      "cumulative_commits": 40766
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "cumulative_commits": 36211
+      "cumulative_commits": 41329
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "cumulative_commits": 36456
+      "cumulative_commits": 41639
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "cumulative_commits": 36722
+      "cumulative_commits": 41936
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "cumulative_commits": 36863
+      "cumulative_commits": 42088
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "cumulative_commits": 37028
+      "cumulative_commits": 42286
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "cumulative_commits": 37159
+      "cumulative_commits": 42438
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "cumulative_commits": 37232
+      "cumulative_commits": 42519
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "cumulative_commits": 37353
+      "cumulative_commits": 42646
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "cumulative_commits": 37495
+      "cumulative_commits": 42797
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -5250,92 +5310,92 @@
     {
       "repo": "https://github.com/milvus-io/milvus",
       "month": "2025-12-01",
-      "cumulative_commits": 75545
+      "cumulative_commits": 75557
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
       "month": "2026-01-01",
-      "cumulative_commits": 77082
+      "cumulative_commits": 77098
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
       "month": "2026-02-01",
-      "cumulative_commits": 79363
+      "cumulative_commits": 79417
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "cumulative_commits": 70
+      "cumulative_commits": 86
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-05-01",
-      "cumulative_commits": 107
+      "cumulative_commits": 123
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-06-01",
-      "cumulative_commits": 141
+      "cumulative_commits": 159
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-07-01",
-      "cumulative_commits": 222
+      "cumulative_commits": 240
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-08-01",
-      "cumulative_commits": 235
+      "cumulative_commits": 253
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-09-01",
-      "cumulative_commits": 247
+      "cumulative_commits": 267
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-10-01",
-      "cumulative_commits": 259
+      "cumulative_commits": 279
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-11-01",
-      "cumulative_commits": 262
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-03-01",
-      "cumulative_commits": 281
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-07-01",
       "cumulative_commits": 282
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-03-01",
+      "cumulative_commits": 301
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-07-01",
+      "cumulative_commits": 303
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-08-01",
-      "cumulative_commits": 285
+      "cumulative_commits": 306
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-09-01",
-      "cumulative_commits": 286
+      "cumulative_commits": 309
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-11-01",
-      "cumulative_commits": 291
+      "cumulative_commits": 314
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-12-01",
-      "cumulative_commits": 292
+      "cumulative_commits": 315
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-02-01",
-      "cumulative_commits": 295
+      "cumulative_commits": 318
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
@@ -5510,7 +5570,7 @@
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2026-02-01",
-      "cumulative_commits": 5466
+      "cumulative_commits": 5467
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -5625,12 +5685,12 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "cumulative_commits": 15553
+      "cumulative_commits": 15555
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "cumulative_commits": 15870
+      "cumulative_commits": 15873
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5870,67 +5930,67 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-02-01",
-      "cumulative_commits": 39215
+      "cumulative_commits": 39216
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "cumulative_commits": 591
+      "cumulative_commits": 847
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "cumulative_commits": 913
+      "cumulative_commits": 1221
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "cumulative_commits": 1145
+      "cumulative_commits": 1478
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "cumulative_commits": 1311
+      "cumulative_commits": 1676
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "cumulative_commits": 1677
+      "cumulative_commits": 2276
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "cumulative_commits": 1929
+      "cumulative_commits": 2660
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "cumulative_commits": 2191
+      "cumulative_commits": 2990
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "cumulative_commits": 2489
+      "cumulative_commits": 3332
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "cumulative_commits": 2609
+      "cumulative_commits": 3498
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "cumulative_commits": 2790
+      "cumulative_commits": 3707
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "cumulative_commits": 3120
+      "cumulative_commits": 4106
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "cumulative_commits": 3274
+      "cumulative_commits": 4363
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5950,247 +6010,247 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "cumulative_commits": 39230
+      "cumulative_commits": 39237
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "cumulative_commits": 52
+      "cumulative_commits": 203
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-04-01",
-      "cumulative_commits": 71
+      "cumulative_commits": 263
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "cumulative_commits": 87
+      "cumulative_commits": 347
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-06-01",
-      "cumulative_commits": 101
+      "cumulative_commits": 442
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-07-01",
-      "cumulative_commits": 123
+      "cumulative_commits": 537
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-08-01",
-      "cumulative_commits": 137
+      "cumulative_commits": 602
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-09-01",
-      "cumulative_commits": 151
+      "cumulative_commits": 660
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-10-01",
-      "cumulative_commits": 162
+      "cumulative_commits": 718
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-11-01",
-      "cumulative_commits": 173
+      "cumulative_commits": 800
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-12-01",
-      "cumulative_commits": 184
+      "cumulative_commits": 858
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-01-01",
-      "cumulative_commits": 196
+      "cumulative_commits": 934
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "cumulative_commits": 215
+      "cumulative_commits": 1021
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "cumulative_commits": 227
+      "cumulative_commits": 1084
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "cumulative_commits": 231
+      "cumulative_commits": 1140
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-05-01",
-      "cumulative_commits": 241
+      "cumulative_commits": 1192
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "cumulative_commits": 247
+      "cumulative_commits": 1248
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "cumulative_commits": 252
+      "cumulative_commits": 1302
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-08-01",
-      "cumulative_commits": 254
+      "cumulative_commits": 1356
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-09-01",
-      "cumulative_commits": 255
+      "cumulative_commits": 1402
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-10-01",
-      "cumulative_commits": 267
+      "cumulative_commits": 1440
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-11-01",
-      "cumulative_commits": 277
+      "cumulative_commits": 1485
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-12-01",
-      "cumulative_commits": 285
+      "cumulative_commits": 1529
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "cumulative_commits": 331
+      "cumulative_commits": 1617
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "cumulative_commits": 339
+      "cumulative_commits": 1672
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-03-01",
-      "cumulative_commits": 320
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2024-04-01",
       "cumulative_commits": 505
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2024-04-01",
+      "cumulative_commits": 701
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-05-01",
-      "cumulative_commits": 911
+      "cumulative_commits": 1140
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-06-01",
-      "cumulative_commits": 1213
+      "cumulative_commits": 1475
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "cumulative_commits": 1447
+      "cumulative_commits": 1728
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "cumulative_commits": 1781
+      "cumulative_commits": 2104
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "cumulative_commits": 2051
+      "cumulative_commits": 2452
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "cumulative_commits": 2559
+      "cumulative_commits": 3107
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "cumulative_commits": 2759
+      "cumulative_commits": 3389
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "cumulative_commits": 3184
+      "cumulative_commits": 3964
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "cumulative_commits": 3742
+      "cumulative_commits": 4747
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "cumulative_commits": 4268
+      "cumulative_commits": 5421
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "cumulative_commits": 4787
+      "cumulative_commits": 6160
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "cumulative_commits": 5337
+      "cumulative_commits": 6989
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "cumulative_commits": 6090
+      "cumulative_commits": 8037
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "cumulative_commits": 6603
+      "cumulative_commits": 8743
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "cumulative_commits": 7171
+      "cumulative_commits": 9667
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "cumulative_commits": 7798
+      "cumulative_commits": 10661
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "cumulative_commits": 8349
+      "cumulative_commits": 11464
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "cumulative_commits": 9069
+      "cumulative_commits": 12540
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "cumulative_commits": 9613
+      "cumulative_commits": 13334
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "cumulative_commits": 10316
+      "cumulative_commits": 14197
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "cumulative_commits": 11311
+      "cumulative_commits": 15470
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "cumulative_commits": 11996
+      "cumulative_commits": 16646
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -6310,7 +6370,7 @@
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2026-02-01",
-      "cumulative_commits": 29032
+      "cumulative_commits": 29034
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
@@ -6520,7 +6580,7 @@
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2026-02-01",
-      "cumulative_commits": 22968
+      "cumulative_commits": 23007
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
@@ -6645,122 +6705,122 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "cumulative_commits": 18083
+      "cumulative_commits": 18240
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-04-01",
-      "cumulative_commits": 18698
+      "cumulative_commits": 18857
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-05-01",
-      "cumulative_commits": 19361
+      "cumulative_commits": 19522
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-06-01",
-      "cumulative_commits": 19770
+      "cumulative_commits": 19934
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-07-01",
-      "cumulative_commits": 20232
+      "cumulative_commits": 20398
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-08-01",
-      "cumulative_commits": 20626
+      "cumulative_commits": 20794
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-09-01",
-      "cumulative_commits": 21299
+      "cumulative_commits": 21473
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "cumulative_commits": 22172
+      "cumulative_commits": 22413
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "cumulative_commits": 23067
+      "cumulative_commits": 23340
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "cumulative_commits": 23496
+      "cumulative_commits": 23784
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-01-01",
-      "cumulative_commits": 24125
+      "cumulative_commits": 24432
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-02-01",
-      "cumulative_commits": 25220
+      "cumulative_commits": 25548
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "cumulative_commits": 26091
+      "cumulative_commits": 26538
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "cumulative_commits": 27122
+      "cumulative_commits": 27795
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "cumulative_commits": 28671
+      "cumulative_commits": 29494
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "cumulative_commits": 30098
+      "cumulative_commits": 31158
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "cumulative_commits": 31410
+      "cumulative_commits": 32706
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "cumulative_commits": 32964
+      "cumulative_commits": 34715
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "cumulative_commits": 34328
+      "cumulative_commits": 36503
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "cumulative_commits": 35341
+      "cumulative_commits": 37861
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "cumulative_commits": 36454
+      "cumulative_commits": 39247
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "cumulative_commits": 37634
+      "cumulative_commits": 40657
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "cumulative_commits": 38844
+      "cumulative_commits": 42105
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "cumulative_commits": 39384
+      "cumulative_commits": 42764
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -6885,47 +6945,47 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-03-01",
-      "cumulative_commits": 10838
+      "cumulative_commits": 11647
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "cumulative_commits": 12158
+      "cumulative_commits": 13043
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "cumulative_commits": 13318
+      "cumulative_commits": 14270
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "cumulative_commits": 14299
+      "cumulative_commits": 15290
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-07-01",
-      "cumulative_commits": 14302
+      "cumulative_commits": 15293
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-08-01",
-      "cumulative_commits": 14304
+      "cumulative_commits": 15295
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-09-01",
-      "cumulative_commits": 14307
+      "cumulative_commits": 15298
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-02-01",
-      "cumulative_commits": 14309
+      "cumulative_commits": 15300
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-09-01",
-      "cumulative_commits": 14311
+      "cumulative_commits": 15302
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -7050,112 +7110,112 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "cumulative_commits": 97
+      "cumulative_commits": 98
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "cumulative_commits": 184
+      "cumulative_commits": 186
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "cumulative_commits": 203
+      "cumulative_commits": 208
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-08-01",
-      "cumulative_commits": 221
+      "cumulative_commits": 230
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "cumulative_commits": 259
+      "cumulative_commits": 268
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "cumulative_commits": 384
+      "cumulative_commits": 397
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "cumulative_commits": 769
+      "cumulative_commits": 792
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "cumulative_commits": 935
+      "cumulative_commits": 964
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "cumulative_commits": 1197
+      "cumulative_commits": 1229
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "cumulative_commits": 1320
+      "cumulative_commits": 1357
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "cumulative_commits": 1569
+      "cumulative_commits": 1611
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "cumulative_commits": 1739
+      "cumulative_commits": 1790
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "cumulative_commits": 1884
+      "cumulative_commits": 1957
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "cumulative_commits": 2000
+      "cumulative_commits": 2099
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "cumulative_commits": 2076
+      "cumulative_commits": 2198
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "cumulative_commits": 2162
+      "cumulative_commits": 2348
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "cumulative_commits": 2214
+      "cumulative_commits": 2446
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "cumulative_commits": 2341
+      "cumulative_commits": 2602
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "cumulative_commits": 2438
+      "cumulative_commits": 2729
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "cumulative_commits": 2498
+      "cumulative_commits": 2794
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "cumulative_commits": 2579
+      "cumulative_commits": 2880
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "cumulative_commits": 2674
+      "cumulative_commits": 2976
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -7275,7 +7335,7 @@
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2026-02-01",
-      "cumulative_commits": 56452
+      "cumulative_commits": 56454
     },
     {
       "repo": "https://github.com/wong2/litemcp",
@@ -7300,122 +7360,122 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-03-01",
-      "cumulative_commits": 133
+      "cumulative_commits": 760
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "cumulative_commits": 166
+      "cumulative_commits": 820
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "cumulative_commits": 169
+      "cumulative_commits": 844
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-06-01",
-      "cumulative_commits": 216
+      "cumulative_commits": 913
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-07-01",
-      "cumulative_commits": 268
+      "cumulative_commits": 968
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-08-01",
-      "cumulative_commits": 270
+      "cumulative_commits": 976
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-09-01",
-      "cumulative_commits": 274
+      "cumulative_commits": 998
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-10-01",
-      "cumulative_commits": 287
+      "cumulative_commits": 1038
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "cumulative_commits": 359
+      "cumulative_commits": 1116
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-12-01",
-      "cumulative_commits": 361
+      "cumulative_commits": 1120
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-01-01",
-      "cumulative_commits": 372
+      "cumulative_commits": 1133
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "cumulative_commits": 387
+      "cumulative_commits": 1163
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "cumulative_commits": 407
+      "cumulative_commits": 1184
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "cumulative_commits": 418
+      "cumulative_commits": 1200
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "cumulative_commits": 450
+      "cumulative_commits": 1253
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "cumulative_commits": 572
+      "cumulative_commits": 1474
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "cumulative_commits": 725
+      "cumulative_commits": 1811
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "cumulative_commits": 796
+      "cumulative_commits": 1909
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "cumulative_commits": 805
+      "cumulative_commits": 1938
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "cumulative_commits": 814
+      "cumulative_commits": 1965
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "cumulative_commits": 821
+      "cumulative_commits": 1979
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "cumulative_commits": 830
+      "cumulative_commits": 1997
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "cumulative_commits": 860
+      "cumulative_commits": 2038
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "cumulative_commits": 882
+      "cumulative_commits": 2079
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/contributor_count.json
+++ b/frontend/public/data/agentic-ai-momentum/contributor_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:13.286352",
+    "fetched_at": "2026-04-01T07:13:47.791473",
     "schema": {
       "name": "contributor_count",
       "description": "Cumulative monthly distinct contributor counts for tracked repositories.",
@@ -150,107 +150,122 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "cumulative_contributors": 15
+      "cumulative_contributors": 29
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "cumulative_contributors": 19
+      "cumulative_contributors": 40
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-05-01",
-      "cumulative_contributors": 25
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-06-01",
-      "cumulative_contributors": 28
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-09-01",
-      "cumulative_contributors": 37
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-10-01",
       "cumulative_contributors": 48
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-06-01",
+      "cumulative_contributors": 52
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-07-01",
+      "cumulative_contributors": 54
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-08-01",
+      "cumulative_contributors": 59
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-09-01",
+      "cumulative_contributors": 74
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-10-01",
+      "cumulative_contributors": 97
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "cumulative_contributors": 50
+      "cumulative_contributors": 99
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "cumulative_contributors": 51
+      "cumulative_contributors": 103
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "cumulative_contributors": 55
+      "cumulative_contributors": 109
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "cumulative_contributors": 60
+      "cumulative_contributors": 126
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "cumulative_contributors": 68
+      "cumulative_contributors": 144
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "cumulative_contributors": 76
+      "cumulative_contributors": 157
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "cumulative_contributors": 77
+      "cumulative_contributors": 164
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "cumulative_contributors": 81
+      "cumulative_contributors": 174
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "cumulative_contributors": 85
+      "cumulative_contributors": 183
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "cumulative_contributors": 86
+      "cumulative_contributors": 190
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "cumulative_contributors": 88
+      "cumulative_contributors": 192
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "cumulative_contributors": 91
+      "cumulative_contributors": 198
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-11-01",
+      "cumulative_contributors": 200
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "cumulative_contributors": 94
+      "cumulative_contributors": 210
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "cumulative_contributors": 98
+      "cumulative_contributors": 220
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "cumulative_contributors": 103
+      "cumulative_contributors": 234
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -370,7 +385,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "cumulative_contributors": 2931
+      "cumulative_contributors": 2933
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -380,117 +395,117 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-04-01",
-      "cumulative_contributors": 6
+      "cumulative_contributors": 7
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-05-01",
-      "cumulative_contributors": 11
+      "cumulative_contributors": 12
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-06-01",
-      "cumulative_contributors": 17
+      "cumulative_contributors": 20
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-07-01",
-      "cumulative_contributors": 24
+      "cumulative_contributors": 27
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-08-01",
-      "cumulative_contributors": 35
+      "cumulative_contributors": 42
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "cumulative_contributors": 46
+      "cumulative_contributors": 55
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "cumulative_contributors": 65
+      "cumulative_contributors": 75
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "cumulative_contributors": 68
+      "cumulative_contributors": 79
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "cumulative_contributors": 70
+      "cumulative_contributors": 81
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "cumulative_contributors": 76
+      "cumulative_contributors": 87
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "cumulative_contributors": 78
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-03-01",
       "cumulative_contributors": 89
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-03-01",
+      "cumulative_contributors": 100
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "cumulative_contributors": 102
+      "cumulative_contributors": 114
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-05-01",
-      "cumulative_contributors": 108
+      "cumulative_contributors": 121
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "cumulative_contributors": 118
+      "cumulative_contributors": 134
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "cumulative_contributors": 124
+      "cumulative_contributors": 143
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "cumulative_contributors": 128
+      "cumulative_contributors": 148
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "cumulative_contributors": 138
+      "cumulative_contributors": 162
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "cumulative_contributors": 141
+      "cumulative_contributors": 166
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "cumulative_contributors": 144
+      "cumulative_contributors": 170
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "cumulative_contributors": 146
+      "cumulative_contributors": 179
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "cumulative_contributors": 151
+      "cumulative_contributors": 187
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "cumulative_contributors": 159
+      "cumulative_contributors": 201
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -575,7 +590,7 @@
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-02-01",
-      "cumulative_contributors": 565
+      "cumulative_contributors": 567
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
@@ -635,252 +650,267 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "cumulative_contributors": 3
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2024-08-01",
-      "cumulative_contributors": 4
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2024-10-01",
-      "cumulative_contributors": 5
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-02-01",
-      "cumulative_contributors": 6
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-03-01",
       "cumulative_contributors": 7
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-05-01",
+      "month": "2024-08-01",
       "cumulative_contributors": 9
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-11-01",
+      "month": "2024-09-01",
       "cumulative_contributors": 10
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-10-01",
+      "cumulative_contributors": 11
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-02-01",
+      "cumulative_contributors": 12
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-03-01",
+      "cumulative_contributors": 14
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-05-01",
+      "cumulative_contributors": 16
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-07-01",
+      "cumulative_contributors": 17
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-11-01",
+      "cumulative_contributors": 18
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "cumulative_contributors": 78
+      "cumulative_contributors": 100
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "cumulative_contributors": 163
+      "cumulative_contributors": 221
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "cumulative_contributors": 216
+      "cumulative_contributors": 294
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "cumulative_contributors": 242
+      "cumulative_contributors": 328
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "cumulative_contributors": 269
+      "cumulative_contributors": 362
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "cumulative_contributors": 280
+      "cumulative_contributors": 375
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "cumulative_contributors": 291
+      "cumulative_contributors": 394
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "cumulative_contributors": 306
+      "cumulative_contributors": 417
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "cumulative_contributors": 330
+      "cumulative_contributors": 454
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "cumulative_contributors": 350
+      "cumulative_contributors": 474
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "cumulative_contributors": 379
+      "cumulative_contributors": 516
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "cumulative_contributors": 412
+      "cumulative_contributors": 556
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "cumulative_contributors": 450
+      "cumulative_contributors": 607
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "cumulative_contributors": 501
+      "cumulative_contributors": 674
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "cumulative_contributors": 543
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-06-01",
-      "cumulative_contributors": 585
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-07-01",
-      "cumulative_contributors": 606
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-08-01",
-      "cumulative_contributors": 642
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-09-01",
-      "cumulative_contributors": 662
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-10-01",
-      "cumulative_contributors": 681
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-11-01",
-      "cumulative_contributors": 700
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-12-01",
       "cumulative_contributors": 732
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-06-01",
+      "cumulative_contributors": 791
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-07-01",
+      "cumulative_contributors": 822
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-08-01",
+      "cumulative_contributors": 873
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-09-01",
+      "cumulative_contributors": 908
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-10-01",
+      "cumulative_contributors": 940
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-11-01",
+      "cumulative_contributors": 968
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-12-01",
+      "cumulative_contributors": 1014
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "cumulative_contributors": 764
+      "cumulative_contributors": 1052
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "cumulative_contributors": 792
+      "cumulative_contributors": 1086
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-03-01",
-      "cumulative_contributors": 183
+      "cumulative_contributors": 241
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-04-01",
-      "cumulative_contributors": 203
+      "cumulative_contributors": 269
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-05-01",
-      "cumulative_contributors": 212
+      "cumulative_contributors": 279
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-06-01",
-      "cumulative_contributors": 215
+      "cumulative_contributors": 284
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-07-01",
-      "cumulative_contributors": 220
+      "cumulative_contributors": 294
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-08-01",
-      "cumulative_contributors": 225
+      "cumulative_contributors": 302
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-09-01",
-      "cumulative_contributors": 232
+      "cumulative_contributors": 313
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-10-01",
-      "cumulative_contributors": 237
+      "cumulative_contributors": 321
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-11-01",
-      "cumulative_contributors": 245
+      "cumulative_contributors": 329
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-12-01",
-      "cumulative_contributors": 246
+      "cumulative_contributors": 330
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-01-01",
-      "cumulative_contributors": 248
+      "cumulative_contributors": 332
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-02-01",
-      "cumulative_contributors": 250
+      "cumulative_contributors": 334
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-03-01",
-      "cumulative_contributors": 251
+      "cumulative_contributors": 336
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-04-01",
-      "cumulative_contributors": 252
+      "cumulative_contributors": 338
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-07-01",
-      "cumulative_contributors": 253
+      "cumulative_contributors": 339
+    },
+    {
+      "repo": "https://github.com/OpenInterpreter/open-interpreter",
+      "month": "2025-08-01",
+      "cumulative_contributors": 340
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-10-01",
-      "cumulative_contributors": 255
+      "cumulative_contributors": 342
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-11-01",
-      "cumulative_contributors": 256
+      "cumulative_contributors": 343
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-01-01",
-      "cumulative_contributors": 259
+      "cumulative_contributors": 346
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-02-01",
-      "cumulative_contributors": 263
+      "cumulative_contributors": 351
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1005,122 +1035,122 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "cumulative_contributors": 48
+      "cumulative_contributors": 72
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "cumulative_contributors": 66
+      "cumulative_contributors": 93
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "cumulative_contributors": 74
+      "cumulative_contributors": 104
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "cumulative_contributors": 76
+      "cumulative_contributors": 108
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "cumulative_contributors": 81
+      "cumulative_contributors": 116
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "cumulative_contributors": 87
+      "cumulative_contributors": 127
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "cumulative_contributors": 95
+      "cumulative_contributors": 140
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "cumulative_contributors": 110
+      "cumulative_contributors": 169
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "cumulative_contributors": 115
+      "cumulative_contributors": 180
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "cumulative_contributors": 120
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-01-01",
-      "cumulative_contributors": 128
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-02-01",
-      "cumulative_contributors": 134
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-03-01",
-      "cumulative_contributors": 142
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-04-01",
-      "cumulative_contributors": 145
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-05-01",
-      "cumulative_contributors": 151
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-06-01",
-      "cumulative_contributors": 162
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-07-01",
-      "cumulative_contributors": 163
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-08-01",
-      "cumulative_contributors": 167
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-09-01",
-      "cumulative_contributors": 176
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-10-01",
-      "cumulative_contributors": 183
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-11-01",
-      "cumulative_contributors": 186
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-12-01",
       "cumulative_contributors": 188
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-01-01",
+      "cumulative_contributors": 198
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-02-01",
+      "cumulative_contributors": 207
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-03-01",
+      "cumulative_contributors": 218
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-04-01",
+      "cumulative_contributors": 228
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-05-01",
+      "cumulative_contributors": 240
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-06-01",
+      "cumulative_contributors": 266
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-07-01",
+      "cumulative_contributors": 271
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-08-01",
+      "cumulative_contributors": 278
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-09-01",
+      "cumulative_contributors": 292
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-10-01",
+      "cumulative_contributors": 308
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-11-01",
+      "cumulative_contributors": 312
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-12-01",
+      "cumulative_contributors": 316
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "cumulative_contributors": 190
+      "cumulative_contributors": 320
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "cumulative_contributors": 194
+      "cumulative_contributors": 325
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -1240,7 +1270,7 @@
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "cumulative_contributors": 2580
+      "cumulative_contributors": 2581
     },
     {
       "repo": "https://github.com/agntcy/acp-spec",
@@ -1585,7 +1615,7 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "cumulative_contributors": 677
+      "cumulative_contributors": 678
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
@@ -1595,202 +1625,202 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "cumulative_contributors": 17
+      "cumulative_contributors": 19
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "cumulative_contributors": 30
+      "cumulative_contributors": 33
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "cumulative_contributors": 95
+      "cumulative_contributors": 127
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "cumulative_contributors": 164
+      "cumulative_contributors": 215
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "cumulative_contributors": 232
+      "cumulative_contributors": 319
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "cumulative_contributors": 291
+      "cumulative_contributors": 403
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "cumulative_contributors": 334
+      "cumulative_contributors": 472
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "cumulative_contributors": 368
+      "cumulative_contributors": 514
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "cumulative_contributors": 397
+      "cumulative_contributors": 555
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-08-01",
-      "cumulative_contributors": 428
+      "cumulative_contributors": 596
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-09-01",
-      "cumulative_contributors": 459
+      "cumulative_contributors": 643
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-10-01",
-      "cumulative_contributors": 493
+      "cumulative_contributors": 685
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "cumulative_contributors": 519
+      "cumulative_contributors": 718
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "cumulative_contributors": 542
+      "cumulative_contributors": 751
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "cumulative_contributors": 568
+      "cumulative_contributors": 784
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "cumulative_contributors": 599
+      "cumulative_contributors": 824
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-03-01",
-      "cumulative_contributors": 33
+      "cumulative_contributors": 50
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "cumulative_contributors": 38
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-05-01",
-      "cumulative_contributors": 43
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-06-01",
-      "cumulative_contributors": 55
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-07-01",
       "cumulative_contributors": 56
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-05-01",
+      "cumulative_contributors": 65
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-06-01",
+      "cumulative_contributors": 84
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-07-01",
+      "cumulative_contributors": 89
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "cumulative_contributors": 64
+      "cumulative_contributors": 101
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "cumulative_contributors": 67
+      "cumulative_contributors": 108
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "cumulative_contributors": 77
+      "cumulative_contributors": 125
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "cumulative_contributors": 78
+      "cumulative_contributors": 136
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "cumulative_contributors": 83
+      "cumulative_contributors": 146
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "cumulative_contributors": 94
+      "cumulative_contributors": 161
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "cumulative_contributors": 102
+      "cumulative_contributors": 174
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "cumulative_contributors": 141
+      "cumulative_contributors": 229
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "cumulative_contributors": 163
+      "cumulative_contributors": 258
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "cumulative_contributors": 183
+      "cumulative_contributors": 286
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-06-01",
-      "cumulative_contributors": 192
+      "cumulative_contributors": 308
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "cumulative_contributors": 207
+      "cumulative_contributors": 329
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "cumulative_contributors": 214
+      "cumulative_contributors": 343
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "cumulative_contributors": 225
+      "cumulative_contributors": 356
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "cumulative_contributors": 232
+      "cumulative_contributors": 367
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "cumulative_contributors": 239
+      "cumulative_contributors": 380
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "cumulative_contributors": 244
+      "cumulative_contributors": 391
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "cumulative_contributors": 257
+      "cumulative_contributors": 407
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "cumulative_contributors": 275
+      "cumulative_contributors": 432
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -2030,212 +2060,212 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-09-01",
-      "cumulative_contributors": 25
+      "cumulative_contributors": 40
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "cumulative_contributors": 28
+      "cumulative_contributors": 46
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "cumulative_contributors": 30
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-12-01",
-      "cumulative_contributors": 34
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-01-01",
-      "cumulative_contributors": 42
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-02-01",
-      "cumulative_contributors": 45
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-03-01",
       "cumulative_contributors": 51
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-04-01",
-      "cumulative_contributors": 61
+      "month": "2024-12-01",
+      "cumulative_contributors": 57
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-05-01",
-      "cumulative_contributors": 69
+      "month": "2025-01-01",
+      "cumulative_contributors": 68
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-06-01",
-      "cumulative_contributors": 79
+      "month": "2025-02-01",
+      "cumulative_contributors": 75
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-07-01",
+      "month": "2025-03-01",
       "cumulative_contributors": 86
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-08-01",
-      "cumulative_contributors": 95
+      "month": "2025-04-01",
+      "cumulative_contributors": 101
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-09-01",
-      "cumulative_contributors": 97
+      "month": "2025-05-01",
+      "cumulative_contributors": 119
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-10-01",
-      "cumulative_contributors": 116
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-11-01",
-      "cumulative_contributors": 124
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-12-01",
+      "month": "2025-06-01",
       "cumulative_contributors": 132
     },
     {
       "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-07-01",
+      "cumulative_contributors": 142
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-08-01",
+      "cumulative_contributors": 155
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-09-01",
+      "cumulative_contributors": 159
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-10-01",
+      "cumulative_contributors": 184
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-11-01",
+      "cumulative_contributors": 197
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-12-01",
+      "cumulative_contributors": 213
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "cumulative_contributors": 144
+      "cumulative_contributors": 229
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "cumulative_contributors": 154
+      "cumulative_contributors": 244
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "cumulative_contributors": 46
+      "cumulative_contributors": 64
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "cumulative_contributors": 59
+      "cumulative_contributors": 78
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "cumulative_contributors": 68
+      "cumulative_contributors": 93
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "cumulative_contributors": 73
+      "cumulative_contributors": 100
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "cumulative_contributors": 81
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-08-01",
-      "cumulative_contributors": 86
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-09-01",
-      "cumulative_contributors": 95
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-10-01",
       "cumulative_contributors": 112
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-08-01",
+      "cumulative_contributors": 120
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-09-01",
+      "cumulative_contributors": 138
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-10-01",
+      "cumulative_contributors": 157
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "cumulative_contributors": 122
+      "cumulative_contributors": 177
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "cumulative_contributors": 129
+      "cumulative_contributors": 190
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "cumulative_contributors": 151
+      "cumulative_contributors": 216
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "cumulative_contributors": 169
+      "cumulative_contributors": 246
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "cumulative_contributors": 192
+      "cumulative_contributors": 283
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "cumulative_contributors": 207
+      "cumulative_contributors": 306
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "cumulative_contributors": 224
+      "cumulative_contributors": 331
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "cumulative_contributors": 235
+      "cumulative_contributors": 346
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "cumulative_contributors": 252
+      "cumulative_contributors": 377
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "cumulative_contributors": 271
+      "cumulative_contributors": 408
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "cumulative_contributors": 282
+      "cumulative_contributors": 425
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "cumulative_contributors": 308
+      "cumulative_contributors": 463
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "cumulative_contributors": 317
+      "cumulative_contributors": 473
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "cumulative_contributors": 320
+      "cumulative_contributors": 479
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "cumulative_contributors": 332
+      "cumulative_contributors": 495
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "cumulative_contributors": 347
+      "cumulative_contributors": 512
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2480,112 +2510,112 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "cumulative_contributors": 38
+      "cumulative_contributors": 42
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "cumulative_contributors": 41
+      "cumulative_contributors": 46
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "cumulative_contributors": 48
+      "cumulative_contributors": 53
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "cumulative_contributors": 54
+      "cumulative_contributors": 60
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "cumulative_contributors": 65
+      "cumulative_contributors": 74
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "cumulative_contributors": 73
+      "cumulative_contributors": 84
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "cumulative_contributors": 77
+      "cumulative_contributors": 91
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "cumulative_contributors": 78
+      "cumulative_contributors": 92
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "cumulative_contributors": 83
+      "cumulative_contributors": 97
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "cumulative_contributors": 233
+      "cumulative_contributors": 358
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "cumulative_contributors": 234
+      "cumulative_contributors": 362
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "cumulative_contributors": 238
+      "cumulative_contributors": 368
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "cumulative_contributors": 241
+      "cumulative_contributors": 373
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "cumulative_contributors": 249
+      "cumulative_contributors": 382
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "cumulative_contributors": 253
+      "cumulative_contributors": 390
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "cumulative_contributors": 256
+      "cumulative_contributors": 395
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "cumulative_contributors": 260
+      "cumulative_contributors": 400
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "cumulative_contributors": 265
+      "cumulative_contributors": 408
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "cumulative_contributors": 272
+      "cumulative_contributors": 419
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "cumulative_contributors": 278
+      "cumulative_contributors": 430
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "cumulative_contributors": 283
+      "cumulative_contributors": 441
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "cumulative_contributors": 287
+      "cumulative_contributors": 450
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2763,144 +2793,149 @@
       "cumulative_contributors": 27
     },
     {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2026-02-01",
+      "cumulative_contributors": 28
+    },
+    {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "cumulative_contributors": 70
+      "cumulative_contributors": 93
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "cumulative_contributors": 147
+      "cumulative_contributors": 215
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "cumulative_contributors": 207
+      "cumulative_contributors": 293
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "cumulative_contributors": 251
+      "cumulative_contributors": 347
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "cumulative_contributors": 291
+      "cumulative_contributors": 408
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "cumulative_contributors": 323
+      "cumulative_contributors": 451
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "cumulative_contributors": 375
+      "cumulative_contributors": 534
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "cumulative_contributors": 429
+      "cumulative_contributors": 620
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "cumulative_contributors": 474
+      "cumulative_contributors": 680
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "cumulative_contributors": 513
+      "cumulative_contributors": 736
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "cumulative_contributors": 558
+      "cumulative_contributors": 793
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "cumulative_contributors": 71
+      "cumulative_contributors": 87
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "cumulative_contributors": 73
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-05-01",
-      "cumulative_contributors": 77
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-06-01",
-      "cumulative_contributors": 83
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-07-01",
       "cumulative_contributors": 90
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-08-01",
-      "cumulative_contributors": 92
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-10-01",
-      "cumulative_contributors": 95
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-11-01",
+      "month": "2024-05-01",
       "cumulative_contributors": 96
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-12-01",
-      "cumulative_contributors": 97
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-01-01",
-      "cumulative_contributors": 98
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-03-01",
-      "cumulative_contributors": 101
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-06-01",
-      "cumulative_contributors": 102
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-07-01",
-      "cumulative_contributors": 103
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-09-01",
-      "cumulative_contributors": 104
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-11-01",
+      "month": "2024-06-01",
       "cumulative_contributors": 106
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-07-01",
+      "cumulative_contributors": 119
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-08-01",
+      "cumulative_contributors": 121
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-10-01",
+      "cumulative_contributors": 124
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-11-01",
+      "cumulative_contributors": 125
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-12-01",
+      "cumulative_contributors": 127
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-01-01",
+      "cumulative_contributors": 130
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-03-01",
+      "cumulative_contributors": 135
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-06-01",
+      "cumulative_contributors": 136
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-07-01",
+      "cumulative_contributors": 137
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-09-01",
+      "cumulative_contributors": 139
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-11-01",
+      "cumulative_contributors": 141
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "cumulative_contributors": 108
+      "cumulative_contributors": 143
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "cumulative_contributors": 111
+      "cumulative_contributors": 146
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -2910,242 +2945,242 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-01-01",
-      "cumulative_contributors": 162
+      "cumulative_contributors": 161
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-02-01",
-      "cumulative_contributors": 258
+      "cumulative_contributors": 257
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-03-01",
-      "cumulative_contributors": 308
+      "cumulative_contributors": 307
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-04-01",
-      "cumulative_contributors": 336
+      "cumulative_contributors": 335
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-05-01",
-      "cumulative_contributors": 361
+      "cumulative_contributors": 360
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-06-01",
-      "cumulative_contributors": 384
+      "cumulative_contributors": 383
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-07-01",
-      "cumulative_contributors": 417
+      "cumulative_contributors": 416
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-08-01",
-      "cumulative_contributors": 443
+      "cumulative_contributors": 442
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-09-01",
-      "cumulative_contributors": 455
+      "cumulative_contributors": 454
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-10-01",
-      "cumulative_contributors": 465
+      "cumulative_contributors": 464
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-11-01",
-      "cumulative_contributors": 478
+      "cumulative_contributors": 477
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-12-01",
-      "cumulative_contributors": 489
+      "cumulative_contributors": 488
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-01-01",
-      "cumulative_contributors": 501
+      "cumulative_contributors": 500
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "cumulative_contributors": 515
+      "cumulative_contributors": 514
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-03-01",
-      "cumulative_contributors": 4989
+      "cumulative_contributors": 4983
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-04-01",
-      "cumulative_contributors": 5083
+      "cumulative_contributors": 5077
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-05-01",
-      "cumulative_contributors": 5189
+      "cumulative_contributors": 5183
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-06-01",
-      "cumulative_contributors": 5309
+      "cumulative_contributors": 5303
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-07-01",
-      "cumulative_contributors": 5458
+      "cumulative_contributors": 5452
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-08-01",
-      "cumulative_contributors": 5596
+      "cumulative_contributors": 5590
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-09-01",
-      "cumulative_contributors": 5722
+      "cumulative_contributors": 5716
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-10-01",
-      "cumulative_contributors": 5878
+      "cumulative_contributors": 5872
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-11-01",
-      "cumulative_contributors": 5979
+      "cumulative_contributors": 5973
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-12-01",
-      "cumulative_contributors": 6080
+      "cumulative_contributors": 6073
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-01-01",
-      "cumulative_contributors": 6199
+      "cumulative_contributors": 6191
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-02-01",
-      "cumulative_contributors": 6299
+      "cumulative_contributors": 6291
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "cumulative_contributors": 6438
+      "cumulative_contributors": 6429
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-04-01",
-      "cumulative_contributors": 6621
+      "cumulative_contributors": 6612
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-05-01",
-      "cumulative_contributors": 6749
+      "cumulative_contributors": 6739
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-06-01",
-      "cumulative_contributors": 6924
+      "cumulative_contributors": 6914
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-07-01",
-      "cumulative_contributors": 7110
+      "cumulative_contributors": 7100
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-08-01",
-      "cumulative_contributors": 7314
+      "cumulative_contributors": 7304
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-09-01",
-      "cumulative_contributors": 7400
+      "cumulative_contributors": 7390
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-10-01",
-      "cumulative_contributors": 7528
+      "cumulative_contributors": 7518
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-11-01",
-      "cumulative_contributors": 7612
+      "cumulative_contributors": 7602
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-12-01",
-      "cumulative_contributors": 7706
+      "cumulative_contributors": 7696
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2026-01-01",
-      "cumulative_contributors": 7817
+      "cumulative_contributors": 7807
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2026-02-01",
-      "cumulative_contributors": 7961
+      "cumulative_contributors": 7951
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-05-01",
-      "cumulative_contributors": 2
+      "cumulative_contributors": 9
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-06-01",
-      "cumulative_contributors": 14
+      "cumulative_contributors": 35
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-07-01",
-      "cumulative_contributors": 30
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-08-01",
-      "cumulative_contributors": 45
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-09-01",
       "cumulative_contributors": 64
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2025-08-01",
+      "cumulative_contributors": 87
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2025-09-01",
+      "cumulative_contributors": 116
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-10-01",
-      "cumulative_contributors": 80
+      "cumulative_contributors": 136
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-11-01",
-      "cumulative_contributors": 93
+      "cumulative_contributors": 167
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-12-01",
-      "cumulative_contributors": 111
+      "cumulative_contributors": 191
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-01-01",
-      "cumulative_contributors": 127
+      "cumulative_contributors": 221
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-02-01",
-      "cumulative_contributors": 154
+      "cumulative_contributors": 285
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -3389,28 +3424,58 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2024-04-01",
-      "cumulative_contributors": 32
+      "month": "2024-03-01",
+      "cumulative_contributors": 36
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2024-05-01",
+      "month": "2024-04-01",
       "cumulative_contributors": 37
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-05-01",
+      "cumulative_contributors": 42
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-07-01",
-      "cumulative_contributors": 38
+      "cumulative_contributors": 43
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-08-01",
+      "cumulative_contributors": 44
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-09-01",
+      "cumulative_contributors": 45
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-10-01",
+      "cumulative_contributors": 48
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-01-01",
-      "cumulative_contributors": 40
+      "cumulative_contributors": 50
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-02-01",
+      "cumulative_contributors": 51
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-08-01",
+      "cumulative_contributors": 52
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "cumulative_contributors": 41
+      "cumulative_contributors": 54
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -3530,7 +3595,7 @@
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2026-02-01",
-      "cumulative_contributors": 609
+      "cumulative_contributors": 610
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -3565,92 +3630,92 @@
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-09-01",
-      "cumulative_contributors": 6359
+      "cumulative_contributors": 6358
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-10-01",
-      "cumulative_contributors": 6530
+      "cumulative_contributors": 6529
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-11-01",
-      "cumulative_contributors": 6671
+      "cumulative_contributors": 6670
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-12-01",
-      "cumulative_contributors": 6811
+      "cumulative_contributors": 6810
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-01-01",
-      "cumulative_contributors": 6958
+      "cumulative_contributors": 6957
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-02-01",
-      "cumulative_contributors": 7080
+      "cumulative_contributors": 7079
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-03-01",
-      "cumulative_contributors": 7224
+      "cumulative_contributors": 7223
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-04-01",
-      "cumulative_contributors": 7339
+      "cumulative_contributors": 7338
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-05-01",
-      "cumulative_contributors": 7430
+      "cumulative_contributors": 7429
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-06-01",
-      "cumulative_contributors": 7521
+      "cumulative_contributors": 7520
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-07-01",
-      "cumulative_contributors": 7644
+      "cumulative_contributors": 7643
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-08-01",
-      "cumulative_contributors": 7766
+      "cumulative_contributors": 7765
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-09-01",
-      "cumulative_contributors": 7858
+      "cumulative_contributors": 7857
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-10-01",
-      "cumulative_contributors": 7911
+      "cumulative_contributors": 7910
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-11-01",
-      "cumulative_contributors": 7971
+      "cumulative_contributors": 7970
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-12-01",
-      "cumulative_contributors": 8055
+      "cumulative_contributors": 8054
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2026-01-01",
-      "cumulative_contributors": 8153
+      "cumulative_contributors": 8152
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2026-02-01",
-      "cumulative_contributors": 8251
+      "cumulative_contributors": 8250
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
@@ -4015,207 +4080,207 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-03-01",
-      "cumulative_contributors": 20
+      "cumulative_contributors": 27
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "cumulative_contributors": 23
+      "cumulative_contributors": 30
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "cumulative_contributors": 25
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-06-01",
       "cumulative_contributors": 33
     },
     {
       "repo": "https://github.com/livekit/agents",
+      "month": "2024-06-01",
+      "cumulative_contributors": 42
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "cumulative_contributors": 41
+      "cumulative_contributors": 54
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "cumulative_contributors": 47
+      "cumulative_contributors": 66
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "cumulative_contributors": 65
+      "cumulative_contributors": 90
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "cumulative_contributors": 88
+      "cumulative_contributors": 127
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "cumulative_contributors": 99
+      "cumulative_contributors": 140
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "cumulative_contributors": 112
+      "cumulative_contributors": 157
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "cumulative_contributors": 118
+      "cumulative_contributors": 168
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "cumulative_contributors": 138
+      "cumulative_contributors": 192
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "cumulative_contributors": 166
+      "cumulative_contributors": 236
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "cumulative_contributors": 190
+      "cumulative_contributors": 271
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "cumulative_contributors": 224
+      "cumulative_contributors": 324
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "cumulative_contributors": 245
+      "cumulative_contributors": 374
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "cumulative_contributors": 273
+      "cumulative_contributors": 419
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "cumulative_contributors": 302
+      "cumulative_contributors": 463
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "cumulative_contributors": 317
+      "cumulative_contributors": 492
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "cumulative_contributors": 346
+      "cumulative_contributors": 536
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "cumulative_contributors": 394
+      "cumulative_contributors": 650
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "cumulative_contributors": 426
+      "cumulative_contributors": 713
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "cumulative_contributors": 462
+      "cumulative_contributors": 774
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "cumulative_contributors": 503
+      "cumulative_contributors": 832
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-08-01",
-      "cumulative_contributors": 12
+      "cumulative_contributors": 16
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-11-01",
-      "cumulative_contributors": 18
+      "cumulative_contributors": 25
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-12-01",
-      "cumulative_contributors": 23
+      "cumulative_contributors": 31
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-01-01",
-      "cumulative_contributors": 35
+      "cumulative_contributors": 49
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "cumulative_contributors": 56
+      "cumulative_contributors": 73
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "cumulative_contributors": 109
+      "cumulative_contributors": 134
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "cumulative_contributors": 158
+      "cumulative_contributors": 193
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "cumulative_contributors": 197
+      "cumulative_contributors": 243
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "cumulative_contributors": 251
+      "cumulative_contributors": 307
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "cumulative_contributors": 302
+      "cumulative_contributors": 369
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "cumulative_contributors": 319
+      "cumulative_contributors": 392
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "cumulative_contributors": 357
+      "cumulative_contributors": 436
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "cumulative_contributors": 391
+      "cumulative_contributors": 489
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "cumulative_contributors": 427
+      "cumulative_contributors": 536
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "cumulative_contributors": 450
+      "cumulative_contributors": 571
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "cumulative_contributors": 479
+      "cumulative_contributors": 612
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "cumulative_contributors": 548
+      "cumulative_contributors": 699
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4225,102 +4290,122 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "cumulative_contributors": 27
+      "cumulative_contributors": 30
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "cumulative_contributors": 30
+      "cumulative_contributors": 33
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "cumulative_contributors": 32
+      "cumulative_contributors": 35
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "cumulative_contributors": 35
+      "cumulative_contributors": 40
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "cumulative_contributors": 48
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-03-01",
       "cumulative_contributors": 57
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-04-01",
-      "cumulative_contributors": 59
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-05-01",
-      "cumulative_contributors": 60
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-06-01",
-      "cumulative_contributors": 62
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-07-01",
-      "cumulative_contributors": 63
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-08-01",
+      "month": "2025-03-01",
       "cumulative_contributors": 67
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-09-01",
+      "month": "2025-04-01",
+      "cumulative_contributors": 69
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-05-01",
       "cumulative_contributors": 70
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-06-01",
+      "cumulative_contributors": 72
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-07-01",
+      "cumulative_contributors": 74
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-08-01",
+      "cumulative_contributors": 78
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-09-01",
+      "cumulative_contributors": 81
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-10-01",
+      "cumulative_contributors": 83
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-12-01",
+      "cumulative_contributors": 84
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "cumulative_contributors": 71
+      "cumulative_contributors": 86
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2026-02-01",
+      "cumulative_contributors": 87
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "cumulative_contributors": 30
+      "cumulative_contributors": 44
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "cumulative_contributors": 35
+      "cumulative_contributors": 51
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "cumulative_contributors": 36
+      "cumulative_contributors": 52
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "cumulative_contributors": 37
+      "cumulative_contributors": 53
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-11-01",
-      "cumulative_contributors": 38
+      "cumulative_contributors": 54
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-02-01",
-      "cumulative_contributors": 39
+      "cumulative_contributors": 55
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-05-01",
-      "cumulative_contributors": 40
+      "cumulative_contributors": 56
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2026-01-01",
+      "cumulative_contributors": 58
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -4450,107 +4535,112 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-04-01",
-      "cumulative_contributors": 8
+      "cumulative_contributors": 9
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-06-01",
-      "cumulative_contributors": 10
+      "cumulative_contributors": 12
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "cumulative_contributors": 54
+      "cumulative_contributors": 69
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "cumulative_contributors": 77
+      "cumulative_contributors": 107
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "cumulative_contributors": 84
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2024-10-01",
-      "cumulative_contributors": 93
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2024-11-01",
-      "cumulative_contributors": 97
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2024-12-01",
-      "cumulative_contributors": 108
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2025-01-01",
-      "cumulative_contributors": 114
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2025-02-01",
-      "cumulative_contributors": 116
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2025-03-01",
       "cumulative_contributors": 121
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
+      "month": "2024-10-01",
+      "cumulative_contributors": 132
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2024-11-01",
+      "cumulative_contributors": 137
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2024-12-01",
+      "cumulative_contributors": 150
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2025-01-01",
+      "cumulative_contributors": 160
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2025-02-01",
+      "cumulative_contributors": 163
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2025-03-01",
+      "cumulative_contributors": 168
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "cumulative_contributors": 127
+      "cumulative_contributors": 174
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "cumulative_contributors": 135
+      "cumulative_contributors": 182
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "cumulative_contributors": 138
+      "cumulative_contributors": 185
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "cumulative_contributors": 141
+      "cumulative_contributors": 188
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "cumulative_contributors": 143
+      "cumulative_contributors": 190
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "cumulative_contributors": 145
+      "cumulative_contributors": 192
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "cumulative_contributors": 147
+      "cumulative_contributors": 194
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "cumulative_contributors": 149
+      "cumulative_contributors": 196
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "cumulative_contributors": 151
+      "cumulative_contributors": 199
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-01-01",
+      "cumulative_contributors": 200
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "cumulative_contributors": 153
+      "cumulative_contributors": 202
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -4675,122 +4765,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "cumulative_contributors": 376
+      "cumulative_contributors": 523
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "cumulative_contributors": 397
+      "cumulative_contributors": 558
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "cumulative_contributors": 415
+      "cumulative_contributors": 586
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "cumulative_contributors": 433
+      "cumulative_contributors": 613
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "cumulative_contributors": 448
+      "cumulative_contributors": 633
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "cumulative_contributors": 460
+      "cumulative_contributors": 654
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "cumulative_contributors": 474
+      "cumulative_contributors": 670
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "cumulative_contributors": 486
+      "cumulative_contributors": 685
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "cumulative_contributors": 487
+      "cumulative_contributors": 691
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "cumulative_contributors": 493
+      "cumulative_contributors": 698
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "cumulative_contributors": 501
+      "cumulative_contributors": 716
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "cumulative_contributors": 519
+      "cumulative_contributors": 736
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "cumulative_contributors": 542
+      "cumulative_contributors": 768
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "cumulative_contributors": 556
+      "cumulative_contributors": 790
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "cumulative_contributors": 571
+      "cumulative_contributors": 808
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "cumulative_contributors": 581
+      "cumulative_contributors": 823
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "cumulative_contributors": 594
+      "cumulative_contributors": 838
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "cumulative_contributors": 609
+      "cumulative_contributors": 860
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "cumulative_contributors": 626
+      "cumulative_contributors": 880
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "cumulative_contributors": 638
+      "cumulative_contributors": 895
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "cumulative_contributors": 646
+      "cumulative_contributors": 910
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "cumulative_contributors": 651
+      "cumulative_contributors": 918
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "cumulative_contributors": 657
+      "cumulative_contributors": 925
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "cumulative_contributors": 671
+      "cumulative_contributors": 941
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -4915,67 +5005,72 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "cumulative_contributors": 34
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-05-01",
       "cumulative_contributors": 41
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-06-01",
-      "cumulative_contributors": 44
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-07-01",
+      "month": "2024-05-01",
       "cumulative_contributors": 48
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-08-01",
-      "cumulative_contributors": 53
+      "month": "2024-06-01",
+      "cumulative_contributors": 52
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-09-01",
-      "cumulative_contributors": 55
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-11-01",
+      "month": "2024-07-01",
       "cumulative_contributors": 56
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-03-01",
-      "cumulative_contributors": 59
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-08-01",
+      "month": "2024-08-01",
       "cumulative_contributors": 61
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-09-01",
+      "cumulative_contributors": 65
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-11-01",
+      "cumulative_contributors": 66
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-03-01",
+      "cumulative_contributors": 69
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-07-01",
+      "cumulative_contributors": 70
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-08-01",
+      "cumulative_contributors": 72
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-09-01",
-      "cumulative_contributors": 62
+      "cumulative_contributors": 75
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-11-01",
-      "cumulative_contributors": 63
+      "cumulative_contributors": 76
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-12-01",
-      "cumulative_contributors": 64
+      "cumulative_contributors": 77
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-02-01",
-      "cumulative_contributors": 66
+      "cumulative_contributors": 79
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
@@ -5150,7 +5245,7 @@
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2026-02-01",
-      "cumulative_contributors": 689
+      "cumulative_contributors": 690
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -5265,12 +5360,12 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "cumulative_contributors": 1733
+      "cumulative_contributors": 1734
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "cumulative_contributors": 1793
+      "cumulative_contributors": 1794
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5480,97 +5575,97 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-08-01",
-      "cumulative_contributors": 1841
+      "cumulative_contributors": 1840
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-09-01",
-      "cumulative_contributors": 1898
+      "cumulative_contributors": 1897
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-10-01",
-      "cumulative_contributors": 1978
+      "cumulative_contributors": 1977
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-11-01",
-      "cumulative_contributors": 2028
+      "cumulative_contributors": 2027
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-12-01",
-      "cumulative_contributors": 2062
+      "cumulative_contributors": 2061
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-01-01",
-      "cumulative_contributors": 2092
+      "cumulative_contributors": 2091
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-02-01",
-      "cumulative_contributors": 2163
+      "cumulative_contributors": 2162
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "cumulative_contributors": 110
+      "cumulative_contributors": 140
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "cumulative_contributors": 143
+      "cumulative_contributors": 184
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "cumulative_contributors": 174
+      "cumulative_contributors": 225
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "cumulative_contributors": 204
+      "cumulative_contributors": 265
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "cumulative_contributors": 247
+      "cumulative_contributors": 341
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "cumulative_contributors": 281
+      "cumulative_contributors": 403
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "cumulative_contributors": 314
+      "cumulative_contributors": 453
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "cumulative_contributors": 332
+      "cumulative_contributors": 478
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "cumulative_contributors": 346
+      "cumulative_contributors": 503
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "cumulative_contributors": 371
+      "cumulative_contributors": 536
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "cumulative_contributors": 385
+      "cumulative_contributors": 552
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "cumulative_contributors": 410
+      "cumulative_contributors": 584
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5590,192 +5685,217 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "cumulative_contributors": 4508
+      "cumulative_contributors": 4514
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "cumulative_contributors": 7
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-07-01",
-      "cumulative_contributors": 9
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-10-01",
-      "cumulative_contributors": 10
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-11-01",
-      "cumulative_contributors": 12
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-12-01",
-      "cumulative_contributors": 14
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-01-01",
-      "cumulative_contributors": 16
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-03-01",
       "cumulative_contributors": 17
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-08-01",
-      "cumulative_contributors": 18
+      "month": "2024-04-01",
+      "cumulative_contributors": 19
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-10-01",
-      "cumulative_contributors": 20
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-11-01",
+      "month": "2024-05-01",
       "cumulative_contributors": 22
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-12-01",
+      "month": "2024-07-01",
+      "cumulative_contributors": 25
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-08-01",
       "cumulative_contributors": 27
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2026-01-01",
+      "month": "2024-10-01",
+      "cumulative_contributors": 28
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-11-01",
+      "cumulative_contributors": 30
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-12-01",
+      "cumulative_contributors": 32
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-01-01",
+      "cumulative_contributors": 35
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-02-01",
+      "cumulative_contributors": 36
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-03-01",
+      "cumulative_contributors": 37
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-05-01",
+      "cumulative_contributors": 38
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-08-01",
+      "cumulative_contributors": 39
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-10-01",
       "cumulative_contributors": 41
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-11-01",
+      "cumulative_contributors": 44
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-12-01",
+      "cumulative_contributors": 50
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-01-01",
+      "cumulative_contributors": 66
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "cumulative_contributors": 42
+      "cumulative_contributors": 67
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-03-01",
-      "cumulative_contributors": 8
+      "cumulative_contributors": 13
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-04-01",
-      "cumulative_contributors": 9
+      "cumulative_contributors": 16
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-05-01",
-      "cumulative_contributors": 14
+      "cumulative_contributors": 22
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-06-01",
-      "cumulative_contributors": 18
+      "cumulative_contributors": 30
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "cumulative_contributors": 26
+      "cumulative_contributors": 40
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "cumulative_contributors": 36
+      "cumulative_contributors": 59
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "cumulative_contributors": 51
+      "cumulative_contributors": 84
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "cumulative_contributors": 69
+      "cumulative_contributors": 114
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "cumulative_contributors": 76
+      "cumulative_contributors": 126
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "cumulative_contributors": 85
+      "cumulative_contributors": 142
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "cumulative_contributors": 102
+      "cumulative_contributors": 172
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "cumulative_contributors": 109
+      "cumulative_contributors": 185
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "cumulative_contributors": 128
+      "cumulative_contributors": 212
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "cumulative_contributors": 149
+      "cumulative_contributors": 248
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "cumulative_contributors": 178
+      "cumulative_contributors": 296
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "cumulative_contributors": 198
+      "cumulative_contributors": 321
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "cumulative_contributors": 218
+      "cumulative_contributors": 357
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "cumulative_contributors": 243
+      "cumulative_contributors": 398
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "cumulative_contributors": 265
+      "cumulative_contributors": 432
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "cumulative_contributors": 285
+      "cumulative_contributors": 462
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "cumulative_contributors": 300
+      "cumulative_contributors": 491
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "cumulative_contributors": 335
+      "cumulative_contributors": 532
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "cumulative_contributors": 375
+      "cumulative_contributors": 584
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "cumulative_contributors": 400
+      "cumulative_contributors": 621
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -6230,122 +6350,122 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "cumulative_contributors": 107
+      "cumulative_contributors": 139
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-04-01",
-      "cumulative_contributors": 111
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-05-01",
-      "cumulative_contributors": 113
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-06-01",
-      "cumulative_contributors": 117
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-07-01",
-      "cumulative_contributors": 124
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-08-01",
-      "cumulative_contributors": 133
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-09-01",
       "cumulative_contributors": 144
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-05-01",
+      "cumulative_contributors": 147
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-06-01",
+      "cumulative_contributors": 152
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-07-01",
+      "cumulative_contributors": 159
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-08-01",
+      "cumulative_contributors": 168
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-09-01",
+      "cumulative_contributors": 184
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "cumulative_contributors": 155
+      "cumulative_contributors": 202
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "cumulative_contributors": 161
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-12-01",
-      "cumulative_contributors": 166
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-01-01",
-      "cumulative_contributors": 173
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-02-01",
-      "cumulative_contributors": 182
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-03-01",
-      "cumulative_contributors": 193
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-04-01",
-      "cumulative_contributors": 203
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-05-01",
       "cumulative_contributors": 211
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-12-01",
+      "cumulative_contributors": 217
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-01-01",
+      "cumulative_contributors": 227
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-02-01",
+      "cumulative_contributors": 238
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-03-01",
+      "cumulative_contributors": 251
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-04-01",
+      "cumulative_contributors": 264
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-05-01",
+      "cumulative_contributors": 275
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "cumulative_contributors": 232
+      "cumulative_contributors": 298
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "cumulative_contributors": 240
+      "cumulative_contributors": 316
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "cumulative_contributors": 252
+      "cumulative_contributors": 338
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "cumulative_contributors": 263
+      "cumulative_contributors": 355
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "cumulative_contributors": 272
+      "cumulative_contributors": 370
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "cumulative_contributors": 290
+      "cumulative_contributors": 400
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "cumulative_contributors": 305
+      "cumulative_contributors": 421
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "cumulative_contributors": 326
+      "cumulative_contributors": 449
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "cumulative_contributors": 346
+      "cumulative_contributors": 473
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -6470,7 +6590,17 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-03-01",
-      "cumulative_contributors": 52
+      "cumulative_contributors": 64
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-04-01",
+      "cumulative_contributors": 65
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-06-01",
+      "cumulative_contributors": 66
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -6590,112 +6720,112 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "cumulative_contributors": 3
+      "cumulative_contributors": 4
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "cumulative_contributors": 7
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2024-07-01",
       "cumulative_contributors": 9
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2024-08-01",
+      "month": "2024-07-01",
       "cumulative_contributors": 13
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2024-08-01",
+      "cumulative_contributors": 19
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "cumulative_contributors": 16
+      "cumulative_contributors": 22
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "cumulative_contributors": 27
+      "cumulative_contributors": 37
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "cumulative_contributors": 40
+      "cumulative_contributors": 54
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "cumulative_contributors": 52
+      "cumulative_contributors": 70
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "cumulative_contributors": 66
+      "cumulative_contributors": 87
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "cumulative_contributors": 83
+      "cumulative_contributors": 108
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "cumulative_contributors": 95
+      "cumulative_contributors": 124
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "cumulative_contributors": 111
+      "cumulative_contributors": 142
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "cumulative_contributors": 133
+      "cumulative_contributors": 167
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "cumulative_contributors": 147
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-07-01",
-      "cumulative_contributors": 161
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-08-01",
-      "cumulative_contributors": 175
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-09-01",
       "cumulative_contributors": 182
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-07-01",
+      "cumulative_contributors": 201
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-08-01",
+      "cumulative_contributors": 221
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-09-01",
+      "cumulative_contributors": 229
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "cumulative_contributors": 183
+      "cumulative_contributors": 232
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "cumulative_contributors": 191
+      "cumulative_contributors": 245
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "cumulative_contributors": 198
+      "cumulative_contributors": 253
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "cumulative_contributors": 210
+      "cumulative_contributors": 267
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "cumulative_contributors": 218
+      "cumulative_contributors": 276
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -6830,117 +6960,117 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-03-01",
-      "cumulative_contributors": 9
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-04-01",
-      "cumulative_contributors": 12
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-05-01",
-      "cumulative_contributors": 13
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-06-01",
-      "cumulative_contributors": 14
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-07-01",
-      "cumulative_contributors": 17
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-09-01",
-      "cumulative_contributors": 18
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-10-01",
-      "cumulative_contributors": 19
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-11-01",
       "cumulative_contributors": 20
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-12-01",
-      "cumulative_contributors": 21
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-01-01",
-      "cumulative_contributors": 22
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-02-01",
+      "month": "2024-04-01",
       "cumulative_contributors": 25
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-05-01",
+      "cumulative_contributors": 28
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-06-01",
+      "cumulative_contributors": 32
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-07-01",
+      "cumulative_contributors": 35
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-09-01",
+      "cumulative_contributors": 39
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-10-01",
+      "cumulative_contributors": 40
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-11-01",
+      "cumulative_contributors": 43
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-12-01",
+      "cumulative_contributors": 44
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-01-01",
+      "cumulative_contributors": 46
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-02-01",
+      "cumulative_contributors": 55
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "cumulative_contributors": 27
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-04-01",
-      "cumulative_contributors": 31
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-05-01",
-      "cumulative_contributors": 34
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-06-01",
-      "cumulative_contributors": 37
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-07-01",
-      "cumulative_contributors": 49
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-08-01",
-      "cumulative_contributors": 54
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-09-01",
       "cumulative_contributors": 57
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-10-01",
-      "cumulative_contributors": 59
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-11-01",
+      "month": "2025-04-01",
       "cumulative_contributors": 63
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-05-01",
+      "cumulative_contributors": 70
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-06-01",
+      "cumulative_contributors": 77
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-07-01",
+      "cumulative_contributors": 98
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-08-01",
+      "cumulative_contributors": 108
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-09-01",
+      "cumulative_contributors": 119
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-10-01",
+      "cumulative_contributors": 124
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-11-01",
+      "cumulative_contributors": 133
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "cumulative_contributors": 64
+      "cumulative_contributors": 138
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "cumulative_contributors": 66
+      "cumulative_contributors": 143
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "cumulative_contributors": 68
+      "cumulative_contributors": 147
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/dependent_packages_count.json
+++ b/frontend/public/data/agentic-ai-momentum/dependent_packages_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:58.415018",
+    "fetched_at": "2026-04-01T07:13:35.612256",
     "schema": {
       "name": "dependent_packages_count",
       "description": "Monthly dependent package counts from Tinybird, broken out by ecosystem.",
@@ -247,7 +247,7 @@
       "repo": "https://github.com/PrefectHQ/prefect",
       "ecosystem": "nixpkgs",
       "month": "2026-03-01",
-      "dependent_package_count": 8
+      "dependent_package_count": 123
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1201,7 +1201,7 @@
       "repo": "https://github.com/microsoft/semantic-kernel",
       "ecosystem": "nuget",
       "month": "2026-03-01",
-      "dependent_package_count": 255
+      "dependent_package_count": 256
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",

--- a/frontend/public/data/agentic-ai-momentum/dependent_repos_count.json
+++ b/frontend/public/data/agentic-ai-momentum/dependent_repos_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:57.844269",
+    "fetched_at": "2026-04-01T07:13:35.066706",
     "schema": {
       "name": "dependent_repos_count",
       "description": "Monthly dependent repository counts from Tinybird, broken out by ecosystem.",
@@ -193,7 +193,7 @@
       "repo": "https://github.com/PrefectHQ/prefect",
       "ecosystem": "nixpkgs",
       "month": "2026-03-01",
-      "dependent_repo_count": 41
+      "dependent_repo_count": 767
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",

--- a/frontend/public/data/agentic-ai-momentum/docker_dependents_count.json
+++ b/frontend/public/data/agentic-ai-momentum/docker_dependents_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:58.819742",
+    "fetched_at": "2026-04-01T07:13:35.903578",
     "schema": {
       "name": "docker_dependents_count",
       "description": "Monthly Docker dependent counts from Tinybird packageDownloads datasource.",
@@ -165,7 +165,7 @@
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-03-01",
-      "docker_dependent_count": 125
+      "docker_dependent_count": 209
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",

--- a/frontend/public/data/agentic-ai-momentum/docker_hub_pulls.json
+++ b/frontend/public/data/agentic-ai-momentum/docker_hub_pulls.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:57.228959",
+    "fetched_at": "2026-04-01T07:13:34.411881",
     "schema": {
       "name": "docker_hub_pulls",
       "description": "Monthly Docker Hub pull counts from Tinybird packageDownloads datasource.",
@@ -165,7 +165,7 @@
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-03-01",
-      "pull_count": 2379
+      "pull_count": 108383784
     },
     {
       "repo": "https://github.com/chroma-core/chroma",

--- a/frontend/public/data/agentic-ai-momentum/fixed_vulnerabilities_count.json
+++ b/frontend/public/data/agentic-ai-momentum/fixed_vulnerabilities_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:25.922060",
+    "fetched_at": "2026-04-01T07:14:03.760981",
     "schema": {
       "name": "fixed_vulnerabilities_count",
       "description": "Cumulative monthly count of vulnerabilities with a known fix for tracked repositories.",
@@ -28,94 +28,64 @@
   },
   "data": [
     {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/BerriAI/litellm",
-      "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/BerriAI/litellm",
-      "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 7
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
-      "month": "2025-06-01",
+      "month": "2025-10-01",
       "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 28
+      "fixed_vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 51
+      "fixed_vulnerabilities_count": 25
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 72
+      "fixed_vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 4
+      "fixed_vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 5
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 10
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 12
+      "fixed_vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 19
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 49
+      "fixed_vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 75
+      "fixed_vulnerabilities_count": 30
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -125,67 +95,62 @@
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 3
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 6
+      "fixed_vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/HKUDS/LightRAG",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/HKUDS/LightRAG",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/OAI/OpenAPI-Specification",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/OAI/OpenAPI-Specification",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2026-02-01",
       "fixed_vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/HKUDS/LightRAG",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 34
-    },
-    {
-      "repo": "https://github.com/HKUDS/LightRAG",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 57
-    },
-    {
-      "repo": "https://github.com/OAI/OpenAPI-Specification",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/OAI/OpenAPI-Specification",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -205,237 +170,237 @@
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 9
+      "fixed_vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 16
+      "fixed_vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 17
+      "fixed_vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 20
+      "fixed_vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
+      "fixed_vulnerabilities_count": 15
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2024-09-01",
+      "fixed_vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2024-10-01",
       "fixed_vulnerabilities_count": 21
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2024-09-01",
+      "month": "2024-11-01",
+      "fixed_vulnerabilities_count": 26
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2024-12-01",
       "fixed_vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 34
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 47
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 49
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 28
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-03-01",
+      "fixed_vulnerabilities_count": 33
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 36
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-05-01",
+      "fixed_vulnerabilities_count": 39
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 41
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-07-01",
+      "fixed_vulnerabilities_count": 45
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-08-01",
+      "fixed_vulnerabilities_count": 46
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-09-01",
       "fixed_vulnerabilities_count": 50
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 56
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 63
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 67
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 72
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 82
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 84
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 91
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 96
+      "fixed_vulnerabilities_count": 52
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 98
+      "fixed_vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 104
+      "fixed_vulnerabilities_count": 57
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 115
+      "fixed_vulnerabilities_count": 64
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 6
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 17
+      "fixed_vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 30
+      "fixed_vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 41
+      "fixed_vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 56
+      "fixed_vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 58
+      "fixed_vulnerabilities_count": 29
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 61
+      "fixed_vulnerabilities_count": 30
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 70
+      "fixed_vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 79
+      "fixed_vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 90
+      "fixed_vulnerabilities_count": 45
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 93
+      "fixed_vulnerabilities_count": 48
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 99
+      "fixed_vulnerabilities_count": 51
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 107
+      "fixed_vulnerabilities_count": 56
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 114
+      "fixed_vulnerabilities_count": 57
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 118
+      "fixed_vulnerabilities_count": 60
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 123
+      "fixed_vulnerabilities_count": 63
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 126
+      "fixed_vulnerabilities_count": 64
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 141
+      "fixed_vulnerabilities_count": 69
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 199
+      "fixed_vulnerabilities_count": 100
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 224
+      "fixed_vulnerabilities_count": 116
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 3
+      "fixed_vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 6
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 36
+      "fixed_vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 42
+      "fixed_vulnerabilities_count": 19
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 51
+      "fixed_vulnerabilities_count": 23
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 60
+      "fixed_vulnerabilities_count": 28
     },
     {
       "repo": "https://github.com/agntcy/slim",
@@ -470,47 +435,42 @@
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 45
+      "fixed_vulnerabilities_count": 44
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 6
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/assafelovic/gpt-researcher",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 10
+      "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 12
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 14
+      "fixed_vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 17
+      "fixed_vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 19
+      "fixed_vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 22
+      "fixed_vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/block/goose",
@@ -520,192 +480,167 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 9
+      "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 22
+      "fixed_vulnerabilities_count": 21
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 12
+      "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 14
+      "fixed_vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 20
+      "fixed_vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "fixed_vulnerabilities_count": 24
+      "fixed_vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 25
+      "fixed_vulnerabilities_count": 16
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 50
+      "fixed_vulnerabilities_count": 26
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "fixed_vulnerabilities_count": 51
+      "fixed_vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 52
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 53
+      "fixed_vulnerabilities_count": 28
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 54
+      "fixed_vulnerabilities_count": 29
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 56
+      "fixed_vulnerabilities_count": 31
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 66
+      "fixed_vulnerabilities_count": 37
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 74
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 22
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 33
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-04-01",
       "fixed_vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
+      "month": "2024-03-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2024-05-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2024-09-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2024-12-01",
+      "fixed_vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 15
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-03-01",
+      "fixed_vulnerabilities_count": 24
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 28
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 47
+      "fixed_vulnerabilities_count": 31
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-07-01",
+      "fixed_vulnerabilities_count": 34
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-08-01",
+      "fixed_vulnerabilities_count": 38
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 43
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 48
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-11-01",
       "fixed_vulnerabilities_count": 52
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 58
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 63
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 73
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 87
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 95
+      "fixed_vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 135
+      "fixed_vulnerabilities_count": 75
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 184
+      "fixed_vulnerabilities_count": 107
     },
     {
       "repo": "https://github.com/cline/cline",
-      "month": "2025-02-01",
+      "month": "2025-12-01",
       "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/cline/cline",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/cline/cline",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 13
+      "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 43
+      "fixed_vulnerabilities_count": 23
     },
     {
       "repo": "https://github.com/comet-ml/opik",
@@ -715,197 +650,167 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-08-01",
-      "fixed_vulnerabilities_count": 3
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 5
+      "fixed_vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 10
+      "fixed_vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 15
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 19
+      "fixed_vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 24
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 25
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 27
+      "fixed_vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 30
+      "fixed_vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 35
+      "fixed_vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 90
+      "fixed_vulnerabilities_count": 48
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-02-01",
+      "month": "2025-07-01",
       "fixed_vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-07-01",
+      "month": "2025-11-01",
       "fixed_vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 9
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 14
+      "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 33
+      "fixed_vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 312
+      "fixed_vulnerabilities_count": 142
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 315
+      "fixed_vulnerabilities_count": 144
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 319
+      "fixed_vulnerabilities_count": 147
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 320
+      "fixed_vulnerabilities_count": 148
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-08-01",
-      "fixed_vulnerabilities_count": 321
+      "fixed_vulnerabilities_count": 149
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 323
+      "fixed_vulnerabilities_count": 150
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 328
+      "fixed_vulnerabilities_count": 153
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 332
+      "fixed_vulnerabilities_count": 155
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 343
+      "fixed_vulnerabilities_count": 159
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 344
+      "fixed_vulnerabilities_count": 160
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 352
+      "fixed_vulnerabilities_count": 162
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 356
+      "fixed_vulnerabilities_count": 165
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 367
+      "fixed_vulnerabilities_count": 174
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 375
+      "fixed_vulnerabilities_count": 178
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 396
+      "fixed_vulnerabilities_count": 191
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 407
+      "fixed_vulnerabilities_count": 196
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 466
+      "fixed_vulnerabilities_count": 228
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 560
+      "fixed_vulnerabilities_count": 274
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
@@ -915,137 +820,107 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 69
+      "fixed_vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 76
+      "fixed_vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 78
+      "fixed_vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 81
+      "fixed_vulnerabilities_count": 43
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 82
+      "fixed_vulnerabilities_count": 44
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 90
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 91
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 93
+      "fixed_vulnerabilities_count": 45
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 94
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-01-01",
-      "fixed_vulnerabilities_count": 96
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 99
+      "fixed_vulnerabilities_count": 46
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 100
+      "fixed_vulnerabilities_count": 47
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 103
+      "fixed_vulnerabilities_count": 48
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 111
+      "fixed_vulnerabilities_count": 51
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 115
+      "fixed_vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 118
+      "fixed_vulnerabilities_count": 55
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 126
+      "fixed_vulnerabilities_count": 61
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 178
+      "fixed_vulnerabilities_count": 87
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 183
+      "fixed_vulnerabilities_count": 88
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 210
+      "fixed_vulnerabilities_count": 103
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 283
+      "fixed_vulnerabilities_count": 140
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 328
+      "fixed_vulnerabilities_count": 164
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-04-01",
       "fixed_vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 4
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 5
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -1055,317 +930,262 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2024-11-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/huggingface/smolagents",
+      "month": "2025-03-01",
+      "fixed_vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/huggingface/smolagents",
+      "month": "2025-04-01",
       "fixed_vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 23
+      "fixed_vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 26
+      "fixed_vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 29
+      "fixed_vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 30
+      "fixed_vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 33
+      "fixed_vulnerabilities_count": 16
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 40
+      "fixed_vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 16
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 17
+      "fixed_vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 19
+      "fixed_vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 21
+      "fixed_vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2025-08-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2025-10-01",
       "fixed_vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 48
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 56
+      "fixed_vulnerabilities_count": 32
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 68
+      "fixed_vulnerabilities_count": 37
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 72
+      "fixed_vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-03-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2024-05-01",
       "fixed_vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 16
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 18
+      "fixed_vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 22
+      "fixed_vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 32
+      "fixed_vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 43
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-06-01",
       "fixed_vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/janhq/jan",
+      "month": "2024-03-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2024-05-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2025-05-01",
+      "fixed_vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 23
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 32
+      "fixed_vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 37
+      "fixed_vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 42
+      "fixed_vulnerabilities_count": 24
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 54
+      "fixed_vulnerabilities_count": 30
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 61
+      "fixed_vulnerabilities_count": 33
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 85
+      "fixed_vulnerabilities_count": 43
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 116
+      "fixed_vulnerabilities_count": 59
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 225
+      "fixed_vulnerabilities_count": 110
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 231
+      "fixed_vulnerabilities_count": 113
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 241
+      "fixed_vulnerabilities_count": 120
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 249
+      "fixed_vulnerabilities_count": 125
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 251
+      "fixed_vulnerabilities_count": 127
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 253
-    },
-    {
-      "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 255
-    },
-    {
-      "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 257
+      "fixed_vulnerabilities_count": 128
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 263
+      "fixed_vulnerabilities_count": 129
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 265
+      "fixed_vulnerabilities_count": 130
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 267
+      "fixed_vulnerabilities_count": 131
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 271
+      "fixed_vulnerabilities_count": 132
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 275
+      "fixed_vulnerabilities_count": 135
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 293
+      "fixed_vulnerabilities_count": 145
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 297
+      "fixed_vulnerabilities_count": 147
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -1478,11 +1298,6 @@
       "fixed_vulnerabilities_count": 2
     },
     {
-      "repo": "https://github.com/langchain-ai/langgraph",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2025-02-01",
       "fixed_vulnerabilities_count": 1
@@ -1494,1158 +1309,978 @@
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 28
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 49
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 63
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 27
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 52
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 80
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 90
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 171
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 293
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 42
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 46
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 54
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 63
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 70
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 83
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 119
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 147
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2025-12-01",
       "fixed_vulnerabilities_count": 4
     },
     {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
+      "repo": "https://github.com/langfuse/langfuse",
       "month": "2026-02-01",
       "fixed_vulnerabilities_count": 12
     },
     {
-      "repo": "https://github.com/microsoft/playwright",
-      "month": "2026-01-01",
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-03-01",
       "fixed_vulnerabilities_count": 1
     },
     {
-      "repo": "https://github.com/microsoft/playwright",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 28
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 32
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 39
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 65
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 98
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 15
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 33
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 15
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/inspector",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2025-09-01",
       "fixed_vulnerabilities_count": 2
     },
     {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 12
+      "fixed_vulnerabilities_count": 7
     },
     {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 27
+      "fixed_vulnerabilities_count": 8
     },
     {
-      "repo": "https://github.com/ollama/ollama",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 31
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 45
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 54
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 15
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 32
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 37
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 47
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 51
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 60
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 106
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 141
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2026-01-01",
       "fixed_vulnerabilities_count": 16
     },
     {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2026-02-01",
       "fixed_vulnerabilities_count": 24
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 1
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 32
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 2
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 9
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-08-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-11-01",
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-03-01",
       "fixed_vulnerabilities_count": 11
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-02-01",
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-07-01",
       "fixed_vulnerabilities_count": 14
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 16
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 31
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 38
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 42
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 82
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 140
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-03-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-05-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-07-01",
       "fixed_vulnerabilities_count": 18
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 27
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-08-01",
+      "fixed_vulnerabilities_count": 20
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 28
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 24
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-10-01",
       "fixed_vulnerabilities_count": 29
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 32
+      "fixed_vulnerabilities_count": 34
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 43
+      "fixed_vulnerabilities_count": 38
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 61
+      "fixed_vulnerabilities_count": 63
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 74
+      "fixed_vulnerabilities_count": 75
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 3
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 2
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-01-01",
-      "fixed_vulnerabilities_count": 5
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 4
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-02-01",
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-02-01",
       "fixed_vulnerabilities_count": 6
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/microsoft/playwright",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/playwright",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-04-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-10-01",
+      "fixed_vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-11-01",
+      "fixed_vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-03-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
       "fixed_vulnerabilities_count": 8
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-07-01",
+      "fixed_vulnerabilities_count": 16
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 19
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 22
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 37
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 54
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2024-11-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 20
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 29
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-12-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/inspector",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-08-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 19
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-12-01",
       "fixed_vulnerabilities_count": 13
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 21
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 26
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-05-01",
+      "fixed_vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-07-01",
+      "fixed_vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-08-01",
       "fixed_vulnerabilities_count": 15
     },
     {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 16
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 21
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 23
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 48
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 68
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-09-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-10-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-05-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-06-01",
+      "fixed_vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-09-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-10-01",
+      "fixed_vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-12-01",
+      "fixed_vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-03-01",
+      "fixed_vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-07-01",
+      "fixed_vulnerabilities_count": 15
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-11-01",
+      "fixed_vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-12-01",
+      "fixed_vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-01-01",
+      "fixed_vulnerabilities_count": 37
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-02-01",
+      "fixed_vulnerabilities_count": 45
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2024-09-01",
+      "fixed_vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-01-01",
+      "fixed_vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-02-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-04-01",
+      "fixed_vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 17
+      "fixed_vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 37
+      "fixed_vulnerabilities_count": 22
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 43
+      "fixed_vulnerabilities_count": 25
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 50
+      "fixed_vulnerabilities_count": 31
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 56
-    },
-    {
-      "repo": "https://github.com/pydantic/pydantic-ai",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 2
+      "fixed_vulnerabilities_count": 32
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 5
+      "fixed_vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 1371
+      "fixed_vulnerabilities_count": 722
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 1375
+      "fixed_vulnerabilities_count": 724
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 1388
+      "fixed_vulnerabilities_count": 732
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 1417
+      "fixed_vulnerabilities_count": 747
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 1424
+      "fixed_vulnerabilities_count": 749
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-08-01",
-      "fixed_vulnerabilities_count": 1442
+      "fixed_vulnerabilities_count": 758
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 1455
+      "fixed_vulnerabilities_count": 763
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 1512
+      "fixed_vulnerabilities_count": 794
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 1545
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 1546
+      "fixed_vulnerabilities_count": 812
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-01-01",
-      "fixed_vulnerabilities_count": 1550
+      "fixed_vulnerabilities_count": 814
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 1560
+      "fixed_vulnerabilities_count": 820
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 1624
+      "fixed_vulnerabilities_count": 852
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 1684
+      "fixed_vulnerabilities_count": 887
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 2265
+      "fixed_vulnerabilities_count": 1200
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 4735
+      "fixed_vulnerabilities_count": 2490
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 6656
+      "fixed_vulnerabilities_count": 3482
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 6744
+      "fixed_vulnerabilities_count": 3532
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 7568
+      "fixed_vulnerabilities_count": 3965
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 7617
+      "fixed_vulnerabilities_count": 3994
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 7645
+      "fixed_vulnerabilities_count": 4011
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 10860
+      "fixed_vulnerabilities_count": 5649
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 18060
+      "fixed_vulnerabilities_count": 9424
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 19962
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-03-01",
-      "fixed_vulnerabilities_count": 261
+      "fixed_vulnerabilities_count": 10391
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 262
+      "fixed_vulnerabilities_count": 135
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 263
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 264
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 266
+      "fixed_vulnerabilities_count": 136
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 272
+      "fixed_vulnerabilities_count": 141
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 273
+      "fixed_vulnerabilities_count": 142
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-01-01",
-      "fixed_vulnerabilities_count": 276
+      "fixed_vulnerabilities_count": 144
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 277
+      "fixed_vulnerabilities_count": 145
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 283
+      "fixed_vulnerabilities_count": 149
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 289
+      "fixed_vulnerabilities_count": 151
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 293
+      "fixed_vulnerabilities_count": 154
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 296
+      "fixed_vulnerabilities_count": 157
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 301
+      "fixed_vulnerabilities_count": 159
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 306
+      "fixed_vulnerabilities_count": 160
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 310
+      "fixed_vulnerabilities_count": 161
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 320
+      "fixed_vulnerabilities_count": 167
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 322
+      "fixed_vulnerabilities_count": 168
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 327
+      "fixed_vulnerabilities_count": 171
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 336
+      "fixed_vulnerabilities_count": 175
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 344
+      "fixed_vulnerabilities_count": 180
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 10
+      "fixed_vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-02-01",
+      "month": "2025-05-01",
+      "fixed_vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-06-01",
+      "fixed_vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-07-01",
+      "fixed_vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-10-01",
       "fixed_vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 23
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 24
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 27
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 28
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 42
+      "fixed_vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 68
+      "fixed_vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 73
+      "fixed_vulnerabilities_count": 37
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 5
+      "fixed_vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "fixed_vulnerabilities_count": 6
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-08-01",
-      "fixed_vulnerabilities_count": 8
+      "fixed_vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-09-01",
-      "fixed_vulnerabilities_count": 18
+      "fixed_vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-10-01",
-      "fixed_vulnerabilities_count": 27
+      "fixed_vulnerabilities_count": 19
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-11-01",
+      "fixed_vulnerabilities_count": 21
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-12-01",
+      "fixed_vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-01-01",
+      "fixed_vulnerabilities_count": 28
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-02-01",
       "fixed_vulnerabilities_count": 30
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-12-01",
-      "fixed_vulnerabilities_count": 37
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-01-01",
-      "fixed_vulnerabilities_count": 41
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-02-01",
-      "fixed_vulnerabilities_count": 46
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 55
+      "fixed_vulnerabilities_count": 34
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 56
+      "fixed_vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 62
+      "fixed_vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 64
+      "fixed_vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 66
+      "fixed_vulnerabilities_count": 41
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 76
+      "fixed_vulnerabilities_count": 50
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 77
+      "fixed_vulnerabilities_count": 51
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 79
+      "fixed_vulnerabilities_count": 52
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 83
+      "fixed_vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 94
+      "fixed_vulnerabilities_count": 61
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 105
+      "fixed_vulnerabilities_count": 66
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 122
+      "fixed_vulnerabilities_count": 72
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "fixed_vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 5
+      "fixed_vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 7
+      "fixed_vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 9
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 11
+      "fixed_vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 13
+      "fixed_vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 19
+      "fixed_vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 47
+      "fixed_vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 66
+      "fixed_vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/wong2/litemcp",
@@ -2664,93 +2299,83 @@
     },
     {
       "repo": "https://github.com/wong2/litemcp",
-      "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/wong2/litemcp",
-      "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/wong2/litemcp",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 9
+      "fixed_vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "fixed_vulnerabilities_count": 13
+      "fixed_vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "fixed_vulnerabilities_count": 16
+      "fixed_vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "fixed_vulnerabilities_count": 28
+      "fixed_vulnerabilities_count": 17
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "fixed_vulnerabilities_count": 32
+      "fixed_vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "fixed_vulnerabilities_count": 40
+      "fixed_vulnerabilities_count": 24
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "fixed_vulnerabilities_count": 44
+      "fixed_vulnerabilities_count": 26
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "fixed_vulnerabilities_count": 45
+      "fixed_vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "fixed_vulnerabilities_count": 53
+      "fixed_vulnerabilities_count": 33
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "fixed_vulnerabilities_count": 55
+      "fixed_vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "fixed_vulnerabilities_count": 61
+      "fixed_vulnerabilities_count": 38
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "fixed_vulnerabilities_count": 64
+      "fixed_vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "fixed_vulnerabilities_count": 67
+      "fixed_vulnerabilities_count": 41
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "fixed_vulnerabilities_count": 73
+      "fixed_vulnerabilities_count": 44
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "fixed_vulnerabilities_count": 90
+      "fixed_vulnerabilities_count": 57
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "fixed_vulnerabilities_count": 103
+      "fixed_vulnerabilities_count": 65
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/fork_count.json
+++ b/frontend/public/data/agentic-ai-momentum/fork_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:56.276709",
+    "fetched_at": "2026-04-01T07:13:33.289263",
     "schema": {
       "name": "fork_count",
       "description": "Cumulative monthly fork counts for tracked repositories.",
@@ -145,127 +145,127 @@
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2026-02-01",
-      "cumulative_forks": 3898
+      "cumulative_forks": 3899
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "cumulative_forks": 193
+      "cumulative_forks": 202
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "cumulative_forks": 203
+      "cumulative_forks": 215
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-05-01",
-      "cumulative_forks": 219
+      "cumulative_forks": 232
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "cumulative_forks": 231
+      "cumulative_forks": 244
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "cumulative_forks": 243
+      "cumulative_forks": 258
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "cumulative_forks": 260
+      "cumulative_forks": 280
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "cumulative_forks": 279
+      "cumulative_forks": 305
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "cumulative_forks": 300
+      "cumulative_forks": 330
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "cumulative_forks": 309
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-12-01",
-      "cumulative_forks": 320
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-01-01",
       "cumulative_forks": 340
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-12-01",
+      "cumulative_forks": 353
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-01-01",
+      "cumulative_forks": 377
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "cumulative_forks": 356
+      "cumulative_forks": 398
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "cumulative_forks": 374
+      "cumulative_forks": 422
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "cumulative_forks": 391
+      "cumulative_forks": 446
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "cumulative_forks": 401
+      "cumulative_forks": 461
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "cumulative_forks": 415
+      "cumulative_forks": 480
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "cumulative_forks": 430
+      "cumulative_forks": 498
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "cumulative_forks": 438
+      "cumulative_forks": 512
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "cumulative_forks": 458
+      "cumulative_forks": 537
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "cumulative_forks": 469
+      "cumulative_forks": 552
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "cumulative_forks": 483
+      "cumulative_forks": 572
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "cumulative_forks": 502
+      "cumulative_forks": 594
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "cumulative_forks": 515
+      "cumulative_forks": 612
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "cumulative_forks": 533
+      "cumulative_forks": 645
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -400,107 +400,107 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-06-01",
-      "cumulative_forks": 59
+      "cumulative_forks": 121
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-07-01",
-      "cumulative_forks": 503
+      "cumulative_forks": 789
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-08-01",
-      "cumulative_forks": 791
+      "cumulative_forks": 1211
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "cumulative_forks": 1243
+      "cumulative_forks": 2042
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "cumulative_forks": 2160
+      "cumulative_forks": 3265
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "cumulative_forks": 2233
+      "cumulative_forks": 3338
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "cumulative_forks": 2277
+      "cumulative_forks": 3382
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "cumulative_forks": 2323
+      "cumulative_forks": 3429
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "cumulative_forks": 2377
+      "cumulative_forks": 3484
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "cumulative_forks": 2538
+      "cumulative_forks": 3654
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "cumulative_forks": 2582
+      "cumulative_forks": 3701
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-05-01",
-      "cumulative_forks": 2619
+      "cumulative_forks": 3739
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "cumulative_forks": 2653
+      "cumulative_forks": 3777
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "cumulative_forks": 2672
+      "cumulative_forks": 3797
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "cumulative_forks": 2694
+      "cumulative_forks": 3819
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "cumulative_forks": 2725
+      "cumulative_forks": 3850
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "cumulative_forks": 2749
+      "cumulative_forks": 3876
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "cumulative_forks": 2801
+      "cumulative_forks": 3931
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "cumulative_forks": 2816
+      "cumulative_forks": 3946
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "cumulative_forks": 2852
+      "cumulative_forks": 3985
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "cumulative_forks": 2919
+      "cumulative_forks": 4055
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -715,337 +715,337 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "cumulative_forks": 55
+      "cumulative_forks": 56
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-09-01",
-      "cumulative_forks": 63
+      "cumulative_forks": 65
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-10-01",
-      "cumulative_forks": 68
+      "cumulative_forks": 72
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-11-01",
-      "cumulative_forks": 71
+      "cumulative_forks": 76
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-12-01",
-      "cumulative_forks": 79
+      "cumulative_forks": 84
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-01-01",
-      "cumulative_forks": 109
+      "cumulative_forks": 118
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-02-01",
-      "cumulative_forks": 126
+      "cumulative_forks": 138
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-03-01",
-      "cumulative_forks": 137
+      "cumulative_forks": 152
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-04-01",
-      "cumulative_forks": 143
+      "cumulative_forks": 158
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-05-01",
-      "cumulative_forks": 154
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-06-01",
-      "cumulative_forks": 160
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-07-01",
-      "cumulative_forks": 171
-    },
-    {
-      "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2025-08-01",
       "cumulative_forks": 173
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-06-01",
+      "cumulative_forks": 179
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-07-01",
+      "cumulative_forks": 192
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2025-08-01",
+      "cumulative_forks": 195
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-09-01",
-      "cumulative_forks": 176
+      "cumulative_forks": 199
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-10-01",
-      "cumulative_forks": 178
+      "cumulative_forks": 201
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-11-01",
-      "cumulative_forks": 183
+      "cumulative_forks": 207
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-12-01",
-      "cumulative_forks": 185
+      "cumulative_forks": 209
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2026-01-01",
-      "cumulative_forks": 188
+      "cumulative_forks": 213
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2026-02-01",
-      "cumulative_forks": 190
+      "cumulative_forks": 216
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "cumulative_forks": 836
+      "cumulative_forks": 918
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "cumulative_forks": 2016
+      "cumulative_forks": 2219
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "cumulative_forks": 2377
+      "cumulative_forks": 2608
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "cumulative_forks": 2560
+      "cumulative_forks": 2812
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "cumulative_forks": 2705
+      "cumulative_forks": 2970
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "cumulative_forks": 2877
+      "cumulative_forks": 3154
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "cumulative_forks": 3009
+      "cumulative_forks": 3294
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "cumulative_forks": 3114
+      "cumulative_forks": 3412
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "cumulative_forks": 3472
+      "cumulative_forks": 3790
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "cumulative_forks": 3658
+      "cumulative_forks": 3993
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "cumulative_forks": 4118
+      "cumulative_forks": 4491
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "cumulative_forks": 4414
+      "cumulative_forks": 4799
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "cumulative_forks": 4793
+      "cumulative_forks": 5207
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "cumulative_forks": 5009
+      "cumulative_forks": 5455
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "cumulative_forks": 5347
+      "cumulative_forks": 5829
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "cumulative_forks": 5727
+      "cumulative_forks": 6268
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "cumulative_forks": 6006
+      "cumulative_forks": 6609
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "cumulative_forks": 6206
+      "cumulative_forks": 6837
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "cumulative_forks": 6358
+      "cumulative_forks": 7021
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "cumulative_forks": 6475
+      "cumulative_forks": 7156
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "cumulative_forks": 6610
+      "cumulative_forks": 7316
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "cumulative_forks": 6771
+      "cumulative_forks": 7503
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "cumulative_forks": 6978
+      "cumulative_forks": 7738
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "cumulative_forks": 7136
+      "cumulative_forks": 7920
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-03-01",
-      "cumulative_forks": 3242
+      "cumulative_forks": 3504
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-04-01",
-      "cumulative_forks": 3461
+      "cumulative_forks": 3734
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-05-01",
-      "cumulative_forks": 3552
+      "cumulative_forks": 3831
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-06-01",
-      "cumulative_forks": 3640
+      "cumulative_forks": 3923
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-07-01",
-      "cumulative_forks": 3721
+      "cumulative_forks": 4010
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-08-01",
-      "cumulative_forks": 3812
+      "cumulative_forks": 4107
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-09-01",
-      "cumulative_forks": 3871
+      "cumulative_forks": 4170
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-10-01",
-      "cumulative_forks": 3992
+      "cumulative_forks": 4308
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-11-01",
-      "cumulative_forks": 4115
+      "cumulative_forks": 4443
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-12-01",
-      "cumulative_forks": 4160
+      "cumulative_forks": 4493
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-01-01",
-      "cumulative_forks": 4205
+      "cumulative_forks": 4539
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-02-01",
-      "cumulative_forks": 4241
+      "cumulative_forks": 4575
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-03-01",
-      "cumulative_forks": 4284
+      "cumulative_forks": 4621
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-04-01",
-      "cumulative_forks": 4314
+      "cumulative_forks": 4657
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-05-01",
-      "cumulative_forks": 4352
+      "cumulative_forks": 4698
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-06-01",
-      "cumulative_forks": 4382
+      "cumulative_forks": 4730
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-07-01",
-      "cumulative_forks": 4425
+      "cumulative_forks": 4778
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-08-01",
-      "cumulative_forks": 4473
+      "cumulative_forks": 4833
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-09-01",
-      "cumulative_forks": 4498
+      "cumulative_forks": 4861
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-10-01",
-      "cumulative_forks": 4526
+      "cumulative_forks": 4894
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-11-01",
-      "cumulative_forks": 4552
+      "cumulative_forks": 4923
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-12-01",
-      "cumulative_forks": 4595
+      "cumulative_forks": 4973
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-01-01",
-      "cumulative_forks": 4669
+      "cumulative_forks": 5049
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-02-01",
-      "cumulative_forks": 4740
+      "cumulative_forks": 5128
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1165,127 +1165,127 @@
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-02-01",
-      "cumulative_forks": 2057
+      "cumulative_forks": 2058
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "cumulative_forks": 572
+      "cumulative_forks": 608
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "cumulative_forks": 624
+      "cumulative_forks": 665
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "cumulative_forks": 651
+      "cumulative_forks": 694
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "cumulative_forks": 691
+      "cumulative_forks": 736
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "cumulative_forks": 718
+      "cumulative_forks": 765
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "cumulative_forks": 751
+      "cumulative_forks": 800
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "cumulative_forks": 771
+      "cumulative_forks": 825
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "cumulative_forks": 797
+      "cumulative_forks": 865
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "cumulative_forks": 820
+      "cumulative_forks": 891
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "cumulative_forks": 829
+      "cumulative_forks": 903
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "cumulative_forks": 848
+      "cumulative_forks": 922
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "cumulative_forks": 862
+      "cumulative_forks": 939
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "cumulative_forks": 880
+      "cumulative_forks": 959
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "cumulative_forks": 899
+      "cumulative_forks": 981
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "cumulative_forks": 919
+      "cumulative_forks": 1008
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "cumulative_forks": 940
+      "cumulative_forks": 1035
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "cumulative_forks": 960
+      "cumulative_forks": 1058
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "cumulative_forks": 982
+      "cumulative_forks": 1082
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-09-01",
-      "cumulative_forks": 998
+      "cumulative_forks": 1100
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-10-01",
-      "cumulative_forks": 1018
+      "cumulative_forks": 1128
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "cumulative_forks": 1037
+      "cumulative_forks": 1151
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-12-01",
-      "cumulative_forks": 1050
+      "cumulative_forks": 1170
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "cumulative_forks": 1061
+      "cumulative_forks": 1183
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "cumulative_forks": 1079
+      "cumulative_forks": 1202
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -1405,7 +1405,7 @@
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "cumulative_forks": 45910
+      "cumulative_forks": 45912
     },
     {
       "repo": "https://github.com/agntcy/acp-spec",
@@ -1770,202 +1770,202 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "cumulative_forks": 173
+      "cumulative_forks": 179
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "cumulative_forks": 480
+      "cumulative_forks": 511
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "cumulative_forks": 1764
+      "cumulative_forks": 1936
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "cumulative_forks": 2831
+      "cumulative_forks": 3156
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "cumulative_forks": 4361
+      "cumulative_forks": 4860
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "cumulative_forks": 5186
+      "cumulative_forks": 5780
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "cumulative_forks": 5667
+      "cumulative_forks": 6330
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "cumulative_forks": 6009
+      "cumulative_forks": 6739
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "cumulative_forks": 6308
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-08-01",
-      "cumulative_forks": 6596
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-09-01",
-      "cumulative_forks": 6851
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-10-01",
       "cumulative_forks": 7085
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-08-01",
+      "cumulative_forks": 7433
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-09-01",
+      "cumulative_forks": 7729
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-10-01",
+      "cumulative_forks": 7993
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "cumulative_forks": 7255
+      "cumulative_forks": 8196
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "cumulative_forks": 7415
+      "cumulative_forks": 8400
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "cumulative_forks": 7668
+      "cumulative_forks": 8704
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "cumulative_forks": 7872
+      "cumulative_forks": 8958
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-03-01",
-      "cumulative_forks": 388
+      "cumulative_forks": 467
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "cumulative_forks": 401
+      "cumulative_forks": 482
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "cumulative_forks": 416
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-06-01",
-      "cumulative_forks": 432
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-07-01",
-      "cumulative_forks": 460
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-08-01",
-      "cumulative_forks": 483
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-09-01",
       "cumulative_forks": 498
     },
     {
       "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-10-01",
+      "month": "2024-06-01",
       "cumulative_forks": 514
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-07-01",
+      "cumulative_forks": 543
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-08-01",
+      "cumulative_forks": 566
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-09-01",
+      "cumulative_forks": 585
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-10-01",
+      "cumulative_forks": 604
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "cumulative_forks": 533
+      "cumulative_forks": 624
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "cumulative_forks": 557
+      "cumulative_forks": 650
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "cumulative_forks": 574
+      "cumulative_forks": 668
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "cumulative_forks": 599
+      "cumulative_forks": 693
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "cumulative_forks": 964
+      "cumulative_forks": 1079
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "cumulative_forks": 1046
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-05-01",
-      "cumulative_forks": 1117
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-06-01",
       "cumulative_forks": 1170
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-05-01",
+      "cumulative_forks": 1247
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-06-01",
+      "cumulative_forks": 1306
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "cumulative_forks": 1231
+      "cumulative_forks": 1373
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "cumulative_forks": 1284
+      "cumulative_forks": 1435
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "cumulative_forks": 1327
+      "cumulative_forks": 1480
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "cumulative_forks": 1356
+      "cumulative_forks": 1517
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "cumulative_forks": 1388
+      "cumulative_forks": 1552
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "cumulative_forks": 1422
+      "cumulative_forks": 1589
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "cumulative_forks": 1486
+      "cumulative_forks": 1661
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "cumulative_forks": 1538
+      "cumulative_forks": 1714
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -2190,237 +2190,237 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-03-01",
-      "cumulative_forks": 23
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-04-01",
-      "cumulative_forks": 24
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-05-01",
       "cumulative_forks": 25
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-07-01",
+      "month": "2024-04-01",
       "cumulative_forks": 26
     },
     {
       "repo": "https://github.com/comet-ml/opik",
+      "month": "2024-05-01",
+      "cumulative_forks": 27
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2024-07-01",
+      "cumulative_forks": 28
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
       "month": "2024-08-01",
-      "cumulative_forks": 29
+      "cumulative_forks": 31
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-09-01",
-      "cumulative_forks": 70
+      "cumulative_forks": 73
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "cumulative_forks": 95
+      "cumulative_forks": 99
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "cumulative_forks": 121
+      "cumulative_forks": 126
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "cumulative_forks": 187
+      "cumulative_forks": 195
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "cumulative_forks": 263
+      "cumulative_forks": 277
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "cumulative_forks": 291
+      "cumulative_forks": 308
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "cumulative_forks": 365
+      "cumulative_forks": 384
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "cumulative_forks": 440
+      "cumulative_forks": 463
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "cumulative_forks": 527
+      "cumulative_forks": 558
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "cumulative_forks": 613
+      "cumulative_forks": 652
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "cumulative_forks": 702
+      "cumulative_forks": 749
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "cumulative_forks": 789
+      "cumulative_forks": 848
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "cumulative_forks": 873
+      "cumulative_forks": 938
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "cumulative_forks": 975
+      "cumulative_forks": 1056
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "cumulative_forks": 1028
+      "cumulative_forks": 1119
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "cumulative_forks": 1076
+      "cumulative_forks": 1179
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "cumulative_forks": 1139
+      "cumulative_forks": 1255
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "cumulative_forks": 1174
+      "cumulative_forks": 1298
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "cumulative_forks": 83
+      "cumulative_forks": 91
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "cumulative_forks": 99
+      "cumulative_forks": 110
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "cumulative_forks": 120
+      "cumulative_forks": 132
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "cumulative_forks": 135
+      "cumulative_forks": 149
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "cumulative_forks": 155
+      "cumulative_forks": 170
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "cumulative_forks": 177
+      "cumulative_forks": 194
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "cumulative_forks": 201
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-10-01",
       "cumulative_forks": 226
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-10-01",
+      "cumulative_forks": 254
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "cumulative_forks": 257
+      "cumulative_forks": 289
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "cumulative_forks": 284
+      "cumulative_forks": 320
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "cumulative_forks": 322
+      "cumulative_forks": 360
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "cumulative_forks": 370
+      "cumulative_forks": 413
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "cumulative_forks": 415
+      "cumulative_forks": 461
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "cumulative_forks": 453
+      "cumulative_forks": 500
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "cumulative_forks": 541
+      "cumulative_forks": 591
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "cumulative_forks": 634
+      "cumulative_forks": 694
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "cumulative_forks": 709
+      "cumulative_forks": 775
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "cumulative_forks": 769
+      "cumulative_forks": 840
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "cumulative_forks": 834
+      "cumulative_forks": 912
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "cumulative_forks": 894
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-11-01",
-      "cumulative_forks": 938
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-12-01",
       "cumulative_forks": 978
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-11-01",
+      "cumulative_forks": 1030
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-12-01",
+      "cumulative_forks": 1073
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "cumulative_forks": 1023
+      "cumulative_forks": 1123
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "cumulative_forks": 1094
+      "cumulative_forks": 1201
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2660,127 +2660,127 @@
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2026-02-01",
-      "cumulative_forks": 5931
+      "cumulative_forks": 5932
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "cumulative_forks": 149
+      "cumulative_forks": 152
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "cumulative_forks": 172
+      "cumulative_forks": 177
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "cumulative_forks": 183
+      "cumulative_forks": 190
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "cumulative_forks": 453
+      "cumulative_forks": 569
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "cumulative_forks": 484
+      "cumulative_forks": 604
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "cumulative_forks": 507
+      "cumulative_forks": 629
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "cumulative_forks": 531
+      "cumulative_forks": 660
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "cumulative_forks": 558
+      "cumulative_forks": 691
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "cumulative_forks": 601
+      "cumulative_forks": 756
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "cumulative_forks": 914
+      "cumulative_forks": 1185
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "cumulative_forks": 930
+      "cumulative_forks": 1202
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "cumulative_forks": 941
+      "cumulative_forks": 1214
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-03-01",
-      "cumulative_forks": 948
+      "cumulative_forks": 1222
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "cumulative_forks": 1253
+      "cumulative_forks": 1534
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "cumulative_forks": 1739
+      "cumulative_forks": 2033
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "cumulative_forks": 1761
+      "cumulative_forks": 2056
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "cumulative_forks": 1808
+      "cumulative_forks": 2112
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "cumulative_forks": 1829
+      "cumulative_forks": 2136
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "cumulative_forks": 1855
+      "cumulative_forks": 2165
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "cumulative_forks": 1970
+      "cumulative_forks": 2310
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "cumulative_forks": 2149
+      "cumulative_forks": 2550
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "cumulative_forks": 2585
+      "cumulative_forks": 3457
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "cumulative_forks": 2893
+      "cumulative_forks": 4233
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "cumulative_forks": 3112
+      "cumulative_forks": 4719
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2900,7 +2900,7 @@
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2026-02-01",
-      "cumulative_forks": 2553
+      "cumulative_forks": 2554
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2910,287 +2910,287 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-05-01",
-      "cumulative_forks": 31
+      "cumulative_forks": 32
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-06-01",
-      "cumulative_forks": 42
+      "cumulative_forks": 43
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-07-01",
-      "cumulative_forks": 49
+      "cumulative_forks": 51
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-08-01",
-      "cumulative_forks": 56
+      "cumulative_forks": 58
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-09-01",
-      "cumulative_forks": 64
+      "cumulative_forks": 66
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-10-01",
-      "cumulative_forks": 72
+      "cumulative_forks": 74
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-11-01",
-      "cumulative_forks": 78
+      "cumulative_forks": 80
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-12-01",
-      "cumulative_forks": 84
+      "cumulative_forks": 86
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-01-01",
-      "cumulative_forks": 94
+      "cumulative_forks": 96
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-02-01",
-      "cumulative_forks": 99
+      "cumulative_forks": 101
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-03-01",
-      "cumulative_forks": 108
-    },
-    {
-      "repo": "https://github.com/e2b-dev/code-interpreter",
-      "month": "2025-04-01",
       "cumulative_forks": 110
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2025-04-01",
+      "cumulative_forks": 112
+    },
+    {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-05-01",
-      "cumulative_forks": 116
+      "cumulative_forks": 119
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-06-01",
-      "cumulative_forks": 123
+      "cumulative_forks": 126
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-07-01",
-      "cumulative_forks": 133
+      "cumulative_forks": 136
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-08-01",
-      "cumulative_forks": 142
+      "cumulative_forks": 145
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-09-01",
-      "cumulative_forks": 143
+      "cumulative_forks": 146
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-10-01",
-      "cumulative_forks": 144
+      "cumulative_forks": 147
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-11-01",
-      "cumulative_forks": 152
+      "cumulative_forks": 155
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-12-01",
-      "cumulative_forks": 164
+      "cumulative_forks": 167
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-01-01",
-      "cumulative_forks": 172
+      "cumulative_forks": 175
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-02-01",
-      "cumulative_forks": 174
+      "cumulative_forks": 179
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "cumulative_forks": 644
+      "cumulative_forks": 695
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "cumulative_forks": 903
+      "cumulative_forks": 977
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "cumulative_forks": 1124
+      "cumulative_forks": 1232
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "cumulative_forks": 1289
+      "cumulative_forks": 1415
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "cumulative_forks": 1492
+      "cumulative_forks": 1653
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "cumulative_forks": 1643
+      "cumulative_forks": 1823
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "cumulative_forks": 1793
+      "cumulative_forks": 2010
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "cumulative_forks": 2046
+      "cumulative_forks": 2361
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "cumulative_forks": 2209
+      "cumulative_forks": 2556
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "cumulative_forks": 2318
+      "cumulative_forks": 2691
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "cumulative_forks": 2461
+      "cumulative_forks": 2867
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "cumulative_forks": 196
+      "cumulative_forks": 206
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "cumulative_forks": 204
+      "cumulative_forks": 214
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-05-01",
-      "cumulative_forks": 210
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-06-01",
       "cumulative_forks": 221
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-06-01",
+      "cumulative_forks": 234
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "cumulative_forks": 232
+      "cumulative_forks": 245
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "cumulative_forks": 243
+      "cumulative_forks": 257
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "cumulative_forks": 252
+      "cumulative_forks": 268
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "cumulative_forks": 261
+      "cumulative_forks": 280
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "cumulative_forks": 271
+      "cumulative_forks": 290
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "cumulative_forks": 285
+      "cumulative_forks": 305
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "cumulative_forks": 296
+      "cumulative_forks": 318
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "cumulative_forks": 302
+      "cumulative_forks": 325
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "cumulative_forks": 319
+      "cumulative_forks": 343
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "cumulative_forks": 333
+      "cumulative_forks": 359
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-05-01",
-      "cumulative_forks": 348
+      "cumulative_forks": 375
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "cumulative_forks": 355
+      "cumulative_forks": 384
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "cumulative_forks": 367
+      "cumulative_forks": 397
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-08-01",
-      "cumulative_forks": 378
+      "cumulative_forks": 409
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-09-01",
-      "cumulative_forks": 386
+      "cumulative_forks": 419
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "cumulative_forks": 405
+      "cumulative_forks": 439
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "cumulative_forks": 417
+      "cumulative_forks": 455
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "cumulative_forks": 432
+      "cumulative_forks": 470
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-01-01",
-      "cumulative_forks": 448
+      "cumulative_forks": 486
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "cumulative_forks": 460
+      "cumulative_forks": 500
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -3230,42 +3230,42 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-07-01",
-      "cumulative_forks": 1784
+      "cumulative_forks": 1785
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-08-01",
-      "cumulative_forks": 1857
+      "cumulative_forks": 1858
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-09-01",
-      "cumulative_forks": 1912
+      "cumulative_forks": 1913
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-10-01",
-      "cumulative_forks": 1971
+      "cumulative_forks": 1972
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-11-01",
-      "cumulative_forks": 2017
+      "cumulative_forks": 2018
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-12-01",
-      "cumulative_forks": 2076
+      "cumulative_forks": 2077
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-01-01",
-      "cumulative_forks": 2139
+      "cumulative_forks": 2140
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "cumulative_forks": 2195
+      "cumulative_forks": 2196
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3390,52 +3390,52 @@
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-05-01",
-      "cumulative_forks": 1
+      "cumulative_forks": 2
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-06-01",
-      "cumulative_forks": 80
+      "cumulative_forks": 88
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-07-01",
-      "cumulative_forks": 131
+      "cumulative_forks": 143
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-08-01",
-      "cumulative_forks": 223
+      "cumulative_forks": 239
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-09-01",
-      "cumulative_forks": 277
+      "cumulative_forks": 298
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-10-01",
-      "cumulative_forks": 316
+      "cumulative_forks": 341
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-11-01",
-      "cumulative_forks": 348
+      "cumulative_forks": 382
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-12-01",
-      "cumulative_forks": 381
+      "cumulative_forks": 421
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-01-01",
-      "cumulative_forks": 411
+      "cumulative_forks": 459
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-02-01",
-      "cumulative_forks": 451
+      "cumulative_forks": 517
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -3550,7 +3550,7 @@
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-02-01",
-      "cumulative_forks": 8221
+      "cumulative_forks": 8222
     },
     {
       "repo": "https://github.com/janhq/jan",
@@ -3675,122 +3675,122 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-03-01",
-      "cumulative_forks": 1483
+      "cumulative_forks": 1611
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "cumulative_forks": 1536
+      "cumulative_forks": 1670
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "cumulative_forks": 1587
+      "cumulative_forks": 1726
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-06-01",
-      "cumulative_forks": 1622
+      "cumulative_forks": 1768
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-07-01",
-      "cumulative_forks": 1660
+      "cumulative_forks": 1811
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-08-01",
-      "cumulative_forks": 1682
+      "cumulative_forks": 1842
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
-      "cumulative_forks": 1704
+      "cumulative_forks": 1872
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "cumulative_forks": 1798
+      "cumulative_forks": 1983
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "cumulative_forks": 1862
+      "cumulative_forks": 2061
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-12-01",
-      "cumulative_forks": 1902
+      "cumulative_forks": 2107
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-01-01",
-      "cumulative_forks": 1930
+      "cumulative_forks": 2145
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-02-01",
-      "cumulative_forks": 1960
+      "cumulative_forks": 2181
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-03-01",
-      "cumulative_forks": 2006
+      "cumulative_forks": 2235
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-04-01",
-      "cumulative_forks": 2038
+      "cumulative_forks": 2269
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-05-01",
-      "cumulative_forks": 2062
+      "cumulative_forks": 2305
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-06-01",
-      "cumulative_forks": 2086
+      "cumulative_forks": 2338
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-07-01",
-      "cumulative_forks": 2112
+      "cumulative_forks": 2372
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-08-01",
-      "cumulative_forks": 2142
+      "cumulative_forks": 2407
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-09-01",
-      "cumulative_forks": 2185
+      "cumulative_forks": 2456
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-10-01",
-      "cumulative_forks": 2217
+      "cumulative_forks": 2498
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-11-01",
-      "cumulative_forks": 2245
+      "cumulative_forks": 2528
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "cumulative_forks": 2265
+      "cumulative_forks": 2559
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-01-01",
-      "cumulative_forks": 2288
+      "cumulative_forks": 2591
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-02-01",
-      "cumulative_forks": 2339
+      "cumulative_forks": 2660
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -4030,7 +4030,7 @@
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2026-02-01",
-      "cumulative_forks": 20731
+      "cumulative_forks": 20733
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
@@ -4150,7 +4150,7 @@
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2026-02-01",
-      "cumulative_forks": 4386
+      "cumulative_forks": 4387
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
@@ -4395,122 +4395,122 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-03-01",
-      "cumulative_forks": 19
+      "cumulative_forks": 20
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "cumulative_forks": 27
+      "cumulative_forks": 29
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "cumulative_forks": 46
+      "cumulative_forks": 49
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "cumulative_forks": 70
+      "cumulative_forks": 73
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "cumulative_forks": 96
+      "cumulative_forks": 103
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "cumulative_forks": 128
+      "cumulative_forks": 137
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "cumulative_forks": 165
+      "cumulative_forks": 186
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "cumulative_forks": 289
+      "cumulative_forks": 318
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "cumulative_forks": 336
+      "cumulative_forks": 367
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "cumulative_forks": 393
+      "cumulative_forks": 427
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "cumulative_forks": 448
+      "cumulative_forks": 489
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "cumulative_forks": 497
+      "cumulative_forks": 547
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "cumulative_forks": 554
+      "cumulative_forks": 618
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "cumulative_forks": 617
+      "cumulative_forks": 694
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "cumulative_forks": 698
+      "cumulative_forks": 785
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "cumulative_forks": 769
+      "cumulative_forks": 881
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "cumulative_forks": 838
+      "cumulative_forks": 970
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "cumulative_forks": 915
+      "cumulative_forks": 1062
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "cumulative_forks": 982
+      "cumulative_forks": 1145
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "cumulative_forks": 1078
+      "cumulative_forks": 1259
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "cumulative_forks": 1225
+      "cumulative_forks": 1593
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "cumulative_forks": 1293
+      "cumulative_forks": 1684
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "cumulative_forks": 1379
+      "cumulative_forks": 1790
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "cumulative_forks": 1444
+      "cumulative_forks": 1873
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4520,287 +4520,287 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-11-01",
-      "cumulative_forks": 20
+      "cumulative_forks": 21
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-12-01",
-      "cumulative_forks": 29
+      "cumulative_forks": 30
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-01-01",
-      "cumulative_forks": 54
+      "cumulative_forks": 55
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "cumulative_forks": 273
+      "cumulative_forks": 293
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "cumulative_forks": 470
+      "cumulative_forks": 499
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "cumulative_forks": 561
+      "cumulative_forks": 595
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "cumulative_forks": 647
+      "cumulative_forks": 692
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "cumulative_forks": 752
+      "cumulative_forks": 805
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "cumulative_forks": 823
+      "cumulative_forks": 882
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "cumulative_forks": 892
+      "cumulative_forks": 953
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "cumulative_forks": 977
+      "cumulative_forks": 1041
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "cumulative_forks": 1069
+      "cumulative_forks": 1141
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "cumulative_forks": 1137
+      "cumulative_forks": 1217
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "cumulative_forks": 1195
+      "cumulative_forks": 1280
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "cumulative_forks": 1296
+      "cumulative_forks": 1398
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "cumulative_forks": 1429
+      "cumulative_forks": 1550
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "cumulative_forks": 211
+      "cumulative_forks": 228
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "cumulative_forks": 316
+      "cumulative_forks": 340
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "cumulative_forks": 344
+      "cumulative_forks": 372
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "cumulative_forks": 367
+      "cumulative_forks": 397
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "cumulative_forks": 1192
+      "cumulative_forks": 1316
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "cumulative_forks": 1447
+      "cumulative_forks": 1588
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "cumulative_forks": 1522
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-05-01",
-      "cumulative_forks": 1554
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-06-01",
-      "cumulative_forks": 1583
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-07-01",
-      "cumulative_forks": 1626
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-08-01",
       "cumulative_forks": 1675
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-05-01",
+      "cumulative_forks": 1712
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-06-01",
+      "cumulative_forks": 1745
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-07-01",
+      "cumulative_forks": 1794
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-08-01",
+      "cumulative_forks": 1847
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-09-01",
-      "cumulative_forks": 1706
+      "cumulative_forks": 1880
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-10-01",
-      "cumulative_forks": 1732
+      "cumulative_forks": 1906
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-11-01",
-      "cumulative_forks": 1751
+      "cumulative_forks": 1928
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-12-01",
-      "cumulative_forks": 1766
+      "cumulative_forks": 1944
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "cumulative_forks": 1806
+      "cumulative_forks": 1989
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-02-01",
-      "cumulative_forks": 1828
+      "cumulative_forks": 2016
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "cumulative_forks": 475
+      "cumulative_forks": 500
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "cumulative_forks": 504
+      "cumulative_forks": 530
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "cumulative_forks": 518
+      "cumulative_forks": 550
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "cumulative_forks": 531
+      "cumulative_forks": 563
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "cumulative_forks": 543
+      "cumulative_forks": 575
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-08-01",
-      "cumulative_forks": 555
+      "cumulative_forks": 587
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "cumulative_forks": 565
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2024-10-01",
-      "cumulative_forks": 577
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2024-11-01",
-      "cumulative_forks": 592
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2024-12-01",
       "cumulative_forks": 598
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2024-10-01",
+      "cumulative_forks": 610
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2024-11-01",
+      "cumulative_forks": 625
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2024-12-01",
+      "cumulative_forks": 631
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "cumulative_forks": 605
+      "cumulative_forks": 638
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-02-01",
-      "cumulative_forks": 614
+      "cumulative_forks": 650
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-03-01",
-      "cumulative_forks": 629
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-04-01",
-      "cumulative_forks": 634
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-05-01",
-      "cumulative_forks": 642
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-06-01",
-      "cumulative_forks": 651
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-07-01",
-      "cumulative_forks": 658
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-08-01",
-      "cumulative_forks": 662
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-09-01",
       "cumulative_forks": 666
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-10-01",
-      "cumulative_forks": 669
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-11-01",
+      "month": "2025-04-01",
       "cumulative_forks": 673
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-05-01",
+      "cumulative_forks": 681
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-06-01",
+      "cumulative_forks": 691
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-07-01",
+      "cumulative_forks": 698
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-08-01",
+      "cumulative_forks": 703
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-09-01",
+      "cumulative_forks": 707
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-10-01",
+      "cumulative_forks": 710
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-11-01",
+      "cumulative_forks": 714
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-12-01",
-      "cumulative_forks": 677
+      "cumulative_forks": 719
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-01-01",
-      "cumulative_forks": 680
+      "cumulative_forks": 722
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-02-01",
-      "cumulative_forks": 684
+      "cumulative_forks": 726
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -4925,102 +4925,102 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "cumulative_forks": 976
+      "cumulative_forks": 1030
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "cumulative_forks": 1262
+      "cumulative_forks": 1339
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "cumulative_forks": 1396
+      "cumulative_forks": 1486
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "cumulative_forks": 1498
+      "cumulative_forks": 1601
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "cumulative_forks": 1611
+      "cumulative_forks": 1723
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "cumulative_forks": 1716
+      "cumulative_forks": 1836
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "cumulative_forks": 1808
+      "cumulative_forks": 1941
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "cumulative_forks": 1891
+      "cumulative_forks": 2033
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "cumulative_forks": 2005
+      "cumulative_forks": 2153
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "cumulative_forks": 2099
+      "cumulative_forks": 2257
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "cumulative_forks": 2175
+      "cumulative_forks": 2346
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "cumulative_forks": 2256
+      "cumulative_forks": 2442
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "cumulative_forks": 2345
+      "cumulative_forks": 2545
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "cumulative_forks": 2409
+      "cumulative_forks": 2621
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "cumulative_forks": 2497
+      "cumulative_forks": 2720
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "cumulative_forks": 2553
+      "cumulative_forks": 2788
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "cumulative_forks": 2619
+      "cumulative_forks": 2863
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "cumulative_forks": 2679
+      "cumulative_forks": 2934
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "cumulative_forks": 2747
+      "cumulative_forks": 3010
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "cumulative_forks": 2799
+      "cumulative_forks": 3071
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -5145,122 +5145,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "cumulative_forks": 1916
+      "cumulative_forks": 2259
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "cumulative_forks": 2005
+      "cumulative_forks": 2371
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "cumulative_forks": 2075
+      "cumulative_forks": 2452
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "cumulative_forks": 2210
+      "cumulative_forks": 2610
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "cumulative_forks": 2283
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-08-01",
-      "cumulative_forks": 2337
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-09-01",
-      "cumulative_forks": 2389
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-10-01",
-      "cumulative_forks": 2448
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-11-01",
-      "cumulative_forks": 2491
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-12-01",
-      "cumulative_forks": 2546
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-01-01",
-      "cumulative_forks": 2611
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-02-01",
       "cumulative_forks": 2695
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-08-01",
+      "cumulative_forks": 2753
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-09-01",
+      "cumulative_forks": 2815
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-10-01",
+      "cumulative_forks": 2885
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-11-01",
+      "cumulative_forks": 2936
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-12-01",
+      "cumulative_forks": 3000
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-01-01",
+      "cumulative_forks": 3079
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-02-01",
+      "cumulative_forks": 3171
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "cumulative_forks": 2783
+      "cumulative_forks": 3285
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "cumulative_forks": 2881
+      "cumulative_forks": 3414
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "cumulative_forks": 2986
+      "cumulative_forks": 3535
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "cumulative_forks": 3085
+      "cumulative_forks": 3662
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "cumulative_forks": 3150
+      "cumulative_forks": 3746
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "cumulative_forks": 3221
+      "cumulative_forks": 3834
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "cumulative_forks": 3295
+      "cumulative_forks": 3926
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "cumulative_forks": 3349
+      "cumulative_forks": 3999
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "cumulative_forks": 3404
+      "cumulative_forks": 4056
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "cumulative_forks": 3449
+      "cumulative_forks": 4106
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "cumulative_forks": 3498
+      "cumulative_forks": 4159
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "cumulative_forks": 3541
+      "cumulative_forks": 4211
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -5385,122 +5385,122 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "cumulative_forks": 573
+      "cumulative_forks": 605
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-04-01",
-      "cumulative_forks": 604
+      "cumulative_forks": 639
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-05-01",
-      "cumulative_forks": 627
+      "cumulative_forks": 662
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-06-01",
-      "cumulative_forks": 647
+      "cumulative_forks": 682
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-07-01",
-      "cumulative_forks": 673
+      "cumulative_forks": 708
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-08-01",
-      "cumulative_forks": 692
+      "cumulative_forks": 728
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-09-01",
-      "cumulative_forks": 700
+      "cumulative_forks": 737
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-10-01",
-      "cumulative_forks": 713
+      "cumulative_forks": 751
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-11-01",
-      "cumulative_forks": 726
+      "cumulative_forks": 764
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-12-01",
-      "cumulative_forks": 730
+      "cumulative_forks": 769
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-01-01",
-      "cumulative_forks": 738
+      "cumulative_forks": 779
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-02-01",
-      "cumulative_forks": 749
+      "cumulative_forks": 794
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-03-01",
-      "cumulative_forks": 760
+      "cumulative_forks": 806
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-04-01",
-      "cumulative_forks": 768
+      "cumulative_forks": 814
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-05-01",
-      "cumulative_forks": 776
+      "cumulative_forks": 824
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-06-01",
-      "cumulative_forks": 784
+      "cumulative_forks": 833
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-07-01",
-      "cumulative_forks": 800
+      "cumulative_forks": 850
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-08-01",
-      "cumulative_forks": 816
+      "cumulative_forks": 868
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-09-01",
-      "cumulative_forks": 827
+      "cumulative_forks": 882
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-10-01",
-      "cumulative_forks": 836
+      "cumulative_forks": 891
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-11-01",
-      "cumulative_forks": 848
+      "cumulative_forks": 905
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-12-01",
-      "cumulative_forks": 860
+      "cumulative_forks": 919
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-01-01",
-      "cumulative_forks": 873
+      "cumulative_forks": 932
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-02-01",
-      "cumulative_forks": 886
+      "cumulative_forks": 946
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
@@ -5760,12 +5760,12 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "cumulative_forks": 14154
+      "cumulative_forks": 14155
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "cumulative_forks": 14590
+      "cumulative_forks": 14594
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5955,117 +5955,117 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-04-01",
-      "cumulative_forks": 10871
+      "cumulative_forks": 10870
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-05-01",
-      "cumulative_forks": 11810
+      "cumulative_forks": 11809
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-06-01",
-      "cumulative_forks": 12612
+      "cumulative_forks": 12611
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-07-01",
-      "cumulative_forks": 13354
+      "cumulative_forks": 13353
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-08-01",
-      "cumulative_forks": 14125
+      "cumulative_forks": 14124
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-09-01",
-      "cumulative_forks": 14789
+      "cumulative_forks": 14788
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-10-01",
-      "cumulative_forks": 15426
+      "cumulative_forks": 15425
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-11-01",
-      "cumulative_forks": 16101
+      "cumulative_forks": 16100
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-12-01",
-      "cumulative_forks": 16696
+      "cumulative_forks": 16695
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-01-01",
-      "cumulative_forks": 17357
+      "cumulative_forks": 17356
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-02-01",
-      "cumulative_forks": 17993
+      "cumulative_forks": 17992
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "cumulative_forks": 744
+      "cumulative_forks": 796
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "cumulative_forks": 1029
+      "cumulative_forks": 1130
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "cumulative_forks": 1232
+      "cumulative_forks": 1371
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "cumulative_forks": 1456
+      "cumulative_forks": 1633
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "cumulative_forks": 1634
+      "cumulative_forks": 1853
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "cumulative_forks": 1811
+      "cumulative_forks": 2063
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "cumulative_forks": 1994
+      "cumulative_forks": 2277
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "cumulative_forks": 2209
+      "cumulative_forks": 2541
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "cumulative_forks": 2325
+      "cumulative_forks": 2676
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "cumulative_forks": 2407
+      "cumulative_forks": 2779
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "cumulative_forks": 2505
+      "cumulative_forks": 2889
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "cumulative_forks": 2585
+      "cumulative_forks": 2983
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -6085,127 +6085,127 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "cumulative_forks": 47469
+      "cumulative_forks": 47470
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "cumulative_forks": 42
+      "cumulative_forks": 53
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-04-01",
-      "cumulative_forks": 48
+      "cumulative_forks": 59
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "cumulative_forks": 56
+      "cumulative_forks": 72
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-06-01",
-      "cumulative_forks": 66
+      "cumulative_forks": 83
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-07-01",
-      "cumulative_forks": 69
+      "cumulative_forks": 86
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-08-01",
-      "cumulative_forks": 76
+      "cumulative_forks": 96
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-09-01",
-      "cumulative_forks": 80
+      "cumulative_forks": 103
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-10-01",
-      "cumulative_forks": 87
+      "cumulative_forks": 111
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-11-01",
-      "cumulative_forks": 91
+      "cumulative_forks": 116
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-12-01",
-      "cumulative_forks": 140
+      "cumulative_forks": 179
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-01-01",
-      "cumulative_forks": 194
+      "cumulative_forks": 242
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "cumulative_forks": 202
+      "cumulative_forks": 250
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "cumulative_forks": 225
+      "cumulative_forks": 282
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "cumulative_forks": 233
+      "cumulative_forks": 297
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-05-01",
-      "cumulative_forks": 395
+      "cumulative_forks": 469
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "cumulative_forks": 428
+      "cumulative_forks": 521
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "cumulative_forks": 535
+      "cumulative_forks": 662
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-08-01",
-      "cumulative_forks": 648
+      "cumulative_forks": 812
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-09-01",
-      "cumulative_forks": 920
+      "cumulative_forks": 1141
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-10-01",
-      "cumulative_forks": 1005
+      "cumulative_forks": 1243
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-11-01",
-      "cumulative_forks": 1034
+      "cumulative_forks": 1277
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-12-01",
-      "cumulative_forks": 1061
+      "cumulative_forks": 1329
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "cumulative_forks": 1108
+      "cumulative_forks": 1407
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "cumulative_forks": 1138
+      "cumulative_forks": 1450
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -6220,107 +6220,107 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-06-01",
-      "cumulative_forks": 92
+      "cumulative_forks": 94
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "cumulative_forks": 139
+      "cumulative_forks": 141
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "cumulative_forks": 180
+      "cumulative_forks": 186
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "cumulative_forks": 223
+      "cumulative_forks": 233
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "cumulative_forks": 249
+      "cumulative_forks": 262
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "cumulative_forks": 270
+      "cumulative_forks": 286
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "cumulative_forks": 318
+      "cumulative_forks": 341
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "cumulative_forks": 389
+      "cumulative_forks": 417
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "cumulative_forks": 445
+      "cumulative_forks": 481
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "cumulative_forks": 500
+      "cumulative_forks": 553
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "cumulative_forks": 560
+      "cumulative_forks": 618
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "cumulative_forks": 680
+      "cumulative_forks": 779
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "cumulative_forks": 741
+      "cumulative_forks": 850
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "cumulative_forks": 852
+      "cumulative_forks": 975
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "cumulative_forks": 941
+      "cumulative_forks": 1081
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "cumulative_forks": 1020
+      "cumulative_forks": 1180
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "cumulative_forks": 1076
+      "cumulative_forks": 1249
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "cumulative_forks": 1139
+      "cumulative_forks": 1324
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "cumulative_forks": 1217
+      "cumulative_forks": 1417
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "cumulative_forks": 1317
+      "cumulative_forks": 1530
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "cumulative_forks": 1390
+      "cumulative_forks": 1622
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -6440,7 +6440,7 @@
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2026-02-01",
-      "cumulative_forks": 931
+      "cumulative_forks": 932
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
@@ -6640,7 +6640,7 @@
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2026-02-01",
-      "cumulative_forks": 2004
+      "cumulative_forks": 2005
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
@@ -6765,122 +6765,122 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "cumulative_forks": 292
+      "cumulative_forks": 312
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-04-01",
-      "cumulative_forks": 311
+      "cumulative_forks": 333
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-05-01",
-      "cumulative_forks": 322
+      "cumulative_forks": 344
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-06-01",
-      "cumulative_forks": 337
+      "cumulative_forks": 360
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-07-01",
-      "cumulative_forks": 351
+      "cumulative_forks": 374
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-08-01",
-      "cumulative_forks": 371
+      "cumulative_forks": 395
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-09-01",
-      "cumulative_forks": 390
+      "cumulative_forks": 414
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "cumulative_forks": 405
+      "cumulative_forks": 430
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "cumulative_forks": 421
+      "cumulative_forks": 448
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "cumulative_forks": 435
+      "cumulative_forks": 462
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-01-01",
-      "cumulative_forks": 452
+      "cumulative_forks": 480
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-02-01",
-      "cumulative_forks": 472
+      "cumulative_forks": 501
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "cumulative_forks": 498
+      "cumulative_forks": 527
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "cumulative_forks": 525
+      "cumulative_forks": 557
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "cumulative_forks": 541
+      "cumulative_forks": 576
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "cumulative_forks": 568
+      "cumulative_forks": 605
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "cumulative_forks": 589
+      "cumulative_forks": 632
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "cumulative_forks": 606
+      "cumulative_forks": 651
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "cumulative_forks": 645
+      "cumulative_forks": 696
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "cumulative_forks": 677
+      "cumulative_forks": 730
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "cumulative_forks": 704
+      "cumulative_forks": 761
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "cumulative_forks": 733
+      "cumulative_forks": 794
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "cumulative_forks": 771
+      "cumulative_forks": 837
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "cumulative_forks": 808
+      "cumulative_forks": 876
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -7005,117 +7005,117 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-03-01",
-      "cumulative_forks": 319
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-04-01",
       "cumulative_forks": 333
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-04-01",
+      "cumulative_forks": 349
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "cumulative_forks": 346
+      "cumulative_forks": 363
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "cumulative_forks": 351
+      "cumulative_forks": 369
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-07-01",
-      "cumulative_forks": 356
+      "cumulative_forks": 374
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-08-01",
-      "cumulative_forks": 360
+      "cumulative_forks": 378
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-09-01",
-      "cumulative_forks": 362
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-10-01",
-      "cumulative_forks": 368
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-11-01",
-      "cumulative_forks": 370
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-12-01",
-      "cumulative_forks": 373
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-01-01",
       "cumulative_forks": 380
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-02-01",
+      "month": "2024-10-01",
       "cumulative_forks": 386
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-03-01",
+      "month": "2024-11-01",
       "cumulative_forks": 388
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-04-01",
-      "cumulative_forks": 390
+      "month": "2024-12-01",
+      "cumulative_forks": 391
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-05-01",
-      "cumulative_forks": 392
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-06-01",
-      "cumulative_forks": 395
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-07-01",
-      "cumulative_forks": 399
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-08-01",
+      "month": "2025-01-01",
       "cumulative_forks": 400
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-02-01",
+      "cumulative_forks": 406
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-03-01",
+      "cumulative_forks": 409
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-04-01",
+      "cumulative_forks": 411
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-05-01",
+      "cumulative_forks": 413
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-06-01",
+      "cumulative_forks": 418
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-07-01",
+      "cumulative_forks": 422
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-08-01",
+      "cumulative_forks": 423
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-09-01",
-      "cumulative_forks": 401
+      "cumulative_forks": 425
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-11-01",
-      "cumulative_forks": 402
+      "cumulative_forks": 426
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-12-01",
-      "cumulative_forks": 403
+      "cumulative_forks": 427
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-01-01",
-      "cumulative_forks": 404
+      "cumulative_forks": 429
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-02-01",
-      "cumulative_forks": 406
+      "cumulative_forks": 431
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -7240,112 +7240,112 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "cumulative_forks": 57
+      "cumulative_forks": 59
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "cumulative_forks": 98
+      "cumulative_forks": 100
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "cumulative_forks": 132
+      "cumulative_forks": 135
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-08-01",
-      "cumulative_forks": 163
+      "cumulative_forks": 170
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "cumulative_forks": 494
+      "cumulative_forks": 529
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "cumulative_forks": 880
+      "cumulative_forks": 958
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "cumulative_forks": 1039
+      "cumulative_forks": 1133
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "cumulative_forks": 1143
+      "cumulative_forks": 1245
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "cumulative_forks": 1842
+      "cumulative_forks": 2013
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "cumulative_forks": 2198
+      "cumulative_forks": 2409
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "cumulative_forks": 2557
+      "cumulative_forks": 2802
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "cumulative_forks": 3173
+      "cumulative_forks": 3468
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "cumulative_forks": 3532
+      "cumulative_forks": 3854
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "cumulative_forks": 3780
+      "cumulative_forks": 4129
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "cumulative_forks": 4106
+      "cumulative_forks": 4490
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "cumulative_forks": 4364
+      "cumulative_forks": 4783
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "cumulative_forks": 4562
+      "cumulative_forks": 5012
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "cumulative_forks": 4688
+      "cumulative_forks": 5159
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "cumulative_forks": 4840
+      "cumulative_forks": 5327
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "cumulative_forks": 5002
+      "cumulative_forks": 5500
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "cumulative_forks": 5192
+      "cumulative_forks": 5710
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "cumulative_forks": 5410
+      "cumulative_forks": 5954
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -7505,112 +7505,117 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "cumulative_forks": 54
+      "cumulative_forks": 55
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "cumulative_forks": 101
+      "cumulative_forks": 104
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-06-01",
-      "cumulative_forks": 107
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-07-01",
       "cumulative_forks": 110
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-07-01",
+      "cumulative_forks": 113
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-08-01",
-      "cumulative_forks": 112
+      "cumulative_forks": 115
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-09-01",
+      "cumulative_forks": 116
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-10-01",
-      "cumulative_forks": 126
+      "cumulative_forks": 131
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "cumulative_forks": 136
+      "cumulative_forks": 143
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-12-01",
-      "cumulative_forks": 140
+      "cumulative_forks": 147
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-01-01",
-      "cumulative_forks": 145
+      "cumulative_forks": 153
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "cumulative_forks": 152
+      "cumulative_forks": 161
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "cumulative_forks": 163
+      "cumulative_forks": 175
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "cumulative_forks": 182
+      "cumulative_forks": 194
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "cumulative_forks": 190
+      "cumulative_forks": 203
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "cumulative_forks": 197
+      "cumulative_forks": 214
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "cumulative_forks": 208
+      "cumulative_forks": 226
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "cumulative_forks": 229
+      "cumulative_forks": 250
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "cumulative_forks": 240
+      "cumulative_forks": 264
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "cumulative_forks": 254
+      "cumulative_forks": 282
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "cumulative_forks": 268
+      "cumulative_forks": 300
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "cumulative_forks": 286
+      "cumulative_forks": 323
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "cumulative_forks": 303
+      "cumulative_forks": 349
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "cumulative_forks": 316
+      "cumulative_forks": 364
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/github_ecosystem_breadth.json
+++ b/frontend/public/data/agentic-ai-momentum/github_ecosystem_breadth.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:30:23.267270",
+    "fetched_at": "2026-04-01T07:16:20.107574",
     "schema": {
       "name": "github_ecosystem_breadth",
       "description": "Monthly snapshot of GitHub repository, issue, and discussion counts per search term.",
@@ -41,45 +41,45 @@
   "data": [
     {
       "search_term": "autonomous_agents",
-      "month": "2026-03-01",
-      "repo_count": 23159,
-      "issue_count": 81918,
-      "discussion_count": 2424
+      "month": "2026-04-01",
+      "repo_count": 24244,
+      "issue_count": 85120,
+      "discussion_count": 2547
     },
     {
       "search_term": "multi_agent_systems",
-      "month": "2026-03-01",
-      "repo_count": 21399,
-      "issue_count": 43539,
-      "discussion_count": 1999
+      "month": "2026-04-01",
+      "repo_count": 22142,
+      "issue_count": 45059,
+      "discussion_count": 2101
     },
     {
       "search_term": "llm_tool_use",
-      "month": "2026-03-01",
-      "repo_count": 6448,
-      "issue_count": 100426,
-      "discussion_count": 8652
+      "month": "2026-04-01",
+      "repo_count": 6572,
+      "issue_count": 104999,
+      "discussion_count": 8830
     },
     {
       "search_term": "agent_memory_planning",
-      "month": "2026-03-01",
-      "repo_count": 407,
-      "issue_count": 19940,
-      "discussion_count": 909
+      "month": "2026-04-01",
+      "repo_count": 418,
+      "issue_count": 20735,
+      "discussion_count": 943
     },
     {
       "search_term": "agent_safety_alignment",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "repo_count": 42,
-      "issue_count": 8028,
-      "discussion_count": 287
+      "issue_count": 8176,
+      "discussion_count": 299
     },
     {
       "search_term": "agentic_rag",
-      "month": "2026-03-01",
-      "repo_count": 20359,
-      "issue_count": 5679,
-      "discussion_count": 433
+      "month": "2026-04-01",
+      "repo_count": 21038,
+      "issue_count": 5902,
+      "discussion_count": 439
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/github_releases_count.json
+++ b/frontend/public/data/agentic-ai-momentum/github_releases_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:30:18.373850",
+    "fetched_at": "2026-04-01T07:16:13.283238",
     "schema": {
       "name": "github_releases_count",
       "description": "Cumulative monthly release counts for tracked repositories.",
@@ -5351,76 +5351,6 @@
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
       "cumulative_release_count": 64
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-03-01",
-      "cumulative_release_count": 3
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-04-01",
-      "cumulative_release_count": 4
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-05-01",
-      "cumulative_release_count": 5
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-06-01",
-      "cumulative_release_count": 6
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-08-01",
-      "cumulative_release_count": 7
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-11-01",
-      "cumulative_release_count": 8
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-12-01",
-      "cumulative_release_count": 9
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-02-01",
-      "cumulative_release_count": 10
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-03-01",
-      "cumulative_release_count": 12
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-04-01",
-      "cumulative_release_count": 13
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-05-01",
-      "cumulative_release_count": 14
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-09-01",
-      "cumulative_release_count": 15
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-12-01",
-      "cumulative_release_count": 16
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-02-01",
-      "cumulative_release_count": 17
     },
     {
       "repo": "https://github.com/NVIDIA/garak",

--- a/frontend/public/data/agentic-ai-momentum/issue_share_no_response_30d.json
+++ b/frontend/public/data/agentic-ai-momentum/issue_share_no_response_30d.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T11:21:37.040484",
+    "fetched_at": "2026-04-01T07:13:58.027800",
     "schema": {
       "name": "issue_share_no_response_30d",
       "description": "3-month trailing average of the monthly share of issues with no response within 30 days per repo.",
@@ -150,122 +150,122 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.42857142857142855
+      "issues_no_response_pct_30d": 0.375
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.5
+      "issues_no_response_pct_30d": 0.4375
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.6666666666666666
+      "issues_no_response_pct_30d": 0.5138888888888888
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.6571428571428571
+      "issues_no_response_pct_30d": 0.5
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.6888888888888888
+      "issues_no_response_pct_30d": 0.5333333333333333
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.35555555555555557
+      "issues_no_response_pct_30d": 0.3111111111111111
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.35185185185185186
+      "issues_no_response_pct_30d": 0.30526315789473685
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.266884531590414
+      "issues_no_response_pct_30d": 0.2719298245614035
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.4097416744475568
+      "issues_no_response_pct_30d": 0.4147869674185463
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.5023342670401494
+      "issues_no_response_pct_30d": 0.5317460317460317
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.6428571428571429
+      "issues_no_response_pct_30d": 0.5132275132275131
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.5666666666666667
+      "issues_no_response_pct_30d": 0.43703703703703706
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.4238095238095238
+      "issues_no_response_pct_30d": 0.28425925925925927
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.14603174603174604
+      "issues_no_response_pct_30d": 0.17314814814814816
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.07936507936507936
+      "issues_no_response_pct_30d": 0.10648148148148147
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.13333333333333333
+      "issues_no_response_pct_30d": 0.15468409586056645
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.21666666666666667
+      "issues_no_response_pct_30d": 0.1843137254901961
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.3833333333333333
+      "issues_no_response_pct_30d": 0.3509803921568628
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.5833333333333334
+      "issues_no_response_pct_30d": 0.5666666666666667
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.611111111111111
+      "issues_no_response_pct_30d": 0.5833333333333334
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.4444444444444444
+      "issues_no_response_pct_30d": 0.5277777777777778
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.2111111111111111
+      "issues_no_response_pct_30d": 0.255050505050505
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.09999999999999999
+      "issues_no_response_pct_30d": 0.2828282828282828
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.35000000000000003
+      "issues_no_response_pct_30d": 0.4217171717171717
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -385,7 +385,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.5215506125080593
+      "issues_no_response_pct_30d": 0.5203450886899674
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -415,92 +415,92 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.2840909090909091
+      "issues_no_response_pct_30d": 0.268939393939394
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.4646464646464646
+      "issues_no_response_pct_30d": 0.4881422924901186
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.5945165945165946
+      "issues_no_response_pct_30d": 0.6180124223602484
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.6178266178266179
+      "issues_no_response_pct_30d": 0.656473960821787
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.6369837059492233
+      "issues_no_response_pct_30d": 0.64004884004884
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.7368300961181941
+      "issues_no_response_pct_30d": 0.7308226495726496
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.736002966258806
+      "issues_no_response_pct_30d": 0.7277146464646465
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.6876061120543294
+      "issues_no_response_pct_30d": 0.6802398989898991
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.7306168647425014
+      "issues_no_response_pct_30d": 0.7323232323232324
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.7644110275689223
+      "issues_no_response_pct_30d": 0.7683982683982684
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.6498599439775911
+      "issues_no_response_pct_30d": 0.6455026455026455
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.411764705882353
+      "issues_no_response_pct_30d": 0.3955026455026455
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.18601514679946052
+      "issues_no_response_pct_30d": 0.1697530864197531
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.2423355473000863
+      "issues_no_response_pct_30d": 0.2223456790123457
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.17273847770301667
+      "issues_no_response_pct_30d": 0.16123456790123455
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.33817057646844884
+      "issues_no_response_pct_30d": 0.3057516339869281
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.22564102564102564
+      "issues_no_response_pct_30d": 0.19760348583877996
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.2888888888888889
+      "issues_no_response_pct_30d": 0.24204793028322438
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -710,27 +710,32 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.2
+      "issues_no_response_pct_30d": 0.15384615384615385
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.26666666666666666
+      "issues_no_response_pct_30d": 0.21978021978021978
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.5111111111111111
+      "issues_no_response_pct_30d": 0.36874236874236876
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.4444444444444444
+      "issues_no_response_pct_30d": 0.31746031746031744
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-11-01",
+      "issues_no_response_pct_30d": 0.2222222222222222
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.5555555555555555
+      "issues_no_response_pct_30d": 0.2222222222222222
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -740,17 +745,17 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.6388888888888888
+      "issues_no_response_pct_30d": 0.611111111111111
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.6666666666666666
+      "issues_no_response_pct_30d": 0.6388888888888888
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.75
+      "issues_no_response_pct_30d": 0.7222222222222222
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -770,122 +775,122 @@
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.07303370786516854
+      "issues_no_response_pct_30d": 0.06341463414634146
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.07053045937476114
+      "issues_no_response_pct_30d": 0.06427436688159985
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.10519640687877158
+      "issues_no_response_pct_30d": 0.09571301404441458
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.14495440169294618
+      "issues_no_response_pct_30d": 0.12733259642728878
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.1815379239907542
+      "issues_no_response_pct_30d": 0.15423234099944713
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.22498783962198599
+      "issues_no_response_pct_30d": 0.18182867499104163
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.25778450032562344
+      "issues_no_response_pct_30d": 0.21425606641123882
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.3281548706959938
+      "issues_no_response_pct_30d": 0.2767560664112388
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.3480241815386349
+      "issues_no_response_pct_30d": 0.30343915343915345
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.34662045222792887
+      "issues_no_response_pct_30d": 0.3003052503052503
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.3259017136874081
+      "issues_no_response_pct_30d": 0.28010323010323007
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.34824200302296054
+      "issues_no_response_pct_30d": 0.27971418559653854
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.37993948998360544
+      "issues_no_response_pct_30d": 0.3073675448954674
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.3619376898035875
+      "issues_no_response_pct_30d": 0.29850973603765857
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.3314354066985646
+      "issues_no_response_pct_30d": 0.28118681771043613
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.3453988868274583
+      "issues_no_response_pct_30d": 0.30740450645731254
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.3941956782713085
+      "issues_no_response_pct_30d": 0.3503532244060305
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.37912824089173247
+      "issues_no_response_pct_30d": 0.35381850496047534
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.4087034856237716
+      "issues_no_response_pct_30d": 0.37698708395429703
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.4581867924600196
+      "issues_no_response_pct_30d": 0.43574776771498086
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.526587563172929
+      "issues_no_response_pct_30d": 0.49099974099974103
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.5157198014340871
+      "issues_no_response_pct_30d": 0.487024343459987
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.4536492563126946
+      "issues_no_response_pct_30d": 0.4365969930326366
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.46880077146420973
+      "issues_no_response_pct_30d": 0.45283240652832407
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1010,122 +1015,122 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.29411764705882354
+      "issues_no_response_pct_30d": 0.2631578947368421
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.38618925831202044
+      "issues_no_response_pct_30d": 0.2982456140350877
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.3500520981339396
+      "issues_no_response_pct_30d": 0.26900584795321636
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.35457698501176765
+      "issues_no_response_pct_30d": 0.27017543859649124
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.22690272690272692
+      "issues_no_response_pct_30d": 0.20073099415204676
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.24542124542124544
+      "issues_no_response_pct_30d": 0.24166666666666667
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.25396825396825395
+      "issues_no_response_pct_30d": 0.2638888888888889
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.3131313131313131
+      "issues_no_response_pct_30d": 0.29914529914529914
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.23710792131844763
+      "issues_no_response_pct_30d": 0.23151244890375325
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.1498063340168603
+      "issues_no_response_pct_30d": 0.14123467112597546
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.20175438596491227
+      "issues_no_response_pct_30d": 0.2124597423510467
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.27777777777777773
+      "issues_no_response_pct_30d": 0.28009259259259256
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.37896825396825395
+      "issues_no_response_pct_30d": 0.4021164021164021
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.3145424836601307
+      "issues_no_response_pct_30d": 0.33239962651727356
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.23120915032679737
+      "issues_no_response_pct_30d": 0.2725705666882137
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.17287581699346408
+      "issues_no_response_pct_30d": 0.18526897938662645
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.28194444444444444
+      "issues_no_response_pct_30d": 0.2822762033288349
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.3875
+      "issues_no_response_pct_30d": 0.38250930356193513
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.4398809523809524
+      "issues_no_response_pct_30d": 0.4602870813397129
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.4857142857142857
+      "issues_no_response_pct_30d": 0.5272727272727272
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.4476190476190476
+      "issues_no_response_pct_30d": 0.5007575757575758
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.49523809523809526
+      "issues_no_response_pct_30d": 0.5340909090909091
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.5476190476190476
+      "issues_no_response_pct_30d": 0.5416666666666666
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.6746031746031745
+      "issues_no_response_pct_30d": 0.6388888888888888
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -1380,7 +1385,7 @@
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.8085618085618086
+      "issues_no_response_pct_30d": 0.8032708032708032
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
@@ -1595,87 +1600,87 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.29780720888180773
+      "issues_no_response_pct_30d": 0.2932095077323824
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.17391304347826086
+      "issues_no_response_pct_30d": 0.15384615384615385
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.20695652173913043
+      "issues_no_response_pct_30d": 0.21978021978021978
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.20591156650973877
+      "issues_no_response_pct_30d": 0.2092652445593622
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.2359035149799481
+      "issues_no_response_pct_30d": 0.23677107206518969
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.24137360045003356
+      "issues_no_response_pct_30d": 0.22311805841217605
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.260975135975136
+      "issues_no_response_pct_30d": 0.23221204083273048
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.23253598253598254
+      "issues_no_response_pct_30d": 0.2118183226287933
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.23243175072443367
+      "issues_no_response_pct_30d": 0.21356657437704504
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.21399535423925667
+      "issues_no_response_pct_30d": 0.20570055789033892
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.21983102183963013
+      "issues_no_response_pct_30d": 0.19815385493351592
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.22911537394241044
+      "issues_no_response_pct_30d": 0.19732877242526511
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.27765674170902926
+      "issues_no_response_pct_30d": 0.23653031162680435
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.3272397933204785
+      "issues_no_response_pct_30d": 0.2773495206663524
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.4135419685115425
+      "issues_no_response_pct_30d": 0.3853174603174603
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.41256157635467977
+      "issues_no_response_pct_30d": 0.37103174603174605
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.44206349206349205
+      "issues_no_response_pct_30d": 0.41757646147890054
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1685,117 +1690,117 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.6550802139037433
+      "issues_no_response_pct_30d": 0.6338383838383839
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.6811645870469399
+      "issues_no_response_pct_30d": 0.6558922558922559
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.6979279655124461
+      "issues_no_response_pct_30d": 0.6685185185185185
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.6248441865463142
+      "issues_no_response_pct_30d": 0.6050827423167848
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.6174367791389068
+      "issues_no_response_pct_30d": 0.6087864460204886
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.6280055456526045
+      "issues_no_response_pct_30d": 0.6234923283734298
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.699520697167756
+      "issues_no_response_pct_30d": 0.6946722123192712
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.7211043497858913
+      "issues_no_response_pct_30d": 0.7144657763751302
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.7459965761799952
+      "issues_no_response_pct_30d": 0.7414265606888558
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.6420885302029836
+      "issues_no_response_pct_30d": 0.6459471766848816
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.5846172658351675
+      "issues_no_response_pct_30d": 0.5901747766501865
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.47431208638105193
+      "issues_no_response_pct_30d": 0.47211922109463095
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.4522276229947675
+      "issues_no_response_pct_30d": 0.44097755589691073
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.3648993359187933
+      "issues_no_response_pct_30d": 0.35486188357434184
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.3787280997475571
+      "issues_no_response_pct_30d": 0.36811945933191764
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.3648624530824842
+      "issues_no_response_pct_30d": 0.3488197626128661
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.3828242606075362
+      "issues_no_response_pct_30d": 0.3523957523957524
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.37859145637473196
+      "issues_no_response_pct_30d": 0.3201817201817202
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.43654485049833885
+      "issues_no_response_pct_30d": 0.325950950950951
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.49523809523809526
+      "issues_no_response_pct_30d": 0.35028957528957533
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.5285714285714286
+      "issues_no_response_pct_30d": 0.40908521303258144
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.4904761904761905
+      "issues_no_response_pct_30d": 0.4311866623079437
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.54
+      "issues_no_response_pct_30d": 0.4678166989379804
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -2040,207 +2045,207 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.3972222222222222
+      "issues_no_response_pct_30d": 0.4276315789473684
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.16038011695906432
+      "issues_no_response_pct_30d": 0.18596491228070175
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.1766844647851513
+      "issues_no_response_pct_30d": 0.19368096166341778
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.2004392540571819
+      "issues_no_response_pct_30d": 0.19006899055918666
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.15728135932033982
+      "issues_no_response_pct_30d": 0.15587358826033607
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.12256615878107457
+      "issues_no_response_pct_30d": 0.12067526937407391
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.09881136950904394
+      "issues_no_response_pct_30d": 0.08117947105474618
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.10749354005167959
+      "issues_no_response_pct_30d": 0.07599578838627649
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.10133174319220832
+      "issues_no_response_pct_30d": 0.08453866395042865
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.13244285430331942
+      "issues_no_response_pct_30d": 0.10834818775995247
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.11804639804639805
+      "issues_no_response_pct_30d": 0.12623604465709728
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.19851335656213706
+      "issues_no_response_pct_30d": 0.17017543859649123
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.2527069049492338
+      "issues_no_response_pct_30d": 0.2075491759702286
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.28445293669526556
+      "issues_no_response_pct_30d": 0.20147630147630147
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.2841141833077317
+      "issues_no_response_pct_30d": 0.18689296814296816
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.2270923520923521
+      "issues_no_response_pct_30d": 0.13470441595441596
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.3143939393939394
+      "issues_no_response_pct_30d": 0.1693672839506173
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.1875
+      "issues_no_response_pct_30d": 0.16666666666666666
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.18198529411764708
+      "issues_no_response_pct_30d": 0.1715686274509804
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.26947167755991286
+      "issues_no_response_pct_30d": 0.2547299621603027
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.34586056644880175
+      "issues_no_response_pct_30d": 0.35302056045090097
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.3476430976430976
+      "issues_no_response_pct_30d": 0.3418160786581839
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.2920875420875421
+      "issues_no_response_pct_30d": 0.2772227772227772
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.2531986531986532
+      "issues_no_response_pct_30d": 0.21428571428571427
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.29865319865319867
+      "issues_no_response_pct_30d": 0.24666666666666667
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.23636363636363636
+      "issues_no_response_pct_30d": 0.19313131313131313
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.2196969696969697
+      "issues_no_response_pct_30d": 0.18555555555555556
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.13585858585858587
+      "issues_no_response_pct_30d": 0.14477124183006537
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.19646464646464645
+      "issues_no_response_pct_30d": 0.2058823529411765
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.21313131313131314
+      "issues_no_response_pct_30d": 0.2558823529411765
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.24646464646464647
+      "issues_no_response_pct_30d": 0.2537037037037037
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.17407407407407405
+      "issues_no_response_pct_30d": 0.20067340067340067
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.19907407407407407
+      "issues_no_response_pct_30d": 0.16257816257816257
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.19113756613756613
+      "issues_no_response_pct_30d": 0.1600238841618152
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.1726190476190476
+      "issues_no_response_pct_30d": 0.14638752052545156
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.10317460317460318
+      "issues_no_response_pct_30d": 0.08623714458560194
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.10763888888888888
+      "issues_no_response_pct_30d": 0.09342105263157895
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.17906746031746032
+      "issues_no_response_pct_30d": 0.1347254004576659
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.17113095238095236
+      "issues_no_response_pct_30d": 0.12527870680044592
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.24404761904761904
+      "issues_no_response_pct_30d": 0.13916759568933482
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.29383116883116883
+      "issues_no_response_pct_30d": 0.22008547008547008
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2360,7 +2365,7 @@
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.033474187713953794
+      "issues_no_response_pct_30d": 0.03344406856895706
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
@@ -2485,117 +2490,117 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.3114754098360656
+      "issues_no_response_pct_30d": 0.28
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.30279652844744454
+      "issues_no_response_pct_30d": 0.2870588235294118
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.3645627649967091
+      "issues_no_response_pct_30d": 0.3521568627450981
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.36490429505135386
+      "issues_no_response_pct_30d": 0.35406162464985996
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.3721282372598162
+      "issues_no_response_pct_30d": 0.35602240896358545
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.3564886480908152
+      "issues_no_response_pct_30d": 0.33533471359558314
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.4438113431262763
+      "issues_no_response_pct_30d": 0.4305728088336784
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.5315306413718903
+      "issues_no_response_pct_30d": 0.5147833351494678
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.4365551511758119
+      "issues_no_response_pct_30d": 0.4237063246351172
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.34762989203778677
+      "issues_no_response_pct_30d": 0.3136899042738693
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.23798076923076925
+      "issues_no_response_pct_30d": 0.26281271129141315
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.3525641025641026
+      "issues_no_response_pct_30d": 0.38045977011494253
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.3333333333333333
+      "issues_no_response_pct_30d": 0.3833333333333333
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.36999999999999994
+      "issues_no_response_pct_30d": 0.44148936170212766
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.2922222222222222
+      "issues_no_response_pct_30d": 0.3951930654058314
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.4380555555555556
+      "issues_no_response_pct_30d": 0.5618597320724981
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.49349415204678365
+      "issues_no_response_pct_30d": 0.544973544973545
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.6665100250626567
+      "issues_no_response_pct_30d": 0.6810134310134309
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.6931573118843621
+      "issues_no_response_pct_30d": 0.6769150703576933
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.7047105853118332
+      "issues_no_response_pct_30d": 0.7144331078757308
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.5761391567404046
+      "issues_no_response_pct_30d": 0.5913561847988077
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.5069918699186992
+      "issues_no_response_pct_30d": 0.5505827505827506
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.57
+      "issues_no_response_pct_30d": 0.5765567765567766
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2655,17 +2660,17 @@
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.4896520215701299
+      "issues_no_response_pct_30d": 0.49264867237217463
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.48072957819332823
+      "issues_no_response_pct_30d": 0.48372622899537304
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.4385154322609827
+      "issues_no_response_pct_30d": 0.44151208306302747
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2750,17 +2755,17 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.0
-    },
-    {
-      "repo": "https://github.com/e2b-dev/code-interpreter",
-      "month": "2024-11-01",
       "issues_no_response_pct_30d": 0.16666666666666666
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2024-11-01",
+      "issues_no_response_pct_30d": 0.3333333333333333
+    },
+    {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.5
+      "issues_no_response_pct_30d": 0.6666666666666666
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2785,17 +2790,17 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.05555555555555555
+      "issues_no_response_pct_30d": 0.2222222222222222
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.16666666666666666
+      "issues_no_response_pct_30d": 0.3333333333333333
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.1111111111111111
+      "issues_no_response_pct_30d": 0.27777777777777773
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2815,187 +2820,187 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.3611111111111111
+      "issues_no_response_pct_30d": 0.3055555555555555
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.5833333333333334
+      "issues_no_response_pct_30d": 0.5277777777777778
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.19213973799126638
+      "issues_no_response_pct_30d": 0.12781954887218044
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.18779648770066915
+      "issues_no_response_pct_30d": 0.13815219867851447
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.24640977967923397
+      "issues_no_response_pct_30d": 0.19518044838273121
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.30873682672243824
+      "issues_no_response_pct_30d": 0.27075575027382254
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.41770069011448324
+      "issues_no_response_pct_30d": 0.3694089489270212
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.4914038231396501
+      "issues_no_response_pct_30d": 0.43866556723699585
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.45746717155593974
+      "issues_no_response_pct_30d": 0.38108980966123823
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.4335510594365608
+      "issues_no_response_pct_30d": 0.2911177621420209
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.3954985502973119
+      "issues_no_response_pct_30d": 0.19337423582706603
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.4098576920122503
+      "issues_no_response_pct_30d": 0.1789968856832925
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.39627534905809075
+      "issues_no_response_pct_30d": 0.1665197097855445
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.2
+      "issues_no_response_pct_30d": 0.17391304347826086
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.25
+      "issues_no_response_pct_30d": 0.18695652173913044
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.3735632183908046
+      "issues_no_response_pct_30d": 0.3315342328835582
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.44578544061302683
+      "issues_no_response_pct_30d": 0.4068965517241379
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.42421681316204646
+      "issues_no_response_pct_30d": 0.4104053236539625
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.272875816993464
+      "issues_no_response_pct_30d": 0.25479082321187585
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.276844070961718
+      "issues_no_response_pct_30d": 0.26729082321187586
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.28174603174603174
+      "issues_no_response_pct_30d": 0.2711894586894587
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.30952380952380953
+      "issues_no_response_pct_30d": 0.2532407407407407
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.19047619047619047
+      "issues_no_response_pct_30d": 0.12962962962962962
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.3071428571428571
+      "issues_no_response_pct_30d": 0.18055555555555555
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.36666666666666664
+      "issues_no_response_pct_30d": 0.3138888888888889
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.5650793650793651
+      "issues_no_response_pct_30d": 0.4583333333333333
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.36507936507936506
+      "issues_no_response_pct_30d": 0.3333333333333333
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.2222222222222222
+      "issues_no_response_pct_30d": 0.16666666666666666
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.047619047619047616
+      "issues_no_response_pct_30d": 0.08333333333333333
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.1865079365079365
+      "issues_no_response_pct_30d": 0.22916666666666666
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.2976190476190476
+      "issues_no_response_pct_30d": 0.34027777777777773
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.25
+      "issues_no_response_pct_30d": 0.2569444444444444
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.34920634920634924
+      "issues_no_response_pct_30d": 0.2962962962962963
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.34920634920634924
+      "issues_no_response_pct_30d": 0.2962962962962963
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.4603174603174603
+      "issues_no_response_pct_30d": 0.39153439153439157
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.2888888888888889
+      "issues_no_response_pct_30d": 0.273015873015873
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.17777777777777778
+      "issues_no_response_pct_30d": 0.1619047619047619
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -3070,7 +3075,7 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.4777777777777778
+      "issues_no_response_pct_30d": 0.4444444444444444
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3125,17 +3130,17 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.1315223725039676
+      "issues_no_response_pct_30d": 0.131806992098932
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.1558850330368409
+      "issues_no_response_pct_30d": 0.15616965263180532
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.1437662020053803
+      "issues_no_response_pct_30d": 0.14405082160034471
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3310,7 +3315,7 @@
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.17056147149932577
+      "issues_no_response_pct_30d": 0.1700453424670677
     },
     {
       "repo": "https://github.com/janhq/jan",
@@ -3434,38 +3439,53 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-03-01",
+      "issues_no_response_pct_30d": 0.5
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 1.0
+      "issues_no_response_pct_30d": 0.75
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.875
+      "issues_no_response_pct_30d": 0.6666666666666666
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-07-01",
+      "issues_no_response_pct_30d": 0.5
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-08-01",
+      "issues_no_response_pct_30d": 0.5
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.75
+      "issues_no_response_pct_30d": 0.5
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.75
+      "issues_no_response_pct_30d": 0.8333333333333334
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.7222222222222222
+      "issues_no_response_pct_30d": 0.75
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.5555555555555555
+      "issues_no_response_pct_30d": 0.5833333333333334
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.5555555555555555
+      "issues_no_response_pct_30d": 0.5833333333333334
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -3474,13 +3494,18 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2025-08-01",
+      "month": "2025-07-01",
       "issues_no_response_pct_30d": 0.5
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-08-01",
+      "issues_no_response_pct_30d": 0.16666666666666666
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.5
+      "issues_no_response_pct_30d": 0.3333333333333333
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -3965,7 +3990,7 @@
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.22520837101344426
+      "issues_no_response_pct_30d": 0.21833551877976728
     },
     {
       "repo": "https://github.com/letta-ai/letta",
@@ -4095,117 +4120,117 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.35
+      "issues_no_response_pct_30d": 0.3125
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.2611111111111111
+      "issues_no_response_pct_30d": 0.24404761904761904
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.1814009661835749
+      "issues_no_response_pct_30d": 0.16071428571428573
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.14806763285024155
+      "issues_no_response_pct_30d": 0.1457142857142857
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.18089591567852437
+      "issues_no_response_pct_30d": 0.17666666666666667
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.13560606060606062
+      "issues_no_response_pct_30d": 0.13837837837837838
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.19816313823163137
+      "issues_no_response_pct_30d": 0.20754504504504503
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.23385337392186703
+      "issues_no_response_pct_30d": 0.2317874692874693
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.3203918354603286
+      "issues_no_response_pct_30d": 0.32430856180856177
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.3034487929224771
+      "issues_no_response_pct_30d": 0.2979196729196729
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.2738191632928475
+      "issues_no_response_pct_30d": 0.2810846560846561
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.21228070175438596
+      "issues_no_response_pct_30d": 0.21108608608608606
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.19115646258503402
+      "issues_no_response_pct_30d": 0.20275275275275276
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.18056456227350756
+      "issues_no_response_pct_30d": 0.17457239848544195
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.18056456227350756
+      "issues_no_response_pct_30d": 0.16256038647342994
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.19025198154501358
+      "issues_no_response_pct_30d": 0.15587104406980182
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.2036216596343179
+      "issues_no_response_pct_30d": 0.17479213907785338
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.16398201999467824
+      "issues_no_response_pct_30d": 0.15184527917447171
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.11473631165411986
+      "issues_no_response_pct_30d": 0.1125750256185039
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.09467458325905814
+      "issues_no_response_pct_30d": 0.09486166007905139
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.12479041337488826
+      "issues_no_response_pct_30d": 0.10786699951459677
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.18123821687040076
+      "issues_no_response_pct_30d": 0.16197955362715089
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.28185550082101807
+      "issues_no_response_pct_30d": 0.24531288696048423
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4225,67 +4250,67 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.16952380952380952
+      "issues_no_response_pct_30d": 0.16900093370681604
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.077439293598234
+      "issues_no_response_pct_30d": 0.07592734063322298
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.15151336767230808
+      "issues_no_response_pct_30d": 0.14761192844684304
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.15262447878341917
+      "issues_no_response_pct_30d": 0.14874086486989713
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.23076529568242277
+      "issues_no_response_pct_30d": 0.22667470639069517
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.25354656752029836
+      "issues_no_response_pct_30d": 0.2477862113731679
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.336430058298526
+      "issues_no_response_pct_30d": 0.32855037474602694
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.3074232437863491
+      "issues_no_response_pct_30d": 0.30064983325852895
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.2920493793558809
+      "issues_no_response_pct_30d": 0.2834710244130534
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.25665692800417655
+      "issues_no_response_pct_30d": 0.21668274023346487
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.26786140979689366
+      "issues_no_response_pct_30d": 0.16086589041661506
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.29552447108827357
+      "issues_no_response_pct_30d": 0.0941885809232136
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.35938608866658117
+      "issues_no_response_pct_30d": 0.061070055758028846
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4295,72 +4320,72 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.14583333333333334
+      "issues_no_response_pct_30d": 0.15384615384615385
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.19722222222222222
+      "issues_no_response_pct_30d": 0.22377622377622378
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.4396464646464646
+      "issues_no_response_pct_30d": 0.47377622377622375
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.4184476342371079
+      "issues_no_response_pct_30d": 0.4557892356399819
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.4517809675704412
+      "issues_no_response_pct_30d": 0.46420674405749035
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.4593567251461988
+      "issues_no_response_pct_30d": 0.44754007739082363
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.5499999999999999
+      "issues_no_response_pct_30d": 0.5574074074074075
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.6388888888888888
+      "issues_no_response_pct_30d": 0.5611111111111111
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.5138888888888888
+      "issues_no_response_pct_30d": 0.41111111111111115
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.34722222222222215
+      "issues_no_response_pct_30d": 0.21666666666666667
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.39166666666666666
+      "issues_no_response_pct_30d": 0.2833333333333333
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.6
+      "issues_no_response_pct_30d": 0.45
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.9333333333333332
+      "issues_no_response_pct_30d": 0.6722222222222222
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.6666666666666666
+      "issues_no_response_pct_30d": 0.47222222222222215
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4370,47 +4395,47 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.022727272727272728
+      "issues_no_response_pct_30d": 0.038461538461538464
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.015151515151515152
+      "issues_no_response_pct_30d": 0.04524886877828055
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.015151515151515152
+      "issues_no_response_pct_30d": 0.04524886877828055
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.07407407407407407
+      "issues_no_response_pct_30d": 0.10294117647058824
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.07407407407407407
+      "issues_no_response_pct_30d": 0.08333333333333333
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.2074074074074074
+      "issues_no_response_pct_30d": 0.15
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.18095238095238098
+      "issues_no_response_pct_30d": 0.14074074074074075
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.18095238095238098
+      "issues_no_response_pct_30d": 0.14074074074074075
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.047619047619047616
+      "issues_no_response_pct_30d": 0.07407407407407407
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4444,13 +4469,18 @@
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-07-01",
+      "issues_no_response_pct_30d": 0.5
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.16666666666666666
+      "issues_no_response_pct_30d": 0.3333333333333333
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.0
+      "issues_no_response_pct_30d": 0.3333333333333333
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -4585,107 +4615,107 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.56
+      "issues_no_response_pct_30d": 0.6433333333333334
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.3732193732193732
+      "issues_no_response_pct_30d": 0.4547970479704797
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.10582010582010581
+      "issues_no_response_pct_30d": 0.19130498447841623
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.1940553999377529
+      "issues_no_response_pct_30d": 0.16723091040434213
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.3128995187818717
+      "issues_no_response_pct_30d": 0.2806156806156806
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.34098254686489976
+      "issues_no_response_pct_30d": 0.2941077441077441
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.31157078215901746
+      "issues_no_response_pct_30d": 0.31592956592956595
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.28327540603755436
+      "issues_no_response_pct_30d": 0.29261954261954265
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.25943375061695156
+      "issues_no_response_pct_30d": 0.301240232274715
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.29584831644328213
+      "issues_no_response_pct_30d": 0.30959004550257707
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.26797763639868905
+      "issues_no_response_pct_30d": 0.33927965413955413
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.4358974358974359
+      "issues_no_response_pct_30d": 0.4434040625235974
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.3962148962148962
+      "issues_no_response_pct_30d": 0.458139834881321
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.5158730158730159
+      "issues_no_response_pct_30d": 0.48206327985739755
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.4444444444444444
+      "issues_no_response_pct_30d": 0.45265151515151514
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.4444444444444444
+      "issues_no_response_pct_30d": 0.4484848484848485
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.27777777777777773
+      "issues_no_response_pct_30d": 0.30833333333333335
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.2222222222222222
+      "issues_no_response_pct_30d": 0.2845238095238095
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.27777777777777773
+      "issues_no_response_pct_30d": 0.3273809523809524
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.31746031746031744
+      "issues_no_response_pct_30d": 0.38095238095238093
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.20634920634920637
+      "issues_no_response_pct_30d": 0.23809523809523805
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -4810,122 +4840,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.375
+      "issues_no_response_pct_30d": 0.35802469135802467
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.43940839694656486
+      "issues_no_response_pct_30d": 0.418142780461621
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.4759990405873274
+      "issues_no_response_pct_30d": 0.4479160824968021
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.5762863969091665
+      "issues_no_response_pct_30d": 0.5496744064773483
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.6000141322781233
+      "issues_no_response_pct_30d": 0.578659913723725
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.556148162182645
+      "issues_no_response_pct_30d": 0.5583152086775275
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.484982669660089
+      "issues_no_response_pct_30d": 0.5025045771093202
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.49844420812162743
+      "issues_no_response_pct_30d": 0.5109491737086583
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.5299817762445614
+      "issues_no_response_pct_30d": 0.527553183733721
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.5265448439521276
+      "issues_no_response_pct_30d": 0.49976392753537385
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.48926533858751586
+      "issues_no_response_pct_30d": 0.46308669400774666
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.45232047934300507
+      "issues_no_response_pct_30d": 0.42696608946608944
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.4463974525980605
+      "issues_no_response_pct_30d": 0.4364746364746364
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.4201609532701969
+      "issues_no_response_pct_30d": 0.41754441415458365
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.45427533976553586
+      "issues_no_response_pct_30d": 0.44739126980789096
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.4337558592460553
+      "issues_no_response_pct_30d": 0.4206834746790431
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.37231243518163354
+      "issues_no_response_pct_30d": 0.3539086219323188
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.3168609998105194
+      "issues_no_response_pct_30d": 0.29893550365274885
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.31928524223476185
+      "issues_no_response_pct_30d": 0.29153797757950123
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.400406788444099
+      "issues_no_response_pct_30d": 0.37091604631927216
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.5012903225806452
+      "issues_no_response_pct_30d": 0.47105045492142267
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.6170478983382209
+      "issues_no_response_pct_30d": 0.5889164598842018
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.6352447552447552
+      "issues_no_response_pct_30d": 0.6017369727047147
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.5806415806415807
+      "issues_no_response_pct_30d": 0.5444947209653092
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -5050,27 +5080,27 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.5
+      "issues_no_response_pct_30d": 0.45454545454545453
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.5833333333333333
+      "issues_no_response_pct_30d": 0.5606060606060606
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.48412698412698413
+      "issues_no_response_pct_30d": 0.4987373737373737
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.5396825396825397
+      "issues_no_response_pct_30d": 0.5694444444444444
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.36507936507936506
+      "issues_no_response_pct_30d": 0.3948412698412698
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -5085,17 +5115,22 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.7000000000000001
+      "issues_no_response_pct_30d": 0.7555555555555555
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.8333333333333334
+      "issues_no_response_pct_30d": 0.5555555555555555
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.8333333333333334
+      "issues_no_response_pct_30d": 0.5555555555555555
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-01-01",
+      "issues_no_response_pct_30d": 0.6666666666666666
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -5415,22 +5450,22 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.16816227113536128
+      "issues_no_response_pct_30d": 0.16788621868539577
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.16447794294399082
+      "issues_no_response_pct_30d": 0.1642018904940253
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.2023856274627663
+      "issues_no_response_pct_30d": 0.20170088830639288
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.1701831680863939
+      "issues_no_response_pct_30d": 0.16977448137998596
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5570,17 +5605,17 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.25
+      "issues_no_response_pct_30d": 0.2435897435897436
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.08333333333333333
+      "issues_no_response_pct_30d": 0.07692307692307693
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.13888888888888887
+      "issues_no_response_pct_30d": 0.13247863247863248
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -5675,62 +5710,62 @@
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.11578947368421053
+      "issues_no_response_pct_30d": 0.10396039603960396
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.13979128856624318
+      "issues_no_response_pct_30d": 0.1353135313531353
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.1733629687488035
+      "issues_no_response_pct_30d": 0.16991916582962643
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.20705563414723935
+      "issues_no_response_pct_30d": 0.2066942719116632
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.21220636067077003
+      "issues_no_response_pct_30d": 0.21413084234035962
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.1791390335748243
+      "issues_no_response_pct_30d": 0.1811496693754402
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.1977589678574092
+      "issues_no_response_pct_30d": 0.1898898743181768
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.2046772068511199
+      "issues_no_response_pct_30d": 0.19262544786444127
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.18858350951374206
+      "issues_no_response_pct_30d": 0.18511216217633422
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.13643410852713178
+      "issues_no_response_pct_30d": 0.14842164667459146
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.0983388704318937
+      "issues_no_response_pct_30d": 0.11443997889010676
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.08320413436692507
+      "issues_no_response_pct_30d": 0.10748235713172599
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5750,22 +5785,22 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.10245111388891869
+      "issues_no_response_pct_30d": 0.09589935399427385
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.391304347826087
+      "issues_no_response_pct_30d": 0.36
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.36231884057971014
+      "issues_no_response_pct_30d": 0.3466666666666667
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.33245498462889767
+      "issues_no_response_pct_30d": 0.32202020202020204
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5779,13 +5814,18 @@
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-09-01",
+      "month": "2024-08-01",
       "issues_no_response_pct_30d": 0.4666666666666666
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-09-01",
+      "issues_no_response_pct_30d": 0.3333333333333333
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.5
+      "issues_no_response_pct_30d": 0.16666666666666666
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5800,47 +5840,47 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.2333333333333333
+      "issues_no_response_pct_30d": 0.27777777777777773
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.2333333333333333
+      "issues_no_response_pct_30d": 0.27777777777777773
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.06666666666666667
+      "issues_no_response_pct_30d": 0.1111111111111111
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.16666666666666666
+      "issues_no_response_pct_30d": 0.1111111111111111
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.16666666666666666
+      "issues_no_response_pct_30d": 0.1111111111111111
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.2222222222222222
+      "issues_no_response_pct_30d": 0.16666666666666666
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.12222222222222223
+      "issues_no_response_pct_30d": 0.1111111111111111
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.45555555555555555
+      "issues_no_response_pct_30d": 0.4444444444444444
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.45555555555555555
+      "issues_no_response_pct_30d": 0.4444444444444444
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5860,12 +5900,12 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.32264957264957267
+      "issues_no_response_pct_30d": 0.33730158730158727
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.24857549857549857
+      "issues_no_response_pct_30d": 0.2632275132275132
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -5885,102 +5925,102 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.07780705606792564
+      "issues_no_response_pct_30d": 0.0754882154882155
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.11643139469226427
+      "issues_no_response_pct_30d": 0.11102375102375102
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "issues_no_response_pct_30d": 0.1618859401468097
+      "issues_no_response_pct_30d": 0.15647829647829647
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.1504442925495557
+      "issues_no_response_pct_30d": 0.1601146601146601
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.1488569909622541
+      "issues_no_response_pct_30d": 0.15869218500797447
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.1650534381931841
+      "issues_no_response_pct_30d": 0.15820342645469979
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.20306513409961688
+      "issues_no_response_pct_30d": 0.18519206281833614
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.1915347357767657
+      "issues_no_response_pct_30d": 0.1742271505376344
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.1529140461215933
+      "issues_no_response_pct_30d": 0.14895833333333333
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.1192164140633055
+      "issues_no_response_pct_30d": 0.11691919191919192
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.1336707889943438
+      "issues_no_response_pct_30d": 0.12816257816257817
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.1544115297350845
+      "issues_no_response_pct_30d": 0.15392015392015393
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.19802979671400722
+      "issues_no_response_pct_30d": 0.18927368927368926
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.20095377332219436
+      "issues_no_response_pct_30d": 0.19758812615955476
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.19664714110858542
+      "issues_no_response_pct_30d": 0.18593311450454308
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.2645042839657283
+      "issues_no_response_pct_30d": 0.23643816500959358
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.2661638382568615
+      "issues_no_response_pct_30d": 0.2492877492877493
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.2998446722584654
+      "issues_no_response_pct_30d": 0.28322440087145967
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.23083882430524896
+      "issues_no_response_pct_30d": 0.235838779956427
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.2316055484762285
+      "issues_no_response_pct_30d": 0.22349310094408134
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -6425,32 +6465,32 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "issues_no_response_pct_30d": 0.5254237288135594
+      "issues_no_response_pct_30d": 0.5081967213114754
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.5198547215496367
+      "issues_no_response_pct_30d": 0.5112412177985948
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.5423370101336203
+      "issues_no_response_pct_30d": 0.5365946742995923
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.48177910052910056
+      "issues_no_response_pct_30d": 0.4783068783068783
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.46035052910052915
+      "issues_no_response_pct_30d": 0.4568783068783069
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.3554924242424242
+      "issues_no_response_pct_30d": 0.35202020202020207
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6460,87 +6500,87 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.43374785591766724
+      "issues_no_response_pct_30d": 0.431662394562543
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.5047435269133382
+      "issues_no_response_pct_30d": 0.4978961607963092
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.44751082251082247
+      "issues_no_response_pct_30d": 0.4481903381142236
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.46329365079365076
+      "issues_no_response_pct_30d": 0.4660586277521761
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.47300605060506046
+      "issues_no_response_pct_30d": 0.4805329323254906
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.5494766388403546
+      "issues_no_response_pct_30d": 0.5451672227662326
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.5510952687484583
+      "issues_no_response_pct_30d": 0.537842260817983
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.5632787300852461
+      "issues_no_response_pct_30d": 0.5504356254176009
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.6207262705049227
+      "issues_no_response_pct_30d": 0.6121925819113995
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.600817343257226
+      "issues_no_response_pct_30d": 0.6023391812865497
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.5824668418587677
+      "issues_no_response_pct_30d": 0.5754056502759245
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.46583266382108096
+      "issues_no_response_pct_30d": 0.4584465859484392
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.4389840722717852
+      "issues_no_response_pct_30d": 0.42348979097593326
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.409127170956267
+      "issues_no_response_pct_30d": 0.39189585578005853
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.4961442956078003
+      "issues_no_response_pct_30d": 0.47285345811923984
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.506560962274467
+      "issues_no_response_pct_30d": 0.4852158883921179
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.5180265654648957
+      "issues_no_response_pct_30d": 0.5065916518122401
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -6670,37 +6710,42 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.25681818181818183
+      "issues_no_response_pct_30d": 0.2661764705882353
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.1784584980237154
+      "issues_no_response_pct_30d": 0.1916353775552774
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.1951251646903821
+      "issues_no_response_pct_30d": 0.2844925204124203
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.4072463768115942
+      "issues_no_response_pct_30d": 0.4903748733535967
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-08-01",
-      "issues_no_response_pct_30d": 0.7333333333333334
+      "issues_no_response_pct_30d": 0.8095238095238094
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 1.0
+      "issues_no_response_pct_30d": 0.6666666666666666
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.6666666666666666
+      "issues_no_response_pct_30d": 0.3333333333333333
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-05-01",
+      "issues_no_response_pct_30d": 0.3333333333333333
     },
     {
       "repo": "https://github.com/sweepai/sweep",
@@ -6709,8 +6754,13 @@
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-07-01",
+      "issues_no_response_pct_30d": 1.0
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.6666666666666666
+      "issues_no_response_pct_30d": 1.0
     },
     {
       "repo": "https://github.com/sweepai/sweep",
@@ -6724,8 +6774,13 @@
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2026-01-01",
+      "issues_no_response_pct_30d": 0.6666666666666666
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 1.0
+      "issues_no_response_pct_30d": 0.6666666666666666
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -6850,17 +6905,17 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.1
+      "issues_no_response_pct_30d": 0.09090909090909091
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.07777777777777778
+      "issues_no_response_pct_30d": 0.07323232323232323
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "issues_no_response_pct_30d": 0.05185185185185185
+      "issues_no_response_pct_30d": 0.04882154882154882
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6875,87 +6930,87 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "issues_no_response_pct_30d": 0.0
+      "issues_no_response_pct_30d": 0.0043859649122807015
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "issues_no_response_pct_30d": 0.00546448087431694
+      "issues_no_response_pct_30d": 0.009287925696594427
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "issues_no_response_pct_30d": 0.00546448087431694
+      "issues_no_response_pct_30d": 0.009287925696594427
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "issues_no_response_pct_30d": 0.04355971896955504
+      "issues_no_response_pct_30d": 0.05471038990308768
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.10098831985624439
+      "issues_no_response_pct_30d": 0.09882803696191121
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.1495994309673555
+      "issues_no_response_pct_30d": 0.14183878965008326
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "issues_no_response_pct_30d": 0.23431121041597705
+      "issues_no_response_pct_30d": 0.2198842418098481
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.2728674040172896
+      "issues_no_response_pct_30d": 0.2734287365308134
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.38685791892243865
+      "issues_no_response_pct_30d": 0.37226195547384705
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.32545441015050885
+      "issues_no_response_pct_30d": 0.320165649952884
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.3573384681215233
+      "issues_no_response_pct_30d": 0.32871265849989256
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.3971177944862155
+      "issues_no_response_pct_30d": 0.38478535353535354
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.4607142857142857
+      "issues_no_response_pct_30d": 0.4462826797385621
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.38001253132832075
+      "issues_no_response_pct_30d": 0.39577762923351156
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.2756707946336429
+      "issues_no_response_pct_30d": 0.28558026081245896
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.17844857241142073
+      "issues_no_response_pct_30d": 0.17610313662945243
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.12581699346405228
+      "issues_no_response_pct_30d": 0.1154970760233918
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -7095,17 +7150,17 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "issues_no_response_pct_30d": 0.125
+      "issues_no_response_pct_30d": 0.1
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "issues_no_response_pct_30d": 0.0625
+      "issues_no_response_pct_30d": 0.05
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-06-01",
-      "issues_no_response_pct_30d": 0.041666666666666664
+      "issues_no_response_pct_30d": 0.03333333333333333
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -7145,67 +7200,67 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "issues_no_response_pct_30d": 0.09523809523809523
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-03-01",
-      "issues_no_response_pct_30d": 0.15079365079365079
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-04-01",
       "issues_no_response_pct_30d": 0.13095238095238096
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-03-01",
+      "issues_no_response_pct_30d": 0.18358395989974938
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-04-01",
+      "issues_no_response_pct_30d": 0.15818713450292396
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "issues_no_response_pct_30d": 0.125
+      "issues_no_response_pct_30d": 0.11189083820662767
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "issues_no_response_pct_30d": 0.3361111111111111
+      "issues_no_response_pct_30d": 0.2814814814814815
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "issues_no_response_pct_30d": 0.375
+      "issues_no_response_pct_30d": 0.35016835016835013
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "issues_no_response_pct_30d": 0.375
+      "issues_no_response_pct_30d": 0.3482190324295587
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "issues_no_response_pct_30d": 0.3464285714285715
+      "issues_no_response_pct_30d": 0.3482190324295587
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "issues_no_response_pct_30d": 0.39087301587301587
+      "issues_no_response_pct_30d": 0.31286549707602335
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "issues_no_response_pct_30d": 0.3795093795093795
+      "issues_no_response_pct_30d": 0.32905982905982906
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "issues_no_response_pct_30d": 0.2080808080808081
+      "issues_no_response_pct_30d": 0.2094017094017094
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "issues_no_response_pct_30d": 0.3191919191919192
+      "issues_no_response_pct_30d": 0.32051282051282054
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "issues_no_response_pct_30d": 0.37222222222222223
+      "issues_no_response_pct_30d": 0.40256410256410263
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/issue_time_to_close.json
+++ b/frontend/public/data/agentic-ai-momentum/issue_time_to_close.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T11:21:36.188200",
+    "fetched_at": "2026-04-01T07:13:57.413619",
     "schema": {
       "name": "issue_time_to_close",
       "description": "3-month trailing average of the monthly median time to close issues (days) per repo.",
@@ -155,112 +155,117 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "median_time_to_close_days": 1.3988078703703704
+      "median_time_to_close_days": 1.4041348379629628
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-05-01",
+      "median_time_to_close_days": 15.089477237654322
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "median_time_to_close_days": 0.958761574074074
+      "median_time_to_close_days": 17.076599151234568
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "median_time_to_close_days": 6.427947530864198
+      "median_time_to_close_days": 18.01484760802469
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "median_time_to_close_days": 16.585686728395064
+      "median_time_to_close_days": 14.094218750000001
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "median_time_to_close_days": 21.156755401234566
+      "median_time_to_close_days": 15.846869212962964
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "median_time_to_close_days": 18.252525077160495
+      "median_time_to_close_days": 18.457690972222224
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "median_time_to_close_days": 9.362478780864198
+      "median_time_to_close_days": 9.568084490740741
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "median_time_to_close_days": 7.820416666666667
+      "median_time_to_close_days": 8.02602237654321
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "median_time_to_close_days": 38.94594907407407
+      "median_time_to_close_days": 35.65976658950618
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "median_time_to_close_days": 43.11460841049382
+      "median_time_to_close_days": 39.01368634259259
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "median_time_to_close_days": 46.6105613425926
+      "median_time_to_close_days": 41.93561728395062
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "median_time_to_close_days": 14.880671296296297
+      "median_time_to_close_days": 13.492349537037036
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "median_time_to_close_days": 31.026934799382715
+      "median_time_to_close_days": 30.45291280864198
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "median_time_to_close_days": 28.49625578703704
+      "median_time_to_close_days": 40.21656828703704
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "median_time_to_close_days": 41.19291087962963
+      "median_time_to_close_days": 52.913223379629635
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "median_time_to_close_days": 34.31199652777778
+      "median_time_to_close_days": 40.27224729938272
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "median_time_to_close_days": 138.81870756172842
+      "median_time_to_close_days": 138.66550925925927
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "median_time_to_close_days": 125.16063271604939
+      "median_time_to_close_days": 125.00743441358024
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "median_time_to_close_days": 113.83159336419754
+      "median_time_to_close_days": 119.43845679012345
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "median_time_to_close_days": 16.802480709876544
+      "median_time_to_close_days": 23.973850308641975
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "median_time_to_close_days": 23.94892939814815
+      "median_time_to_close_days": 31.12029899691358
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "median_time_to_close_days": 21.430380015432096
+      "median_time_to_close_days": 28.674967206790125
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -380,7 +385,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "median_time_to_close_days": 3.7424826388888888
+      "median_time_to_close_days": 3.7380844907407407
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -410,52 +415,52 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "median_time_to_close_days": 23.626082175925927
+      "median_time_to_close_days": 23.626057098765433
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "median_time_to_close_days": 10.078586033950616
+      "median_time_to_close_days": 10.614618055555555
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "median_time_to_close_days": 0.6243904320987655
+      "median_time_to_close_days": 1.7728317901234567
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "median_time_to_close_days": 3.2232195216049386
+      "median_time_to_close_days": 4.411277006172839
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "median_time_to_close_days": 4.45558063271605
+      "median_time_to_close_days": 5.107565586419753
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "median_time_to_close_days": 3.8547492283950615
+      "median_time_to_close_days": 3.89433063271605
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "median_time_to_close_days": 1.3222569444444445
+      "median_time_to_close_days": 1.3266917438271604
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "median_time_to_close_days": 3.1093557098765428
+      "median_time_to_close_days": 3.4591763117283953
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-05-01",
-      "median_time_to_close_days": 3.1003086419753085
+      "median_time_to_close_days": 3.4501234567901236
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "median_time_to_close_days": 3.0358719135802468
+      "median_time_to_close_days": 3.3812422839506175
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -465,37 +470,37 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "median_time_to_close_days": 3.4483912037037037
+      "median_time_to_close_days": 3.3526774691358026
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "median_time_to_close_days": 7.307104552469135
+      "median_time_to_close_days": 7.211390817901235
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "median_time_to_close_days": 7.216456404320987
+      "median_time_to_close_days": 7.125127314814815
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "median_time_to_close_days": 6.06578125
+      "median_time_to_close_days": 6.070165895061728
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "median_time_to_close_days": 2.978387345679012
+      "median_time_to_close_days": 3.339444444444444
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "median_time_to_close_days": 4.755138888888889
+      "median_time_to_close_days": 4.272309027777777
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "median_time_to_close_days": 3.019014274691358
+      "median_time_to_close_days": 2.6621122685185186
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -720,137 +725,137 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-12-01",
-      "median_time_to_close_days": 15.679930555555556
+      "median_time_to_close_days": 25.885353009259262
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-01-01",
-      "median_time_to_close_days": 2.113599537037037
+      "median_time_to_close_days": 12.319021990740742
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-10-01",
-      "median_time_to_close_days": 8.685123456790123
+      "median_time_to_close_days": 18.890545910493827
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "median_time_to_close_days": 0.6400231481481482
+      "median_time_to_close_days": 0.6078587962962962
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "median_time_to_close_days": 0.6719386574074074
+      "median_time_to_close_days": 0.6473321759259258
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "median_time_to_close_days": 1.0771875
+      "median_time_to_close_days": 1.1810841049382714
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "median_time_to_close_days": 1.8531095679012346
+      "median_time_to_close_days": 3.7033892746913577
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "median_time_to_close_days": 3.0595351080246913
+      "median_time_to_close_days": 6.72457561728395
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "median_time_to_close_days": 3.840102237654321
+      "median_time_to_close_days": 7.384841820987654
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "median_time_to_close_days": 5.155619212962963
+      "median_time_to_close_days": 6.275750385802469
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "median_time_to_close_days": 4.19408950617284
+      "median_time_to_close_days": 3.5051427469135805
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "median_time_to_close_days": 3.475698302469136
+      "median_time_to_close_days": 2.9228163580246913
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "median_time_to_close_days": 2.4854359567901234
+      "median_time_to_close_days": 2.955061728395062
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "median_time_to_close_days": 2.9161612654320987
+      "median_time_to_close_days": 3.759224537037037
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "median_time_to_close_days": 2.980210262345679
+      "median_time_to_close_days": 5.108896604938272
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "median_time_to_close_days": 2.670353009259259
+      "median_time_to_close_days": 5.366454475308642
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "median_time_to_close_days": 2.6827912808641976
+      "median_time_to_close_days": 5.149646990740741
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "median_time_to_close_days": 2.641983024691358
+      "median_time_to_close_days": 3.687150848765432
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "median_time_to_close_days": 2.5994618055555554
+      "median_time_to_close_days": 2.710306712962963
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "median_time_to_close_days": 2.0925983796296297
+      "median_time_to_close_days": 2.6487268518518516
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "median_time_to_close_days": 2.687390046296296
+      "median_time_to_close_days": 3.69045524691358
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "median_time_to_close_days": 5.295779320987655
+      "median_time_to_close_days": 6.077318672839506
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "median_time_to_close_days": 6.570181327160494
+      "median_time_to_close_days": 7.460609567901234
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "median_time_to_close_days": 11.161006944444445
+      "median_time_to_close_days": 11.429328703703703
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "median_time_to_close_days": 9.021165123456791
+      "median_time_to_close_days": 9.551948302469137
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "median_time_to_close_days": 8.363387345679014
+      "median_time_to_close_days": 8.052631172839506
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "median_time_to_close_days": 7.268371913580247
+      "median_time_to_close_days": 9.168177083333333
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -980,27 +985,27 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "median_time_to_close_days": 4.308425925925926
+      "median_time_to_close_days": 4.059809027777778
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "median_time_to_close_days": 4.30085262345679
+      "median_time_to_close_days": 4.135108024691358
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "median_time_to_close_days": 5.69289737654321
+      "median_time_to_close_days": 5.645378086419753
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "median_time_to_close_days": 7.032750771604938
+      "median_time_to_close_days": 7.150976080246913
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "median_time_to_close_days": 7.892478780864198
+      "median_time_to_close_days": 8.010704089506172
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1010,62 +1015,62 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "median_time_to_close_days": 17.320702160493827
+      "median_time_to_close_days": 15.912119984567902
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "median_time_to_close_days": 16.478584104938275
+      "median_time_to_close_days": 15.070001929012344
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "median_time_to_close_days": 18.075208333333332
+      "median_time_to_close_days": 18.151907793209876
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "median_time_to_close_days": 6.552035108024691
+      "median_time_to_close_days": 8.03731674382716
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "median_time_to_close_days": 26.8839737654321
+      "median_time_to_close_days": 26.765239197530864
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "median_time_to_close_days": 36.28245177469136
+      "median_time_to_close_days": 34.64138117283951
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "median_time_to_close_days": 35.146967592592596
+      "median_time_to_close_days": 33.60226466049382
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "median_time_to_close_days": 20.06113811728395
+      "median_time_to_close_days": 27.21016589506173
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "median_time_to_close_days": 11.045198688271604
+      "median_time_to_close_days": 18.231280864197533
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "median_time_to_close_days": 12.379284336419753
+      "median_time_to_close_days": 18.95698688271605
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "median_time_to_close_days": 9.251344521604938
+      "median_time_to_close_days": 8.739332561728395
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-09-01",
-      "median_time_to_close_days": 10.746853780864198
+      "median_time_to_close_days": 10.234841820987654
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1550,197 +1555,197 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "median_time_to_close_days": 3.5068923611111114
+      "median_time_to_close_days": 1.3935706018518519
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "median_time_to_close_days": 3.1927025462962964
+      "median_time_to_close_days": 1.7838213734567903
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "median_time_to_close_days": 7.54396412037037
+      "median_time_to_close_days": 6.394419367283951
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "median_time_to_close_days": 6.730557484567901
+      "median_time_to_close_days": 7.058248456790124
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "median_time_to_close_days": 7.706963734567901
+      "median_time_to_close_days": 8.052123842592593
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "median_time_to_close_days": 9.475144675925927
+      "median_time_to_close_days": 8.629565972222222
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "median_time_to_close_days": 9.125441743827162
+      "median_time_to_close_days": 8.21150848765432
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "median_time_to_close_days": 7.657025462962963
+      "median_time_to_close_days": 7.000868055555556
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-08-01",
-      "median_time_to_close_days": 59.69619984567902
+      "median_time_to_close_days": 58.36760802469136
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-09-01",
-      "median_time_to_close_days": 100.07948302469136
+      "median_time_to_close_days": 98.90470679012346
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-10-01",
-      "median_time_to_close_days": 100.13234182098766
+      "median_time_to_close_days": 98.76257716049383
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "median_time_to_close_days": 50.75713541666667
+      "median_time_to_close_days": 53.21338734567902
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "median_time_to_close_days": 10.761097608024691
+      "median_time_to_close_days": 12.939342206790123
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "median_time_to_close_days": 26.841790123456793
+      "median_time_to_close_days": 23.25223186728395
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "median_time_to_close_days": 25.58837962962963
+      "median_time_to_close_days": 19.722640817901233
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-03-01",
-      "median_time_to_close_days": 2.271261574074074
+      "median_time_to_close_days": 2.742164351851852
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "median_time_to_close_days": 26.957838541666668
+      "median_time_to_close_days": 27.193289930555558
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "median_time_to_close_days": 24.774909336419753
+      "median_time_to_close_days": 25.319000771604937
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "median_time_to_close_days": 28.79028163580247
+      "median_time_to_close_days": 29.177405478395062
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "median_time_to_close_days": 17.678227237654323
+      "median_time_to_close_days": 17.99539737654321
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "median_time_to_close_days": 13.665750385802468
+      "median_time_to_close_days": 13.595796682098765
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "median_time_to_close_days": 13.048341049382715
+      "median_time_to_close_days": 12.978387345679012
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "median_time_to_close_days": 9.684783950617286
+      "median_time_to_close_days": 9.59014660493827
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "median_time_to_close_days": 9.477206790123457
+      "median_time_to_close_days": 9.57752700617284
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "median_time_to_close_days": 12.298896604938273
+      "median_time_to_close_days": 12.6300887345679
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "median_time_to_close_days": 14.6353125
+      "median_time_to_close_days": 14.421668595679014
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "median_time_to_close_days": 15.513825231481482
+      "median_time_to_close_days": 14.255065586419752
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "median_time_to_close_days": 9.233138503086419
+      "median_time_to_close_days": 7.770295138888888
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "median_time_to_close_days": 5.802274305555556
+      "median_time_to_close_days": 4.978904320987653
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "median_time_to_close_days": 6.183283179012346
+      "median_time_to_close_days": 6.210071373456789
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-06-01",
-      "median_time_to_close_days": 7.59516010802469
+      "median_time_to_close_days": 7.600968364197531
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "median_time_to_close_days": 7.165719521604938
+      "median_time_to_close_days": 7.315578703703704
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "median_time_to_close_days": 10.15117862654321
+      "median_time_to_close_days": 10.010374228395062
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "median_time_to_close_days": 13.460347222222223
+      "median_time_to_close_days": 13.313734567901234
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "median_time_to_close_days": 14.13565200617284
+      "median_time_to_close_days": 14.90630787037037
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "median_time_to_close_days": 8.23949074074074
+      "median_time_to_close_days": 10.733541666666667
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "median_time_to_close_days": 4.174839891975309
+      "median_time_to_close_days": 6.882037037037037
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "median_time_to_close_days": 3.3304494598765437
+      "median_time_to_close_days": 6.288165509259259
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "median_time_to_close_days": 105.24056905864198
+      "median_time_to_close_days": 105.97466820987654
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -1960,7 +1965,7 @@
     {
       "repo": "https://github.com/cline/cline",
       "month": "2026-02-01",
-      "median_time_to_close_days": 127.40837962962962
+      "median_time_to_close_days": 127.39097608024692
     },
     {
       "repo": "https://github.com/comet-ml/opik",
@@ -1975,207 +1980,207 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "median_time_to_close_days": 4.1914390432098765
+      "median_time_to_close_days": 3.631597222222222
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "median_time_to_close_days": 5.606670524691357
+      "median_time_to_close_days": 5.228420138888889
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "median_time_to_close_days": 4.710295138888889
+      "median_time_to_close_days": 4.603867669753087
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "median_time_to_close_days": 4.852451774691358
+      "median_time_to_close_days": 5.162187500000001
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "median_time_to_close_days": 4.6522800925925925
+      "median_time_to_close_days": 4.845144675925926
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "median_time_to_close_days": 4.8053993055555555
+      "median_time_to_close_days": 3.7693942901234565
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "median_time_to_close_days": 5.068994984567901
+      "median_time_to_close_days": 4.156784336419753
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "median_time_to_close_days": 7.035451388888888
+      "median_time_to_close_days": 6.203501157407406
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "median_time_to_close_days": 6.165675154320987
+      "median_time_to_close_days": 7.825937499999999
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "median_time_to_close_days": 8.623086419753086
+      "median_time_to_close_days": 19.167189429012346
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "median_time_to_close_days": 21.423271604938275
+      "median_time_to_close_days": 31.25164351851852
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "median_time_to_close_days": 21.24688271604938
+      "median_time_to_close_days": 29.52224537037037
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "median_time_to_close_days": 18.50311728395062
+      "median_time_to_close_days": 17.990503472222223
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "median_time_to_close_days": 5.304359567901234
+      "median_time_to_close_days": 32.68640239197531
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "median_time_to_close_days": 7.406971450617284
+      "median_time_to_close_days": 33.486859567901234
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "median_time_to_close_days": 8.403003472222222
+      "median_time_to_close_days": 34.00304398148148
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "median_time_to_close_days": 17.885380015432098
+      "median_time_to_close_days": 22.712156635802472
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "median_time_to_close_days": 1.0201967592592593
+      "median_time_to_close_days": 0.8721006944444445
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "median_time_to_close_days": 2.9258622685185185
+      "median_time_to_close_days": 2.851814236111111
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "median_time_to_close_days": 3.5871334876543215
+      "median_time_to_close_days": 3.1768846450617283
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "median_time_to_close_days": 4.538753858024691
+      "median_time_to_close_days": 4.17787037037037
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "median_time_to_close_days": 3.6442631172839506
+      "median_time_to_close_days": 3.28337962962963
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "median_time_to_close_days": 2.837746913580247
+      "median_time_to_close_days": 2.52836612654321
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "median_time_to_close_days": 3.0287538580246913
+      "median_time_to_close_days": 2.004025848765432
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-10-01",
-      "median_time_to_close_days": 2.7105787037037037
+      "median_time_to_close_days": 1.818605324074074
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "median_time_to_close_days": 3.227548225308642
+      "median_time_to_close_days": 2.6449556327160493
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "median_time_to_close_days": 2.9946315586419754
+      "median_time_to_close_days": 4.149708719135803
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "median_time_to_close_days": 4.068337191358025
+      "median_time_to_close_days": 5.090659722222222
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "median_time_to_close_days": 4.358146219135802
+      "median_time_to_close_days": 5.375981867283951
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "median_time_to_close_days": 3.5878317901234564
+      "median_time_to_close_days": 3.611413966049383
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "median_time_to_close_days": 2.8506037808641977
+      "median_time_to_close_days": 2.9392881944444444
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "median_time_to_close_days": 1.9957233796296296
+      "median_time_to_close_days": 2.6405729166666663
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "median_time_to_close_days": 2.5117091049382716
+      "median_time_to_close_days": 3.1284895833333333
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "median_time_to_close_days": 3.1314197530864196
+      "median_time_to_close_days": 3.4510050154320986
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "median_time_to_close_days": 4.366319444444444
+      "median_time_to_close_days": 4.55953125
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "median_time_to_close_days": 4.2004166666666665
+      "median_time_to_close_days": 4.613859953703703
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "median_time_to_close_days": 5.593350694444445
+      "median_time_to_close_days": 5.9701967592592595
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "median_time_to_close_days": 4.055144675925926
+      "median_time_to_close_days": 4.270644290123457
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "median_time_to_close_days": 6.0591030092592595
+      "median_time_to_close_days": 5.619058641975308
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "median_time_to_close_days": 4.495717592592592
+      "median_time_to_close_days": 5.90636574074074
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "median_time_to_close_days": 7.03466049382716
+      "median_time_to_close_days": 9.652716049382716
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2235,17 +2240,17 @@
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-02-01",
-      "median_time_to_close_days": 11.101761188271604
+      "median_time_to_close_days": 10.431585648148149
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-03-01",
-      "median_time_to_close_days": 11.853198302469137
+      "median_time_to_close_days": 11.18302276234568
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-04-01",
-      "median_time_to_close_days": 6.388931327160493
+      "median_time_to_close_days": 5.718755787037036
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2430,107 +2435,112 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "median_time_to_close_days": 2.2130131172839507
+      "median_time_to_close_days": 2.2225096450617285
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "median_time_to_close_days": 5.410237268518519
+      "median_time_to_close_days": 6.336784336419753
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "median_time_to_close_days": 10.006992669753087
+      "median_time_to_close_days": 10.877332175925927
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "median_time_to_close_days": 12.067771990740743
+      "median_time_to_close_days": 13.868271604938272
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "median_time_to_close_days": 10.270590277777778
+      "median_time_to_close_days": 11.196728395061728
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "median_time_to_close_days": 13.70363425925926
+      "median_time_to_close_days": 16.196373456790123
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "median_time_to_close_days": 12.746379243827159
+      "median_time_to_close_days": 14.538734567901235
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "median_time_to_close_days": 15.527980324074074
+      "median_time_to_close_days": 17.596658950617286
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "median_time_to_close_days": 16.018501157407407
+      "median_time_to_close_days": 16.609689429012345
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "median_time_to_close_days": 28.379074074074072
+      "median_time_to_close_days": 28.033628472222222
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-03-01",
+      "median_time_to_close_days": 45.94268325617284
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "median_time_to_close_days": 90.63943287037036
+      "median_time_to_close_days": 98.75513503086421
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "median_time_to_close_days": 84.77018518518518
+      "median_time_to_close_days": 88.64604938271606
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "median_time_to_close_days": 70.68431134259258
+      "median_time_to_close_days": 66.16173225308641
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "median_time_to_close_days": 8.703277391975309
+      "median_time_to_close_days": 9.104587191358025
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "median_time_to_close_days": 6.146053240740741
+      "median_time_to_close_days": 6.435632716049383
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "median_time_to_close_days": 5.845565200617284
+      "median_time_to_close_days": 6.316898148148148
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "median_time_to_close_days": 17.828192515432097
+      "median_time_to_close_days": 22.997905092592593
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "median_time_to_close_days": 17.276030092592592
+      "median_time_to_close_days": 22.35474729938272
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "median_time_to_close_days": 17.976662808641976
+      "median_time_to_close_days": 27.700285493827163
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "median_time_to_close_days": 8.268011188271606
+      "median_time_to_close_days": 11.548775077160492
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "median_time_to_close_days": 13.960171682098766
+      "median_time_to_close_days": 20.77889081790123
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2684,13 +2694,18 @@
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2024-10-01",
+      "median_time_to_close_days": 10.081963734567902
+    },
+    {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-11-01",
-      "median_time_to_close_days": 10.083144290123457
+      "median_time_to_close_days": 0.3622723765432099
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-01-01",
-      "median_time_to_close_days": 0.7150617283950617
+      "median_time_to_close_days": 0.355775462962963
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2740,167 +2755,172 @@
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "median_time_to_close_days": 1.3232407407407407
+      "median_time_to_close_days": 1.564849537037037
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "median_time_to_close_days": 6.43630787037037
+      "median_time_to_close_days": 5.0310706018518525
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "median_time_to_close_days": 5.905534336419753
+      "median_time_to_close_days": 5.502959104938271
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "median_time_to_close_days": 12.190947145061727
+      "median_time_to_close_days": 11.800144675925926
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "median_time_to_close_days": 14.371298225308642
+      "median_time_to_close_days": 25.144481095679012
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "median_time_to_close_days": 17.443356481481484
+      "median_time_to_close_days": 26.053730709876543
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "median_time_to_close_days": 33.43162229938272
+      "median_time_to_close_days": 58.01077739197532
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "median_time_to_close_days": 51.56930362654321
+      "median_time_to_close_days": 63.67240162037037
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "median_time_to_close_days": 48.411203703703706
+      "median_time_to_close_days": 70.61447530864199
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "median_time_to_close_days": 28.063863811728396
+      "median_time_to_close_days": 36.46321759259259
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "median_time_to_close_days": 6.161051311728396
+      "median_time_to_close_days": 25.909390432098764
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "median_time_to_close_days": 1.8204224537037037
+      "median_time_to_close_days": 1.1536458333333333
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "median_time_to_close_days": 6.028602430555555
+      "median_time_to_close_days": 1.9250405092592593
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-05-01",
-      "median_time_to_close_days": 7.026271219135803
+      "median_time_to_close_days": 4.290563271604938
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-06-01",
-      "median_time_to_close_days": 18.482351466049384
+      "median_time_to_close_days": 15.968902391975307
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "median_time_to_close_days": 24.132961033950618
+      "median_time_to_close_days": 25.730488040123458
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "median_time_to_close_days": 36.5306925154321
+      "median_time_to_close_days": 33.749375
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "median_time_to_close_days": 30.62729938271605
+      "median_time_to_close_days": 23.37541859567901
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "median_time_to_close_days": 24.910540123456787
+      "median_time_to_close_days": 16.061132330246913
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "median_time_to_close_days": 23.0624537037037
+      "median_time_to_close_days": 10.606404320987656
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "median_time_to_close_days": 16.917511574074073
+      "median_time_to_close_days": 8.932025462962963
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "median_time_to_close_days": 24.47611882716049
+      "median_time_to_close_days": 9.114261188271605
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "median_time_to_close_days": 49.979413580246906
+      "median_time_to_close_days": 42.603042052469135
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "median_time_to_close_days": 49.9735686728395
+      "median_time_to_close_days": 47.364511959876545
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "median_time_to_close_days": 43.18555555555556
+      "median_time_to_close_days": 47.95287037037037
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-05-01",
+      "median_time_to_close_days": 8.969421296296296
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "median_time_to_close_days": 4.227611882716049
+      "median_time_to_close_days": 4.295597993827161
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "median_time_to_close_days": 4.563989197530864
+      "median_time_to_close_days": 0.47555555555555556
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-09-01",
-      "median_time_to_close_days": 12.205794753086417
+      "median_time_to_close_days": 12.157372685185186
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "median_time_to_close_days": 12.203645833333333
+      "median_time_to_close_days": 12.151167052469134
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "median_time_to_close_days": 22.725983796296294
+      "median_time_to_close_days": 24.850042438271604
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "median_time_to_close_days": 17.971342592592595
+      "median_time_to_close_days": 16.642650462962965
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-01-01",
-      "median_time_to_close_days": 21.930019290123457
+      "median_time_to_close_days": 20.60538387345679
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "median_time_to_close_days": 22.404729938271604
+      "median_time_to_close_days": 18.95197916666667
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -2925,17 +2945,17 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-04-01",
-      "median_time_to_close_days": 3.6299710648148147
+      "median_time_to_close_days": 3.5298360339506174
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-05-01",
-      "median_time_to_close_days": 2.1086265432098767
+      "median_time_to_close_days": 2.008491512345679
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-06-01",
-      "median_time_to_close_days": 3.6491782407407407
+      "median_time_to_close_days": 3.5490432098765434
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -3035,17 +3055,17 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "median_time_to_close_days": 5.613001543209877
+      "median_time_to_close_days": 5.578829089506173
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-04-01",
-      "median_time_to_close_days": 3.2891512345679015
+      "median_time_to_close_days": 3.2549787808641977
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-05-01",
-      "median_time_to_close_days": 3.754770447530864
+      "median_time_to_close_days": 3.7205979938271603
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3331,6 +3351,11 @@
       "repo": "https://github.com/janhq/jan",
       "month": "2026-02-01",
       "median_time_to_close_days": 42.72421682098766
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-07-01",
+      "median_time_to_close_days": 1.8687615740740742
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -3775,17 +3800,17 @@
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2025-07-01",
-      "median_time_to_close_days": 5.5482754629629625
+      "median_time_to_close_days": 5.543684413580247
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2025-08-01",
-      "median_time_to_close_days": 6.103217592592593
+      "median_time_to_close_days": 6.098626543209877
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2025-09-01",
-      "median_time_to_close_days": 6.060684799382716
+      "median_time_to_close_days": 6.05609375
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
@@ -3945,107 +3970,107 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "median_time_to_close_days": 2.3094020061728395
+      "median_time_to_close_days": 2.3078703703703707
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "median_time_to_close_days": 4.522860725308642
+      "median_time_to_close_days": 3.7277932098765434
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "median_time_to_close_days": 6.985985725308642
+      "median_time_to_close_days": 5.809068287037037
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "median_time_to_close_days": 8.312270447530864
+      "median_time_to_close_days": 7.136884645061728
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "median_time_to_close_days": 7.055163966049382
+      "median_time_to_close_days": 6.7688290895061725
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "median_time_to_close_days": 4.679708719135802
+      "median_time_to_close_days": 4.119143518518519
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "median_time_to_close_days": 4.057166280864197
+      "median_time_to_close_days": 3.568190586419753
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "median_time_to_close_days": 4.629097222222222
+      "median_time_to_close_days": 3.9867785493827164
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "median_time_to_close_days": 3.5015779320987654
+      "median_time_to_close_days": 3.616153549382716
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "median_time_to_close_days": 3.2859876543209876
+      "median_time_to_close_days": 3.330856481481481
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "median_time_to_close_days": 1.6178530092592591
+      "median_time_to_close_days": 1.6326736111111113
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "median_time_to_close_days": 1.878587962962963
+      "median_time_to_close_days": 1.619608410493827
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "median_time_to_close_days": 1.7432368827160492
+      "median_time_to_close_days": 1.477204861111111
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "median_time_to_close_days": 1.6033236882716049
+      "median_time_to_close_days": 1.3992862654320988
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "median_time_to_close_days": 1.8600848765432099
+      "median_time_to_close_days": 1.7274170524691357
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "median_time_to_close_days": 2.121280864197531
+      "median_time_to_close_days": 1.999770447530864
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "median_time_to_close_days": 2.6709780092592594
+      "median_time_to_close_days": 2.9879224537037037
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "median_time_to_close_days": 2.378107638888889
+      "median_time_to_close_days": 2.7164409722222227
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "median_time_to_close_days": 2.5707658179012345
+      "median_time_to_close_days": 2.753775077160494
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "median_time_to_close_days": 2.8651118827160498
+      "median_time_to_close_days": 2.4851851851851854
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "median_time_to_close_days": 2.509050925925926
+      "median_time_to_close_days": 2.434278549382716
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4075,57 +4100,57 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "median_time_to_close_days": 2.806518132716049
+      "median_time_to_close_days": 2.7902507716049385
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "median_time_to_close_days": 5.499207175925926
+      "median_time_to_close_days": 5.482939814814816
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "median_time_to_close_days": 5.177438271604939
+      "median_time_to_close_days": 5.161170910493827
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "median_time_to_close_days": 5.6221759259259265
+      "median_time_to_close_days": 5.600653935185186
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "median_time_to_close_days": 3.7308526234567903
+      "median_time_to_close_days": 3.762283950617284
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "median_time_to_close_days": 4.192125771604938
+      "median_time_to_close_days": 4.35335262345679
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "median_time_to_close_days": 3.37947337962963
+      "median_time_to_close_days": 3.461446759259259
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "median_time_to_close_days": 14.325790895061727
+      "median_time_to_close_days": 6.5887172067901245
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "median_time_to_close_days": 21.788728780864194
+      "median_time_to_close_days": 7.738234953703704
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "median_time_to_close_days": 21.948921682098767
+      "median_time_to_close_days": 7.584760802469137
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "median_time_to_close_days": 11.199851466049383
+      "median_time_to_close_days": 4.566496913580247
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4150,27 +4175,27 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "median_time_to_close_days": 10.066792052469136
+      "median_time_to_close_days": 9.890241126543211
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "median_time_to_close_days": 10.619319058641976
+      "median_time_to_close_days": 10.442768132716049
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "median_time_to_close_days": 2.0220524691358026
+      "median_time_to_close_days": 1.8983101851851851
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-05-01",
-      "median_time_to_close_days": 1.4157021604938274
+      "median_time_to_close_days": 1.4685108024691358
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-06-01",
-      "median_time_to_close_days": 2.760389660493827
+      "median_time_to_close_days": 2.813198302469136
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4183,64 +4208,79 @@
       "median_time_to_close_days": 2.8717631172839506
     },
     {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-10-01",
+      "median_time_to_close_days": 0.21588734567901233
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-12-01",
+      "median_time_to_close_days": 0.010412808641975307
+    },
+    {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "median_time_to_close_days": 0.9093171296296296
+      "median_time_to_close_days": 2.456388888888889
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "median_time_to_close_days": 8.134236111111113
+      "median_time_to_close_days": 6.859739583333333
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "median_time_to_close_days": 5.849434799382717
+      "median_time_to_close_days": 5.106512345679012
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "median_time_to_close_days": 8.168142361111112
+      "median_time_to_close_days": 6.960551697530864
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "median_time_to_close_days": 6.873520447530865
+      "median_time_to_close_days": 10.553121141975309
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "median_time_to_close_days": 10.219124228395062
+      "median_time_to_close_days": 11.513342978395064
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "median_time_to_close_days": 26.81536844135803
+      "median_time_to_close_days": 34.2759625771605
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-11-01",
-      "median_time_to_close_days": 29.063312114197533
+      "median_time_to_close_days": 33.00206983024692
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-12-01",
-      "median_time_to_close_days": 31.556649305555556
+      "median_time_to_close_days": 37.774047067901236
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "median_time_to_close_days": 21.707457561728393
+      "median_time_to_close_days": 31.563117283950618
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-02-01",
+      "median_time_to_close_days": 28.266917438271605
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-03-01",
-      "median_time_to_close_days": 25.26951774691358
+      "median_time_to_close_days": 31.636466049382715
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-09-01",
-      "median_time_to_close_days": 85.24635416666666
+      "median_time_to_close_days": 72.63237075617285
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -4365,37 +4405,37 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "median_time_to_close_days": 7.048034336419754
+      "median_time_to_close_days": 6.75765625
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "median_time_to_close_days": 6.500036651234567
+      "median_time_to_close_days": 6.245731095679012
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "median_time_to_close_days": 3.6269560185185186
+      "median_time_to_close_days": 3.2215875771604936
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "median_time_to_close_days": 4.595345293209877
+      "median_time_to_close_days": 4.144342206790124
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "median_time_to_close_days": 6.645194830246914
+      "median_time_to_close_days": 5.805198688271605
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "median_time_to_close_days": 6.668400848765432
+      "median_time_to_close_days": 5.979467592592592
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "median_time_to_close_days": 8.51000385802469
+      "median_time_to_close_days": 8.157083333333334
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
@@ -4405,62 +4445,62 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "median_time_to_close_days": 56.09922067901235
+      "median_time_to_close_days": 56.22231288580247
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "median_time_to_close_days": 84.69160686728395
+      "median_time_to_close_days": 79.85704668209877
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "median_time_to_close_days": 34.16280671296297
+      "median_time_to_close_days": 29.32824652777778
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "median_time_to_close_days": 51.3382851080247
+      "median_time_to_close_days": 67.76850694444444
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "median_time_to_close_days": 34.00562114197531
+      "median_time_to_close_days": 51.51067708333334
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "median_time_to_close_days": 114.28066358024692
+      "median_time_to_close_days": 131.7177372685185
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "median_time_to_close_days": 106.57293209876543
+      "median_time_to_close_days": 102.5855613425926
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "median_time_to_close_days": 94.64542631172839
+      "median_time_to_close_days": 94.95731674382716
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "median_time_to_close_days": 94.92513310185184
+      "median_time_to_close_days": 95.30500578703703
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "median_time_to_close_days": 152.93959683641975
+      "median_time_to_close_days": 89.91700810185186
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "median_time_to_close_days": 153.57399305555558
+      "median_time_to_close_days": 111.61770447530864
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "median_time_to_close_days": 80.27050925925926
+      "median_time_to_close_days": 36.284124228395065
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -4585,122 +4625,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "median_time_to_close_days": 60.47935185185185
+      "median_time_to_close_days": 59.949068287037036
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "median_time_to_close_days": 44.201333912037036
+      "median_time_to_close_days": 43.11653645833333
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "median_time_to_close_days": 32.68970486111111
+      "median_time_to_close_days": 32.240125385802465
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "median_time_to_close_days": 20.245854552469137
+      "median_time_to_close_days": 20.45404320987654
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "median_time_to_close_days": 15.381481481481481
+      "median_time_to_close_days": 16.066531635802466
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "median_time_to_close_days": 16.79750771604938
+      "median_time_to_close_days": 17.56520833333333
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "median_time_to_close_days": 18.581051311728395
+      "median_time_to_close_days": 17.556377314814814
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "median_time_to_close_days": 22.104502314814813
+      "median_time_to_close_days": 20.214328703703703
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "median_time_to_close_days": 59.846678240740744
+      "median_time_to_close_days": 52.76315586419753
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "median_time_to_close_days": 90.39535300925927
+      "median_time_to_close_days": 81.01643518518519
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "median_time_to_close_days": 89.21534143518518
+      "median_time_to_close_days": 80.38631558641974
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "median_time_to_close_days": 50.62722415123457
+      "median_time_to_close_days": 45.78836033950617
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "median_time_to_close_days": 14.496552854938273
+      "median_time_to_close_days": 12.821369598765434
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "median_time_to_close_days": 14.300019290123457
+      "median_time_to_close_days": 12.249521604938272
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "median_time_to_close_days": 16.120148533950616
+      "median_time_to_close_days": 13.914596836419753
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "median_time_to_close_days": 18.04243634259259
+      "median_time_to_close_days": 14.913655478395063
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "median_time_to_close_days": 14.139376929012345
+      "median_time_to_close_days": 11.747943672839506
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "median_time_to_close_days": 12.509610339506173
+      "median_time_to_close_days": 11.133701774691358
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "median_time_to_close_days": 10.908568672839507
+      "median_time_to_close_days": 10.303344907407407
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "median_time_to_close_days": 18.21182484567901
+      "median_time_to_close_days": 16.69828896604938
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "median_time_to_close_days": 30.176678240740742
+      "median_time_to_close_days": 33.51347029320988
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "median_time_to_close_days": 39.27136574074074
+      "median_time_to_close_days": 44.91241898148147
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "median_time_to_close_days": 76.26054012345679
+      "median_time_to_close_days": 82.83305555555556
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "median_time_to_close_days": 130.12046103395062
+      "median_time_to_close_days": 103.88878858024691
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -5145,12 +5185,12 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "median_time_to_close_days": 3.1361882716049383
+      "median_time_to_close_days": 3.114158950617284
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "median_time_to_close_days": 3.374810956790123
+      "median_time_to_close_days": 3.352781635802469
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5290,17 +5330,17 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-06-01",
-      "median_time_to_close_days": 8.123043981481482
+      "median_time_to_close_days": 8.108653549382717
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-07-01",
-      "median_time_to_close_days": 15.106759259259258
+      "median_time_to_close_days": 15.092368827160493
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-08-01",
-      "median_time_to_close_days": 11.381682098765431
+      "median_time_to_close_days": 11.367291666666667
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -5395,62 +5435,62 @@
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "median_time_to_close_days": 0.25631944444444443
+      "median_time_to_close_days": 0.2727546296296296
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "median_time_to_close_days": 0.6568981481481482
+      "median_time_to_close_days": 0.6974131944444444
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "median_time_to_close_days": 1.313846450617284
+      "median_time_to_close_days": 1.3408564814814816
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "median_time_to_close_days": 4.1393865740740745
+      "median_time_to_close_days": 4.206909722222222
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "median_time_to_close_days": 4.171597222222222
+      "median_time_to_close_days": 4.120663580246913
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "median_time_to_close_days": 5.401967592592592
+      "median_time_to_close_days": 4.94789737654321
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "median_time_to_close_days": 3.090779320987654
+      "median_time_to_close_days": 2.7173070987654326
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "median_time_to_close_days": 3.6583969907407408
+      "median_time_to_close_days": 3.4682445987654322
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "median_time_to_close_days": 2.0884085648148147
+      "median_time_to_close_days": 2.2226929012345678
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "median_time_to_close_days": 3.077145061728395
+      "median_time_to_close_days": 2.7504301697530864
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "median_time_to_close_days": 25.907887731481484
+      "median_time_to_close_days": 25.15259452160494
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "median_time_to_close_days": 26.407521219135806
+      "median_time_to_close_days": 25.40023726851852
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5470,7 +5510,7 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "median_time_to_close_days": 1.4582754629629628
+      "median_time_to_close_days": 1.4569251543209878
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5485,17 +5525,17 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "median_time_to_close_days": 7.004349922839506
+      "median_time_to_close_days": 7.114668209876544
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-06-01",
-      "median_time_to_close_days": 12.326493055555554
+      "median_time_to_close_days": 12.436811342592591
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-07-01",
-      "median_time_to_close_days": 8.150283564814815
+      "median_time_to_close_days": 8.260601851851852
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5520,57 +5560,57 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "median_time_to_close_days": 23.395663580246914
+      "median_time_to_close_days": 18.880248842592593
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "median_time_to_close_days": 68.8471662808642
+      "median_time_to_close_days": 64.33175154320988
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "median_time_to_close_days": 70.36121720679013
+      "median_time_to_close_days": 65.8458024691358
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "median_time_to_close_days": 54.35861304012346
+      "median_time_to_close_days": 53.93693479938272
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-08-01",
-      "median_time_to_close_days": 38.11503279320988
+      "median_time_to_close_days": 37.69335455246914
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-09-01",
-      "median_time_to_close_days": 39.31904899691358
+      "median_time_to_close_days": 38.89737075617284
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-10-01",
-      "median_time_to_close_days": 43.69781442901235
+      "median_time_to_close_days": 44.93656057098766
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-11-01",
-      "median_time_to_close_days": 17.373904320987652
+      "median_time_to_close_days": 18.61265046296296
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-12-01",
-      "median_time_to_close_days": 56.29499421296297
+      "median_time_to_close_days": 69.0449575617284
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "median_time_to_close_days": 51.24316165123457
+      "median_time_to_close_days": 62.754378858024694
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "median_time_to_close_days": 51.0446199845679
+      "median_time_to_close_days": 62.2504475308642
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -5595,102 +5635,102 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "median_time_to_close_days": 4.275061728395062
+      "median_time_to_close_days": 3.883966049382716
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "median_time_to_close_days": 3.9531192129629633
+      "median_time_to_close_days": 3.466375385802469
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "median_time_to_close_days": 3.9691917438271602
+      "median_time_to_close_days": 3.4824479166666666
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "median_time_to_close_days": 12.752721836419752
+      "median_time_to_close_days": 11.794899691358024
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "median_time_to_close_days": 29.95007523148148
+      "median_time_to_close_days": 29.22784336419753
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "median_time_to_close_days": 31.99496527777778
+      "median_time_to_close_days": 29.40886766975309
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "median_time_to_close_days": 29.168991126543208
+      "median_time_to_close_days": 26.85058834876543
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "median_time_to_close_days": 12.737679398148147
+      "median_time_to_close_days": 10.997729552469137
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "median_time_to_close_days": 10.511599151234568
+      "median_time_to_close_days": 10.635515046296296
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "median_time_to_close_days": 3.923904320987654
+      "median_time_to_close_days": 4.796342592592592
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "median_time_to_close_days": 4.389712577160494
+      "median_time_to_close_days": 4.441385030864198
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "median_time_to_close_days": 4.907274305555556
+      "median_time_to_close_days": 5.0063503086419745
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "median_time_to_close_days": 5.935229552469136
+      "median_time_to_close_days": 5.849297839506172
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "median_time_to_close_days": 6.1151022376543205
+      "median_time_to_close_days": 5.735976080246914
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "median_time_to_close_days": 5.541417824074074
+      "median_time_to_close_days": 5.026111111111111
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "median_time_to_close_days": 5.776911651234568
+      "median_time_to_close_days": 4.644301697530864
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "median_time_to_close_days": 5.460412808641975
+      "median_time_to_close_days": 4.50391975308642
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "median_time_to_close_days": 19.673084490740738
+      "median_time_to_close_days": 23.186315586419752
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "median_time_to_close_days": 19.825854552469135
+      "median_time_to_close_days": 25.382272376543213
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "median_time_to_close_days": 19.892393904320986
+      "median_time_to_close_days": 25.48037808641975
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -5885,12 +5925,12 @@
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2026-01-01",
-      "median_time_to_close_days": 3.7287712191358025
+      "median_time_to_close_days": 3.6656944444444446
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2026-02-01",
-      "median_time_to_close_days": 4.141394675925926
+      "median_time_to_close_days": 4.078317901234568
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
@@ -6170,17 +6210,17 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "median_time_to_close_days": 13.681722608024693
+      "median_time_to_close_days": 14.496577932098766
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "median_time_to_close_days": 6.136500771604939
+      "median_time_to_close_days": 6.951356095679013
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "median_time_to_close_days": 13.605590277777777
+      "median_time_to_close_days": 14.420445601851851
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6195,62 +6235,62 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "median_time_to_close_days": 6.048545524691359
+      "median_time_to_close_days": 6.083491512345678
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "median_time_to_close_days": 5.350119598765431
+      "median_time_to_close_days": 5.424708719135803
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "median_time_to_close_days": 6.045046296296296
+      "median_time_to_close_days": 6.928242669753086
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "median_time_to_close_days": 8.547854938271605
+      "median_time_to_close_days": 9.396105324074075
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "median_time_to_close_days": 10.308406635802468
+      "median_time_to_close_days": 11.83484760802469
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "median_time_to_close_days": 9.02653549382716
+      "median_time_to_close_days": 9.77081211419753
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "median_time_to_close_days": 5.291030092592592
+      "median_time_to_close_days": 6.0937422839506175
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "median_time_to_close_days": 3.472299382716049
+      "median_time_to_close_days": 3.587739197530864
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "median_time_to_close_days": 4.468090277777778
+      "median_time_to_close_days": 5.444537037037037
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "median_time_to_close_days": 6.269481095679012
+      "median_time_to_close_days": 7.5218846450617285
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "median_time_to_close_days": 11.769490740740741
+      "median_time_to_close_days": 13.138703703703705
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "median_time_to_close_days": 12.007602237654323
+      "median_time_to_close_days": 12.917179783950617
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -6380,27 +6420,32 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "median_time_to_close_days": 0.03725983796296296
+      "median_time_to_close_days": 0.03777777777777778
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "median_time_to_close_days": 0.032991898148148145
+      "median_time_to_close_days": 0.03352237654320988
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "median_time_to_close_days": 0.7573283179012346
+      "median_time_to_close_days": 0.05042824074074074
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-03-01",
-      "median_time_to_close_days": 96.62885030864197
+      "median_time_to_close_days": 95.92160493827159
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-05-01",
+      "median_time_to_close_days": 96.04288580246913
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-06-01",
-      "median_time_to_close_days": 96.62142746913578
+      "median_time_to_close_days": 96.01735725308642
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -6525,17 +6570,17 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "median_time_to_close_days": 1.4162847222222221
+      "median_time_to_close_days": 2.4153067129629626
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "median_time_to_close_days": 2.5218692129629625
+      "median_time_to_close_days": 3.021380208333333
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "median_time_to_close_days": 2.911929012345679
+      "median_time_to_close_days": 3.244936342592592
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6545,107 +6590,107 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "median_time_to_close_days": 3.326041666666667
+      "median_time_to_close_days": 3.3364062499999996
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "median_time_to_close_days": 2.811338734567901
+      "median_time_to_close_days": 2.7965297067901234
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "median_time_to_close_days": 2.385150462962963
+      "median_time_to_close_days": 2.3133661265432095
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "median_time_to_close_days": 3.002974537037037
+      "median_time_to_close_days": 2.7065239197530864
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "median_time_to_close_days": 7.625806327160493
+      "median_time_to_close_days": 7.197145061728396
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "median_time_to_close_days": 7.8675887345679
+      "median_time_to_close_days": 7.425659722222222
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "median_time_to_close_days": 7.380256558641975
+      "median_time_to_close_days": 7.351593364197531
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "median_time_to_close_days": 4.237814429012346
+      "median_time_to_close_days": 3.85188850308642
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "median_time_to_close_days": 14.816961805555556
+      "median_time_to_close_days": 14.226194058641974
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "median_time_to_close_days": 14.374569830246914
+      "median_time_to_close_days": 13.584837962962963
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "median_time_to_close_days": 25.344847608024693
+      "median_time_to_close_days": 26.637355324074075
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "median_time_to_close_days": 33.37519483024692
+      "median_time_to_close_days": 34.28287229938272
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "median_time_to_close_days": 40.45119020061728
+      "median_time_to_close_days": 44.50475887345679
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "median_time_to_close_days": 47.33585455246914
+      "median_time_to_close_days": 50.949176311728394
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "median_time_to_close_days": 57.00675347222222
+      "median_time_to_close_days": 75.65031057098766
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "median_time_to_close_days": 87.45004629629629
+      "median_time_to_close_days": 102.94771219135804
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "median_time_to_close_days": 67.42653935185184
+      "median_time_to_close_days": 81.79685956790124
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "median_time_to_close_days": 48.47395640432098
+      "median_time_to_close_days": 57.74986111111111
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-03-01",
-      "median_time_to_close_days": 5.024618055555556
+      "median_time_to_close_days": 4.7716724537037045
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-04-01",
-      "median_time_to_close_days": 2.9229687500000003
+      "median_time_to_close_days": 2.7964959490740746
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-05-01",
-      "median_time_to_close_days": 8.386319444444444
+      "median_time_to_close_days": 8.302004243827161
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -6770,17 +6815,17 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "median_time_to_close_days": 1.3460185185185185
+      "median_time_to_close_days": 3.4815017361111114
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-06-01",
-      "median_time_to_close_days": 9.289569830246913
+      "median_time_to_close_days": 10.713225308641976
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-07-01",
-      "median_time_to_close_days": 9.91259837962963
+      "median_time_to_close_days": 11.33625385802469
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -6805,17 +6850,17 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "median_time_to_close_days": 2.881253858024691
+      "median_time_to_close_days": 2.1238792438271603
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "median_time_to_close_days": 2.8339313271604936
+      "median_time_to_close_days": 2.076556712962963
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "median_time_to_close_days": 3.639861111111111
+      "median_time_to_close_days": 2.88248649691358
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -6840,22 +6885,22 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "median_time_to_close_days": 11.130154320987655
+      "median_time_to_close_days": 12.257588734567902
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "median_time_to_close_days": 3.329166666666667
+      "median_time_to_close_days": 7.246386959876543
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "median_time_to_close_days": 12.058348765432099
+      "median_time_to_close_days": 15.975569058641973
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "median_time_to_close_days": 18.180013503086418
+      "median_time_to_close_days": 20.969799382716047
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/issue_time_to_first_response.json
+++ b/frontend/public/data/agentic-ai-momentum/issue_time_to_first_response.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T11:21:36.751359",
+    "fetched_at": "2026-04-01T07:13:57.720359",
     "schema": {
       "name": "issue_time_to_first_response",
       "description": "3-month trailing average of the monthly median time to first response (hours) per repo.",
@@ -150,102 +150,107 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 347.4659722222222
+      "median_time_to_first_response_hours": 120.50638888888889
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 174.65812499999998
+      "median_time_to_first_response_hours": 61.71513888888889
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-05-01",
+      "median_time_to_first_response_hours": 44.31064814814815
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 117.69828703703702
+      "median_time_to_first_response_hours": 6.193657407407407
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 9.953796296296296
+      "median_time_to_first_response_hours": 10.443657407407407
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 13.091018518518519
+      "median_time_to_first_response_hours": 13.446805555555555
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 14.250370370370371
+      "median_time_to_first_response_hours": 13.813888888888888
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 12.607916666666668
+      "median_time_to_first_response_hours": 17.131851851851852
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 10.468935185185186
+      "median_time_to_first_response_hours": 12.57648148148148
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 8.057083333333333
+      "median_time_to_first_response_hours": 10.258379629629628
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 118.87546296296297
+      "median_time_to_first_response_hours": 71.9450462962963
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 147.03180555555556
+      "median_time_to_first_response_hours": 97.42689814814815
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 150.15337962962963
+      "median_time_to_first_response_hours": 100.0224074074074
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 34.04208333333333
+      "median_time_to_first_response_hours": 32.66328703703704
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 11.535000000000002
+      "median_time_to_first_response_hours": 12.160601851851851
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 13.943333333333333
+      "median_time_to_first_response_hours": 15.001249999999999
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 15.699629629629628
+      "median_time_to_first_response_hours": 13.86064814814815
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 12.250648148148146
+      "median_time_to_first_response_hours": 11.081759259259258
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 10.69699074074074
+      "median_time_to_first_response_hours": 9.956157407407408
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 25.423935185185183
+      "median_time_to_first_response_hours": 25.851990740740742
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 44.2099537037037
+      "median_time_to_first_response_hours": 44.63800925925926
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
@@ -375,22 +380,22 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 14.924398148148148
+      "median_time_to_first_response_hours": 14.952546296296296
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 0.3827777777777778
+      "median_time_to_first_response_hours": 0.22833333333333333
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 31.202569444444443
+      "median_time_to_first_response_hours": 31.12534722222222
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 26.076157407407408
+      "median_time_to_first_response_hours": 26.024675925925923
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -405,17 +410,17 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 71.97814814814815
+      "median_time_to_first_response_hours": 58.144814814814815
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 53.106481481481474
+      "median_time_to_first_response_hours": 39.273148148148145
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 30.899583333333336
+      "median_time_to_first_response_hours": 17.06625
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -425,62 +430,62 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 49.02064814814815
+      "median_time_to_first_response_hours": 46.80032407407407
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 44.3949537037037
+      "median_time_to_first_response_hours": 40.14407407407407
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 33.029953703703704
+      "median_time_to_first_response_hours": 29.777546296296293
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 40.12916666666667
+      "median_time_to_first_response_hours": 39.09708333333334
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 34.76277777777778
+      "median_time_to_first_response_hours": 36.988703703703706
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 57.47486111111112
+      "median_time_to_first_response_hours": 72.64916666666666
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 62.369861111111106
+      "median_time_to_first_response_hours": 77.54416666666667
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 60.331250000000004
+      "median_time_to_first_response_hours": 74.30226851851852
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 43.13175925925926
+      "median_time_to_first_response_hours": 40.894814814814815
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 12.71199074074074
+      "median_time_to_first_response_hours": 10.475046296296297
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 22.26648148148148
+      "median_time_to_first_response_hours": 16.482824074074074
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 17.034675925925928
+      "median_time_to_first_response_hours": 14.518472222222222
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -690,42 +695,52 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 6.785416666666666
+      "median_time_to_first_response_hours": 8.806666666666667
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 8.045902777777778
+      "median_time_to_first_response_hours": 9.488472222222223
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-09-01",
+      "median_time_to_first_response_hours": 6.398518518518519
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 5.386342592592594
+      "median_time_to_first_response_hours": 3.485462962962963
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-11-01",
+      "median_time_to_first_response_hours": 2.4789814814814815
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 10.82712962962963
+      "median_time_to_first_response_hours": 10.108703703703704
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 8.78111111111111
+      "median_time_to_first_response_hours": 11.142314814814815
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 32.03824074074074
+      "median_time_to_first_response_hours": 110.66462962962963
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 74.1112037037037
+      "median_time_to_first_response_hours": 152.7375925925926
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 113.55907407407408
+      "median_time_to_first_response_hours": 192.18546296296293
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -740,127 +755,127 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 228.0048148148148
+      "median_time_to_first_response_hours": 209.7187962962963
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 2.237222222222222
+      "median_time_to_first_response_hours": 1.8775
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 1.6851388888888887
+      "median_time_to_first_response_hours": 1.469861111111111
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 2.3605555555555555
+      "median_time_to_first_response_hours": 2.283240740740741
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 2.0917592592592595
+      "median_time_to_first_response_hours": 2.1353703703703704
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 2.456898148148148
+      "median_time_to_first_response_hours": 2.5470370370370374
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 4.7767129629629625
+      "median_time_to_first_response_hours": 4.659490740740741
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 5.080416666666666
+      "median_time_to_first_response_hours": 5.163101851851851
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 7.4425
+      "median_time_to_first_response_hours": 7.502268518518519
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 6.742685185185185
+      "median_time_to_first_response_hours": 6.317777777777778
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 6.528935185185186
+      "median_time_to_first_response_hours": 5.853796296296296
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 3.899768518518519
+      "median_time_to_first_response_hours": 3.184212962962963
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 1.252361111111111
+      "median_time_to_first_response_hours": 1.4157870370370371
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 0.9596296296296295
+      "median_time_to_first_response_hours": 1.2505555555555554
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 0.8652777777777777
+      "median_time_to_first_response_hours": 1.1683796296296296
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 1.0424074074074074
+      "median_time_to_first_response_hours": 1.1116666666666666
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 1.4562962962962962
+      "median_time_to_first_response_hours": 1.5516203703703706
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 2.9367592592592593
+      "median_time_to_first_response_hours": 2.8548148148148145
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 4.3758333333333335
+      "median_time_to_first_response_hours": 4.106944444444444
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 5.1887037037037045
+      "median_time_to_first_response_hours": 4.743009259259259
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 5.768796296296297
+      "median_time_to_first_response_hours": 4.556481481481481
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 14.627407407407409
+      "median_time_to_first_response_hours": 12.924861111111111
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 17.976666666666667
+      "median_time_to_first_response_hours": 16.094074074074076
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 20.15787037037037
+      "median_time_to_first_response_hours": 19.00888888888889
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 16.185092592592593
+      "median_time_to_first_response_hours": 15.705740740740742
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -985,32 +1000,32 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 55.685694444444444
+      "median_time_to_first_response_hours": 39.23111111111111
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 30.361527777777777
+      "median_time_to_first_response_hours": 22.72597222222222
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 23.873055555555556
+      "median_time_to_first_response_hours": 18.782685185185183
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 17.964027777777776
+      "median_time_to_first_response_hours": 21.127314814814813
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 22.11537037037037
+      "median_time_to_first_response_hours": 24.88416666666667
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 25.684074074074076
+      "median_time_to_first_response_hours": 28.452870370370373
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1025,52 +1040,52 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 8.432685185185186
+      "median_time_to_first_response_hours": 8.512083333333335
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 7.187037037037037
+      "median_time_to_first_response_hours": 7.287916666666667
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 40.954490740740745
+      "median_time_to_first_response_hours": 8.058842592592592
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 42.781851851851854
+      "median_time_to_first_response_hours": 9.806805555555556
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 47.97342592592593
+      "median_time_to_first_response_hours": 17.74550925925926
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 14.716805555555558
+      "median_time_to_first_response_hours": 17.485416666666666
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 42.20425925925926
+      "median_time_to_first_response_hours": 44.97287037037037
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 39.41935185185185
+      "median_time_to_first_response_hours": 40.766018518518514
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 55.38962962962963
+      "median_time_to_first_response_hours": 56.736296296296295
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 44.93412037037037
+      "median_time_to_first_response_hours": 46.28078703703704
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1095,12 +1110,12 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 255.57305555555556
+      "median_time_to_first_response_hours": 248.11305555555555
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 240.44194444444443
+      "median_time_to_first_response_hours": 238.93527777777777
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -1320,7 +1335,7 @@
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 172.90412037037038
+      "median_time_to_first_response_hours": 174.36685185185186
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
@@ -1535,87 +1550,87 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 11.700740740740741
+      "median_time_to_first_response_hours": 11.943148148148149
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 7.856944444444444
+      "median_time_to_first_response_hours": 5.669305555555556
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 11.249166666666667
+      "median_time_to_first_response_hours": 8.079375
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 12.209074074074074
+      "median_time_to_first_response_hours": 10.004907407407407
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 18.136157407407406
+      "median_time_to_first_response_hours": 16.715277777777775
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 16.268194444444443
+      "median_time_to_first_response_hours": 16.987268518518515
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 15.244768518518518
+      "median_time_to_first_response_hours": 15.753333333333332
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 8.149259259259258
+      "median_time_to_first_response_hours": 8.396805555555556
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 8.221851851851852
+      "median_time_to_first_response_hours": 7.16462962962963
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 5.316481481481481
+      "median_time_to_first_response_hours": 4.516435185185185
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 7.45388888888889
+      "median_time_to_first_response_hours": 6.770277777777778
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 10.770740740740742
+      "median_time_to_first_response_hours": 13.090787037037037
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 13.61101851851852
+      "median_time_to_first_response_hours": 16.358425925925925
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 18.729074074074074
+      "median_time_to_first_response_hours": 21.65476851851852
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 28.86101851851852
+      "median_time_to_first_response_hours": 29.331851851851855
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 31.710185185185185
+      "median_time_to_first_response_hours": 30.64342592592593
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 37.036203703703706
+      "median_time_to_first_response_hours": 34.180092592592594
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1625,117 +1640,117 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 66.47701388888889
+      "median_time_to_first_response_hours": 110.50805555555556
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 148.16518518518518
+      "median_time_to_first_response_hours": 161.65351851851852
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 241.93527777777777
+      "median_time_to_first_response_hours": 248.48037037037037
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 238.94995370370373
+      "median_time_to_first_response_hours": 216.25041666666667
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 178.31055555555557
+      "median_time_to_first_response_hours": 171.47671296296298
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 144.78009259259258
+      "median_time_to_first_response_hours": 136.55652777777777
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 112.64712962962962
+      "median_time_to_first_response_hours": 105.98518518518519
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 77.31620370370369
+      "median_time_to_first_response_hours": 70.5138425925926
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 20.03175925925926
+      "median_time_to_first_response_hours": 21.562361111111112
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 36.01217592592592
+      "median_time_to_first_response_hours": 35.85773148148149
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 34.69828703703704
+      "median_time_to_first_response_hours": 34.64453703703703
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 28.2675462962963
+      "median_time_to_first_response_hours": 28.922407407407405
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 14.351296296296297
+      "median_time_to_first_response_hours": 14.00861111111111
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 22.807083333333335
+      "median_time_to_first_response_hours": 22.19212962962963
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 38.24476851851852
+      "median_time_to_first_response_hours": 33.20342592592593
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 51.683194444444446
+      "median_time_to_first_response_hours": 40.99953703703704
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 44.77407407407407
+      "median_time_to_first_response_hours": 38.42638888888889
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 42.702638888888885
+      "median_time_to_first_response_hours": 50.112175925925925
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 31.588009259259263
+      "median_time_to_first_response_hours": 43.76069444444445
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 29.515324074074073
+      "median_time_to_first_response_hours": 36.364953703703705
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 19.934444444444445
+      "median_time_to_first_response_hours": 16.13763888888889
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 18.1775
+      "median_time_to_first_response_hours": 16.271435185185187
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 22.418796296296296
+      "median_time_to_first_response_hours": 29.00708333333333
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -1975,82 +1990,82 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 3.93125
+      "median_time_to_first_response_hours": 4.4551388888888885
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 3.800231481481481
+      "median_time_to_first_response_hours": 4.324120370370371
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 3.6484259259259257
+      "median_time_to_first_response_hours": 4.255740740740741
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 3.242314814814815
+      "median_time_to_first_response_hours": 4.040277777777778
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 3.1233333333333335
+      "median_time_to_first_response_hours": 3.957222222222222
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 5.5740740740740735
+      "median_time_to_first_response_hours": 4.13824074074074
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 6.8176851851851845
+      "median_time_to_first_response_hours": 4.7662962962962965
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 7.779629629629629
+      "median_time_to_first_response_hours": 5.379444444444445
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 12.774166666666668
+      "median_time_to_first_response_hours": 9.786203703703704
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 10.530601851851852
+      "median_time_to_first_response_hours": 7.483240740740741
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 22.45328703703704
+      "median_time_to_first_response_hours": 13.691990740740742
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 15.60875
+      "median_time_to_first_response_hours": 10.00449074074074
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 20.36925925925926
+      "median_time_to_first_response_hours": 16.45486111111111
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 9.723333333333333
+      "median_time_to_first_response_hours": 10.030555555555555
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 12.790925925925926
+      "median_time_to_first_response_hours": 12.715185185185184
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 14.083472222222222
+      "median_time_to_first_response_hours": 8.293148148148148
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2065,112 +2080,112 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 6.560277777777777
+      "median_time_to_first_response_hours": 5.315648148148148
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 4.855555555555555
+      "median_time_to_first_response_hours": 3.610925925925926
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 35.934999999999995
+      "median_time_to_first_response_hours": 14.558703703703705
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 35.36944444444445
+      "median_time_to_first_response_hours": 20.49398148148148
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 52.76583333333334
+      "median_time_to_first_response_hours": 33.37185185185185
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 27.506574074074077
+      "median_time_to_first_response_hours": 33.2387037037037
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 38.34291666666667
+      "median_time_to_first_response_hours": 38.818842592592596
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 28.493009259259257
+      "median_time_to_first_response_hours": 33.4874537037037
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 29.486064814814814
+      "median_time_to_first_response_hours": 29.56699074074074
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 35.498333333333335
+      "median_time_to_first_response_hours": 39.43388888888889
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 29.34523148148148
+      "median_time_to_first_response_hours": 34.539351851851855
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 27.00236111111111
+      "median_time_to_first_response_hours": 45.505324074074075
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 13.341620370370372
+      "median_time_to_first_response_hours": 27.35134259259259
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 18.274398148148148
+      "median_time_to_first_response_hours": 31.597731481481485
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 24.051990740740745
+      "median_time_to_first_response_hours": 23.29287037037037
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 33.171527777777776
+      "median_time_to_first_response_hours": 33.05101851851852
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 34.0275
+      "median_time_to_first_response_hours": 33.33481481481481
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 41.1562962962963
+      "median_time_to_first_response_hours": 37.59685185185185
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 49.51657407407407
+      "median_time_to_first_response_hours": 45.95712962962963
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 58.180416666666666
+      "median_time_to_first_response_hours": 54.62097222222223
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 45.47486111111112
+      "median_time_to_first_response_hours": 44.97773148148148
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 76.85717592592593
+      "median_time_to_first_response_hours": 76.36004629629629
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2290,7 +2305,7 @@
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 3.1457870370370373
+      "median_time_to_first_response_hours": 3.182592592592593
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
@@ -2415,117 +2430,117 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 5.183055555555556
+      "median_time_to_first_response_hours": 5.429444444444444
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 5.878402777777778
+      "median_time_to_first_response_hours": 6.001597222222221
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 7.55050925925926
+      "median_time_to_first_response_hours": 7.783240740740741
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 7.383101851851852
+      "median_time_to_first_response_hours": 7.533703703703703
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 13.947037037037036
+      "median_time_to_first_response_hours": 14.245138888888889
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 15.770879629629631
+      "median_time_to_first_response_hours": 16.889120370370367
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 17.335740740740743
+      "median_time_to_first_response_hours": 19.136898148148145
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 15.317546296296298
+      "median_time_to_first_response_hours": 17.575972222222223
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 10.157314814814816
+      "median_time_to_first_response_hours": 11.499166666666667
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 11.030972222222223
+      "median_time_to_first_response_hours": 11.689907407407409
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 5.13287037037037
+      "median_time_to_first_response_hours": 5.052314814814815
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 4.887037037037037
+      "median_time_to_first_response_hours": 4.752314814814815
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 6.041851851851852
+      "median_time_to_first_response_hours": 5.90712962962963
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 10.309537037037037
+      "median_time_to_first_response_hours": 10.550324074074073
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 11.489259259259258
+      "median_time_to_first_response_hours": 11.719768518518519
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 6.699907407407408
+      "median_time_to_first_response_hours": 6.930416666666666
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 14.852685185185186
+      "median_time_to_first_response_hours": 11.193148148148147
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 13.633425925925925
+      "median_time_to_first_response_hours": 10.294305555555555
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 18.74800925925926
+      "median_time_to_first_response_hours": 17.73138888888889
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 6.334537037037037
+      "median_time_to_first_response_hours": 9.861712962962963
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 11.75060185185185
+      "median_time_to_first_response_hours": 15.619351851851851
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 9.40462962962963
+      "median_time_to_first_response_hours": 14.83384259259259
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 26.919398148148147
+      "median_time_to_first_response_hours": 30.241481481481483
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2740,152 +2755,152 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 12.21662037037037
+      "median_time_to_first_response_hours": 6.316481481481482
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 9.711388888888889
+      "median_time_to_first_response_hours": 9.606111111111112
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 13.645694444444445
+      "median_time_to_first_response_hours": 12.622361111111111
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 20.5725
+      "median_time_to_first_response_hours": 19.748935185185186
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 26.74851851851852
+      "median_time_to_first_response_hours": 24.591805555555556
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 25.26212962962963
+      "median_time_to_first_response_hours": 25.675833333333333
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 24.542037037037037
+      "median_time_to_first_response_hours": 38.96050925925926
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 37.19916666666667
+      "median_time_to_first_response_hours": 50.27337962962963
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 40.802268518518524
+      "median_time_to_first_response_hours": 54.66101851851852
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 42.9713425925926
+      "median_time_to_first_response_hours": 45.20342592592593
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 28.37611111111111
+      "median_time_to_first_response_hours": 37.62430555555556
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 31.53912037037037
+      "median_time_to_first_response_hours": 37.39319444444445
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 12.37138888888889
+      "median_time_to_first_response_hours": 10.461944444444445
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 9.470277777777778
+      "median_time_to_first_response_hours": 6.818333333333333
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 9.517592592592592
+      "median_time_to_first_response_hours": 7.74962962962963
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 5.904212962962963
+      "median_time_to_first_response_hours": 4.821296296296296
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 5.567175925925926
+      "median_time_to_first_response_hours": 5.658703703703703
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 4.162083333333333
+      "median_time_to_first_response_hours": 4.248518518518519
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 4.625972222222223
+      "median_time_to_first_response_hours": 5.331574074074074
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 4.655601851851852
+      "median_time_to_first_response_hours": 5.536944444444444
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 5.653009259259259
+      "median_time_to_first_response_hours": 16.614814814814814
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 9.299999999999999
+      "median_time_to_first_response_hours": 20.413055555555555
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 40.97574074074074
+      "median_time_to_first_response_hours": 20.599907407407407
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 53.673611111111114
+      "median_time_to_first_response_hours": 23.222407407407406
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 49.2612962962963
+      "median_time_to_first_response_hours": 38.02722222222223
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 24.77587962962963
+      "median_time_to_first_response_hours": 44.81199074074075
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 21.918796296296296
+      "median_time_to_first_response_hours": 30.008935185185184
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 23.658055555555553
+      "median_time_to_first_response_hours": 10.970277777777776
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 16.09189814814815
+      "median_time_to_first_response_hours": 3.40412037037037
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 3.4735185185185187
+      "median_time_to_first_response_hours": 2.731712962962963
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2895,27 +2910,27 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 32.10472222222222
+      "median_time_to_first_response_hours": 31.774768518518517
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 39.67337962962963
+      "median_time_to_first_response_hours": 39.34342592592592
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 61.95078703703703
+      "median_time_to_first_response_hours": 15.949444444444444
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 60.44837962962962
+      "median_time_to_first_response_hours": 14.776990740740741
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 96.33296296296295
+      "median_time_to_first_response_hours": 65.77185185185185
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -2990,7 +3005,7 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 264.4322685185185
+      "median_time_to_first_response_hours": 273.9462037037037
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3045,17 +3060,17 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 9.505925925925926
+      "median_time_to_first_response_hours": 9.556064814814816
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 9.04787037037037
+      "median_time_to_first_response_hours": 9.098009259259259
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 7.664814814814815
+      "median_time_to_first_response_hours": 7.714953703703704
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3230,7 +3245,7 @@
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 1.8449074074074074
+      "median_time_to_first_response_hours": 1.819675925925926
     },
     {
       "repo": "https://github.com/janhq/jan",
@@ -3354,18 +3369,28 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-03-01",
+      "median_time_to_first_response_hours": 46.73777777777778
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 104.72777777777777
+      "median_time_to_first_response_hours": 139.28076388888888
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-07-01",
+      "median_time_to_first_response_hours": 100.36759259259259
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 105.06555555555556
+      "median_time_to_first_response_hours": 119.92277777777777
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 70.06175925925926
+      "median_time_to_first_response_hours": 42.66625
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -3379,8 +3404,13 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-07-01",
+      "median_time_to_first_response_hours": 118.44509259259259
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 55.69652777777778
+      "median_time_to_first_response_hours": 168.9801388888889
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -3860,7 +3890,7 @@
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 22.00763888888889
+      "median_time_to_first_response_hours": 22.059490740740742
     },
     {
       "repo": "https://github.com/letta-ai/letta",
@@ -3990,117 +4020,117 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 150.5353472222222
+      "median_time_to_first_response_hours": 147.23659722222223
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 115.89476851851852
+      "median_time_to_first_response_hours": 113.30569444444444
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 29.055185185185184
+      "median_time_to_first_response_hours": 26.49884259259259
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 21.721574074074073
+      "median_time_to_first_response_hours": 19.116527777777776
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 14.426111111111112
+      "median_time_to_first_response_hours": 12.210972222222223
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 19.88486111111111
+      "median_time_to_first_response_hours": 17.636990740740742
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 19.062685185185185
+      "median_time_to_first_response_hours": 18.080416666666668
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 16.823703703703703
+      "median_time_to_first_response_hours": 16.697777777777777
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 15.980231481481482
+      "median_time_to_first_response_hours": 17.2474537037037
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 19.592037037037038
+      "median_time_to_first_response_hours": 19.58791666666667
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 19.046111111111113
+      "median_time_to_first_response_hours": 17.096759259259258
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 15.005046296296298
+      "median_time_to_first_response_hours": 12.050092592592593
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 9.280601851851852
+      "median_time_to_first_response_hours": 8.797638888888889
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 5.375231481481482
+      "median_time_to_first_response_hours": 5.63375
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 5.090277777777778
+      "median_time_to_first_response_hours": 5.280648148148148
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 5.400555555555556
+      "median_time_to_first_response_hours": 5.593009259259259
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 8.470694444444444
+      "median_time_to_first_response_hours": 7.994305555555556
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 6.934814814814814
+      "median_time_to_first_response_hours": 6.5334259259259255
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 7.0938888888888885
+      "median_time_to_first_response_hours": 6.550370370370371
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 5.323842592592593
+      "median_time_to_first_response_hours": 5.916111111111111
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 6.967083333333334
+      "median_time_to_first_response_hours": 6.905925925925925
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 7.708935185185186
+      "median_time_to_first_response_hours": 7.398333333333333
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 11.988750000000001
+      "median_time_to_first_response_hours": 11.663287037037037
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4120,132 +4150,142 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 3.4427777777777777
+      "median_time_to_first_response_hours": 3.4306944444444447
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 5.54462962962963
+      "median_time_to_first_response_hours": 5.425833333333333
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 8.23486111111111
+      "median_time_to_first_response_hours": 8.010833333333332
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 15.401574074074075
+      "median_time_to_first_response_hours": 15.189629629629628
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 20.247592592592593
+      "median_time_to_first_response_hours": 20.03824074074074
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 23.838333333333335
+      "median_time_to_first_response_hours": 23.71638888888889
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 29.177314814814817
+      "median_time_to_first_response_hours": 29.10287037037037
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 28.66111111111111
+      "median_time_to_first_response_hours": 28.627037037037038
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 28.18800925925926
+      "median_time_to_first_response_hours": 28.233796296296294
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 29.26564814814815
+      "median_time_to_first_response_hours": 15.586481481481483
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 23.840833333333336
+      "median_time_to_first_response_hours": 7.543611111111112
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 20.990925925925925
+      "median_time_to_first_response_hours": 0.42333333333333334
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 8.711157407407407
+      "median_time_to_first_response_hours": 0.011851851851851851
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 16.189722222222223
+      "median_time_to_first_response_hours": 16.05902777777778
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 20.870555555555555
+      "median_time_to_first_response_hours": 22.024583333333332
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 21.27138888888889
+      "median_time_to_first_response_hours": 22.04074074074074
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 16.488055555555555
+      "median_time_to_first_response_hours": 17.30097222222222
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 19.583518518518517
+      "median_time_to_first_response_hours": 15.581944444444444
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 12.719490740740738
+      "median_time_to_first_response_hours": 9.337546296296296
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 12.627824074074072
+      "median_time_to_first_response_hours": 8.752268518518518
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 7.165509259259259
+      "median_time_to_first_response_hours": 7.291527777777778
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 6.807685185185185
+      "median_time_to_first_response_hours": 9.098425925925925
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 9.264166666666666
+      "median_time_to_first_response_hours": 13.173287037037037
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 101.27004629629629
+      "median_time_to_first_response_hours": 105.17916666666666
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 183.21671296296293
+      "median_time_to_first_response_hours": 240.88425925925927
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-10-01",
+      "median_time_to_first_response_hours": 303.54421296296294
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-12-01",
+      "median_time_to_first_response_hours": 309.6380555555556
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 180.2988425925926
+      "median_time_to_first_response_hours": 171.07296296296295
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4255,62 +4295,62 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 7.598680555555555
+      "median_time_to_first_response_hours": 6.878819444444444
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 5.971388888888889
+      "median_time_to_first_response_hours": 5.5825
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 10.548425925925926
+      "median_time_to_first_response_hours": 9.585879629629629
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 6.756851851851852
+      "median_time_to_first_response_hours": 6.959768518518518
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 19.864722222222223
+      "median_time_to_first_response_hours": 31.348055555555558
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 17.062083333333334
+      "median_time_to_first_response_hours": 28.23810185185185
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 24.695833333333336
+      "median_time_to_first_response_hours": 38.03560185185185
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 27.498101851851853
+      "median_time_to_first_response_hours": 29.466435185185187
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 28.810092592592593
+      "median_time_to_first_response_hours": 31.659398148148146
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 26.753981481481485
+      "median_time_to_first_response_hours": 32.666435185185186
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 15.64101851851852
+      "median_time_to_first_response_hours": 21.553472222222222
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 11.932314814814816
+      "median_time_to_first_response_hours": 17.844768518518517
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4465,102 +4505,102 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 9.246805555555556
+      "median_time_to_first_response_hours": 9.614212962962963
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 8.606712962962964
+      "median_time_to_first_response_hours": 8.922453703703704
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 14.225416666666666
+      "median_time_to_first_response_hours": 17.77837962962963
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 21.17657407407407
+      "median_time_to_first_response_hours": 27.756481481481483
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 30.58037037037037
+      "median_time_to_first_response_hours": 36.90611111111111
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 34.75717592592593
+      "median_time_to_first_response_hours": 37.84569444444444
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 45.49314814814815
+      "median_time_to_first_response_hours": 45.18731481481482
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 46.49296296296296
+      "median_time_to_first_response_hours": 38.97768518518519
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 45.768379629629635
+      "median_time_to_first_response_hours": 37.94337962962963
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 52.77916666666667
+      "median_time_to_first_response_hours": 46.58726851851852
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 64.37726851851852
+      "median_time_to_first_response_hours": 43.66902777777778
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 109.7963888888889
+      "median_time_to_first_response_hours": 90.16476851851853
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 188.9613888888889
+      "median_time_to_first_response_hours": 102.52166666666666
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 214.2285648148148
+      "median_time_to_first_response_hours": 149.82046296296298
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 199.86092592592593
+      "median_time_to_first_response_hours": 134.68592592592594
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 115.0174074074074
+      "median_time_to_first_response_hours": 99.25925925925925
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 112.3974537037037
+      "median_time_to_first_response_hours": 96.63930555555555
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 172.42337962962964
+      "median_time_to_first_response_hours": 133.97194444444443
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 205.22273148148147
+      "median_time_to_first_response_hours": 182.52944444444447
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 173.8087037037037
+      "median_time_to_first_response_hours": 144.47800925925927
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -4685,122 +4725,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 12.92
+      "median_time_to_first_response_hours": 12.560277777777777
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 15.270277777777778
+      "median_time_to_first_response_hours": 14.304791666666667
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 13.225462962962963
+      "median_time_to_first_response_hours": 12.950787037037037
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 14.216064814814814
+      "median_time_to_first_response_hours": 13.804722222222223
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 12.013888888888888
+      "median_time_to_first_response_hours": 12.654351851851851
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 17.48037037037037
+      "median_time_to_first_response_hours": 17.546666666666667
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 17.31939814814815
+      "median_time_to_first_response_hours": 17.199953703703702
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 18.712962962962962
+      "median_time_to_first_response_hours": 17.63675925925926
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 13.417499999999999
+      "median_time_to_first_response_hours": 12.59425925925926
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 13.534259259259258
+      "median_time_to_first_response_hours": 13.811018518518518
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 18.469953703703705
+      "median_time_to_first_response_hours": 18.085462962962964
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 20.350231481481483
+      "median_time_to_first_response_hours": 18.99138888888889
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 24.566435185185185
+      "median_time_to_first_response_hours": 20.755277777777778
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 27.54398148148148
+      "median_time_to_first_response_hours": 20.707916666666666
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 26.956203703703704
+      "median_time_to_first_response_hours": 20.823287037037037
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 24.869537037037038
+      "median_time_to_first_response_hours": 21.717083333333335
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 20.496574074074072
+      "median_time_to_first_response_hours": 23.745
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 22.23
+      "median_time_to_first_response_hours": 26.38138888888889
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 45.99462962962963
+      "median_time_to_first_response_hours": 45.80916666666667
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 54.64134259259259
+      "median_time_to_first_response_hours": 42.43694444444444
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 59.07263888888889
+      "median_time_to_first_response_hours": 43.75787037037037
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 32.71273148148148
+      "median_time_to_first_response_hours": 41.43435185185185
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 33.94402777777778
+      "median_time_to_first_response_hours": 79.03726851851853
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 50.02939814814815
+      "median_time_to_first_response_hours": 97.55347222222223
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -4925,17 +4965,17 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 66.09027777777777
+      "median_time_to_first_response_hours": 60.149027777777775
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 159.31666666666666
+      "median_time_to_first_response_hours": 156.34604166666668
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 119.29722222222222
+      "median_time_to_first_response_hours": 117.31680555555556
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -4959,13 +4999,18 @@
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-11-01",
+      "median_time_to_first_response_hours": 172.8163888888889
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 41.98833333333334
+      "median_time_to_first_response_hours": 178.06925925925927
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 72.56722222222221
+      "median_time_to_first_response_hours": 172.41907407407408
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -5250,22 +5295,22 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 1.3247222222222221
+      "median_time_to_first_response_hours": 1.3249074074074072
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 1.3941666666666668
+      "median_time_to_first_response_hours": 1.3943518518518518
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 1.4341666666666668
+      "median_time_to_first_response_hours": 1.4422685185185184
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 1.5503703703703706
+      "median_time_to_first_response_hours": 1.5582870370370372
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5405,17 +5450,17 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 23.834351851851853
+      "median_time_to_first_response_hours": 23.75615740740741
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 3.770787037037037
+      "median_time_to_first_response_hours": 3.6925925925925926
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 3.586527777777778
+      "median_time_to_first_response_hours": 3.5083333333333333
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -5510,62 +5555,62 @@
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 2.409861111111111
+      "median_time_to_first_response_hours": 2.2575
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 4.573680555555555
+      "median_time_to_first_response_hours": 4.493541666666666
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 9.042592592592593
+      "median_time_to_first_response_hours": 7.905277777777779
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 11.672824074074073
+      "median_time_to_first_response_hours": 11.04601851851852
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 11.651527777777778
+      "median_time_to_first_response_hours": 10.62800925925926
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 6.548425925925926
+      "median_time_to_first_response_hours": 6.414351851851852
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 4.608611111111111
+      "median_time_to_first_response_hours": 3.8206018518518516
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 3.9625925925925927
+      "median_time_to_first_response_hours": 3.5607870370370365
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 4.9521296296296295
+      "median_time_to_first_response_hours": 4.751342592592592
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 4.951342592592592
+      "median_time_to_first_response_hours": 4.944768518518519
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 4.1880092592592595
+      "median_time_to_first_response_hours": 4.012361111111111
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 5.159305555555556
+      "median_time_to_first_response_hours": 4.251759259259259
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5585,22 +5630,22 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 23.808703703703703
+      "median_time_to_first_response_hours": 25.273425925925924
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 3.9034722222222222
+      "median_time_to_first_response_hours": 3.5956944444444447
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 2.617986111111111
+      "median_time_to_first_response_hours": 2.4640972222222226
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 5.631157407407407
+      "median_time_to_first_response_hours": 5.528564814814814
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5609,13 +5654,18 @@
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-08-01",
+      "median_time_to_first_response_hours": 36.44305555555555
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 25.575925925925926
+      "median_time_to_first_response_hours": 45.892037037037035
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 21.73888888888889
+      "median_time_to_first_response_hours": 37.58555555555556
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5635,42 +5685,42 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 19.42574074074074
+      "median_time_to_first_response_hours": 16.87949074074074
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 14.163148148148148
+      "median_time_to_first_response_hours": 12.058564814814815
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 22.827731481481482
+      "median_time_to_first_response_hours": 12.66777777777778
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 97.5676851851852
+      "median_time_to_first_response_hours": 89.95398148148149
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 235.6288888888889
+      "median_time_to_first_response_hours": 227.5735185185185
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 222.70699074074074
+      "median_time_to_first_response_hours": 225.23416666666665
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 146.6626388888889
+      "median_time_to_first_response_hours": 149.1898148148148
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 32.86212962962963
+      "median_time_to_first_response_hours": 35.38930555555556
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5710,102 +5760,102 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 14.331435185185185
+      "median_time_to_first_response_hours": 14.913472222222223
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 16.47689814814815
+      "median_time_to_first_response_hours": 17.87421296296296
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 63.03481481481481
+      "median_time_to_first_response_hours": 64.43212962962963
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 80.04555555555555
+      "median_time_to_first_response_hours": 77.47310185185185
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 89.24787037037036
+      "median_time_to_first_response_hours": 91.25828703703702
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 61.70861111111111
+      "median_time_to_first_response_hours": 51.11388888888889
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 44.72824074074074
+      "median_time_to_first_response_hours": 36.72578703703704
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 33.04583333333333
+      "median_time_to_first_response_hours": 19.447175925925926
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 12.102685185185186
+      "median_time_to_first_response_hours": 14.459074074074074
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 12.164722222222222
+      "median_time_to_first_response_hours": 14.300740740740741
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 9.797685185185186
+      "median_time_to_first_response_hours": 11.25861111111111
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 11.134629629629629
+      "median_time_to_first_response_hours": 16.62763888888889
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 10.35962962962963
+      "median_time_to_first_response_hours": 17.476574074074072
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 12.093703703703705
+      "median_time_to_first_response_hours": 19.499537037037037
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 16.983796296296294
+      "median_time_to_first_response_hours": 15.721157407407409
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 24.108796296296294
+      "median_time_to_first_response_hours": 23.002962962962965
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 27.523888888888887
+      "median_time_to_first_response_hours": 25.26648148148148
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 26.141296296296293
+      "median_time_to_first_response_hours": 31.008935185185184
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 15.120324074074075
+      "median_time_to_first_response_hours": 19.227175925925923
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 10.682638888888889
+      "median_time_to_first_response_hours": 16.222916666666666
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -6250,32 +6300,32 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "median_time_to_first_response_hours": 4.424027777777778
+      "median_time_to_first_response_hours": 3.026527777777778
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-04-01",
-      "median_time_to_first_response_hours": 3.9938194444444446
+      "median_time_to_first_response_hours": 3.2950694444444446
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 5.2252777777777775
+      "median_time_to_first_response_hours": 4.759444444444445
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 4.301064814814815
+      "median_time_to_first_response_hours": 4.1698611111111115
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 8.075462962962963
+      "median_time_to_first_response_hours": 7.944259259259259
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 13.430092592592592
+      "median_time_to_first_response_hours": 13.298888888888888
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6285,22 +6335,22 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 15.366249999999999
+      "median_time_to_first_response_hours": 14.673657407407406
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 8.638287037037037
+      "median_time_to_first_response_hours": 7.915555555555556
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 6.373101851851852
+      "median_time_to_first_response_hours": 5.6503703703703705
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 2.587824074074074
+      "median_time_to_first_response_hours": 2.557685185185185
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6310,62 +6360,62 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 5.1627777777777775
+      "median_time_to_first_response_hours": 4.79925925925926
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 6.179537037037036
+      "median_time_to_first_response_hours": 5.748888888888889
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 5.936805555555555
+      "median_time_to_first_response_hours": 5.359907407407408
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 3.292083333333333
+      "median_time_to_first_response_hours": 3.0787037037037037
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 4.8032407407407405
+      "median_time_to_first_response_hours": 4.656990740740741
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 5.14162037037037
+      "median_time_to_first_response_hours": 5.196527777777778
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 5.045555555555556
+      "median_time_to_first_response_hours": 5.1785648148148145
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 4.409398148148148
+      "median_time_to_first_response_hours": 4.947037037037037
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 6.641435185185185
+      "median_time_to_first_response_hours": 7.682824074074074
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 8.7825
+      "median_time_to_first_response_hours": 9.384305555555555
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 10.794907407407408
+      "median_time_to_first_response_hours": 11.508842592592591
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 7.844444444444445
+      "median_time_to_first_response_hours": 7.999722222222222
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -6509,8 +6559,18 @@
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-11-01",
+      "median_time_to_first_response_hours": 0.014259259259259258
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 136.74638888888887
+      "median_time_to_first_response_hours": 136.74416666666664
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2026-01-01",
+      "median_time_to_first_response_hours": 226.2213888888889
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -6635,17 +6695,17 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 10.657777777777778
+      "median_time_to_first_response_hours": 13.450694444444444
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 13.535277777777777
+      "median_time_to_first_response_hours": 14.93173611111111
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 14.850648148148148
+      "median_time_to_first_response_hours": 15.78162037037037
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6655,72 +6715,72 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 27.578888888888887
+      "median_time_to_first_response_hours": 27.88175925925926
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 29.518703703703704
+      "median_time_to_first_response_hours": 29.443055555555556
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 22.67740740740741
+      "median_time_to_first_response_hours": 20.49138888888889
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 21.947314814814817
+      "median_time_to_first_response_hours": 19.151851851851852
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 23.558425925925928
+      "median_time_to_first_response_hours": 20.09287037037037
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "median_time_to_first_response_hours": 24.46083333333333
+      "median_time_to_first_response_hours": 22.485370370370372
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 23.71777777777778
+      "median_time_to_first_response_hours": 20.795879629629628
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 23.661620370370372
+      "median_time_to_first_response_hours": 22.763935185185186
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 22.060046296296296
+      "median_time_to_first_response_hours": 22.13513888888889
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 34.883472222222224
+      "median_time_to_first_response_hours": 27.194814814814816
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 35.151296296296294
+      "median_time_to_first_response_hours": 26.338379629629628
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 42.461157407407406
+      "median_time_to_first_response_hours": 32.82958333333334
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 31.44125
+      "median_time_to_first_response_hours": 30.826435185185186
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 41.57888888888889
+      "median_time_to_first_response_hours": 41.11273148148148
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6740,7 +6800,7 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 63.52037037037038
+      "median_time_to_first_response_hours": 59.68199074074074
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -6880,47 +6940,47 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "median_time_to_first_response_hours": 3.468888888888889
+      "median_time_to_first_response_hours": 3.383611111111111
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-06-01",
-      "median_time_to_first_response_hours": 4.5156018518518515
+      "median_time_to_first_response_hours": 4.458749999999999
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-07-01",
-      "median_time_to_first_response_hours": 6.038333333333333
+      "median_time_to_first_response_hours": 6.30912037037037
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-08-01",
-      "median_time_to_first_response_hours": 4.385277777777778
+      "median_time_to_first_response_hours": 5.637546296296296
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-09-01",
-      "median_time_to_first_response_hours": 3.54125
+      "median_time_to_first_response_hours": 4.7935185185185185
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-10-01",
-      "median_time_to_first_response_hours": 2.84
+      "median_time_to_first_response_hours": 3.5314814814814817
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "median_time_to_first_response_hours": 8.969351851851853
+      "median_time_to_first_response_hours": 6.198425925925926
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-12-01",
-      "median_time_to_first_response_hours": 10.507777777777777
+      "median_time_to_first_response_hours": 7.736851851851852
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-01-01",
-      "median_time_to_first_response_hours": 12.433287037037038
+      "median_time_to_first_response_hours": 9.895509259259258
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -6930,62 +6990,62 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "median_time_to_first_response_hours": 35.581435185185185
+      "median_time_to_first_response_hours": 35.40625
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "median_time_to_first_response_hours": 35.864814814814814
+      "median_time_to_first_response_hours": 35.52425925925926
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "median_time_to_first_response_hours": 13.958055555555555
+      "median_time_to_first_response_hours": 10.714861111111112
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "median_time_to_first_response_hours": 145.29675925925926
+      "median_time_to_first_response_hours": 80.56532407407407
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "median_time_to_first_response_hours": 143.71064814814815
+      "median_time_to_first_response_hours": 79.14458333333333
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "median_time_to_first_response_hours": 138.87875
+      "median_time_to_first_response_hours": 77.40222222222222
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "median_time_to_first_response_hours": 6.376759259259259
+      "median_time_to_first_response_hours": 5.512777777777778
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "median_time_to_first_response_hours": 16.581666666666667
+      "median_time_to_first_response_hours": 10.24537037037037
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "median_time_to_first_response_hours": 60.70462962962963
+      "median_time_to_first_response_hours": 78.44314814814815
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "median_time_to_first_response_hours": 67.05499999999999
+      "median_time_to_first_response_hours": 80.26277777777779
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "median_time_to_first_response_hours": 55.182314814814816
+      "median_time_to_first_response_hours": 81.25527777777778
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "median_time_to_first_response_hours": 17.093009259259258
+      "median_time_to_first_response_hours": 18.90425925925926
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/new_contributors_90d.json
+++ b/frontend/public/data/agentic-ai-momentum/new_contributors_90d.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:17.573727",
+    "fetched_at": "2026-04-01T07:13:53.396860",
     "schema": {
       "name": "new_contributors_90d",
       "description": "Monthly count of contributors whose first commit was within the past 90 days.",
@@ -145,7 +145,7 @@
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 77
+      "new_contributors_90d_count": 78
     },
     {
       "repo": "https://github.com/a2aproject/A2A",
@@ -1260,17 +1260,17 @@
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 548
+      "new_contributors_90d_count": 547
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 508
+      "new_contributors_90d_count": 507
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 467
+      "new_contributors_90d_count": 466
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -1650,182 +1650,182 @@
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 110
+      "new_contributors_90d_count": 140
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 143
+      "new_contributors_90d_count": 184
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 174
+      "new_contributors_90d_count": 225
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 90
+      "new_contributors_90d_count": 120
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 102
+      "new_contributors_90d_count": 155
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 104
+      "new_contributors_90d_count": 175
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 107
+      "new_contributors_90d_count": 184
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 84
+      "new_contributors_90d_count": 131
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 64
+      "new_contributors_90d_count": 97
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 57
+      "new_contributors_90d_count": 83
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 51
+      "new_contributors_90d_count": 72
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 64
+      "new_contributors_90d_count": 81
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 55
+      "new_contributors_90d_count": 84
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 63
+      "new_contributors_90d_count": 97
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 64
+      "new_contributors_90d_count": 97
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 56
+      "new_contributors_90d_count": 87
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 50
+      "new_contributors_90d_count": 71
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 45
+      "new_contributors_90d_count": 68
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 40
+      "new_contributors_90d_count": 55
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 36
+      "new_contributors_90d_count": 50
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 27
+      "new_contributors_90d_count": 37
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 26
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 15
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 32
+      "new_contributors_90d_count": 45
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 49
+      "new_contributors_90d_count": 70
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 56
+      "new_contributors_90d_count": 75
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 51
+      "new_contributors_90d_count": 71
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 38
+      "new_contributors_90d_count": 54
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 36
+      "new_contributors_90d_count": 46
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 38
+      "new_contributors_90d_count": 52
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 44
+      "new_contributors_90d_count": 56
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 43
+      "new_contributors_90d_count": 56
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 36
+      "new_contributors_90d_count": 49
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 37
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 19
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 25
+      "new_contributors_90d_count": 31
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -1880,17 +1880,17 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 162
+      "new_contributors_90d_count": 161
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 258
+      "new_contributors_90d_count": 257
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 297
+      "new_contributors_90d_count": 296
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -2095,217 +2095,217 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 16
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 16
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 16
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 11
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 23
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 38
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 86
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 123
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 139
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 141
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 141
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 118
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 103
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 88
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 108
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-12-01",
-      "new_contributors_90d_count": 87
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-01-01",
-      "new_contributors_90d_count": 88
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-02-01",
-      "new_contributors_90d_count": 121
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-03-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 8
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 13
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 21
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 18
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 21
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 12
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 20
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
       "new_contributors_90d_count": 15
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 33
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 48
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 58
+      "new_contributors_90d_count": 103
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 69
+      "new_contributors_90d_count": 144
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 81
+      "new_contributors_90d_count": 168
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 51
+      "new_contributors_90d_count": 171
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 40
+      "new_contributors_90d_count": 172
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 31
+      "new_contributors_90d_count": 145
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 32
+      "new_contributors_90d_count": 126
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 25
+      "new_contributors_90d_count": 119
     },
     {
-      "repo": "https://github.com/camel-ai/camel",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 143
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-12-01",
+      "new_contributors_90d_count": 128
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2026-01-01",
+      "new_contributors_90d_count": 123
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2026-02-01",
+      "new_contributors_90d_count": 163
     },
     {
       "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-12-01",
+      "month": "2024-03-01",
+      "new_contributors_90d_count": 7
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 10
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-05-01",
       "new_contributors_90d_count": 19
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 33
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 33
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 36
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 24
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 37
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 36
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 38
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 83
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 97
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 111
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 79
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 67
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 57
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 46
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 38
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 36
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-12-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 25
+      "new_contributors_90d_count": 39
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 36
+      "new_contributors_90d_count": 52
     },
     {
       "repo": "https://github.com/google/adk-python",
@@ -2375,57 +2375,57 @@
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 70
+      "new_contributors_90d_count": 93
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 147
+      "new_contributors_90d_count": 215
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 207
+      "new_contributors_90d_count": 293
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 178
+      "new_contributors_90d_count": 248
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 140
+      "new_contributors_90d_count": 185
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 112
+      "new_contributors_90d_count": 154
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 120
+      "new_contributors_90d_count": 183
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 138
+      "new_contributors_90d_count": 212
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 148
+      "new_contributors_90d_count": 225
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 136
+      "new_contributors_90d_count": 200
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 129
+      "new_contributors_90d_count": 173
     },
     {
       "repo": "https://github.com/block/goose",
@@ -2545,7 +2545,7 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 154
+      "new_contributors_90d_count": 155
     },
     {
       "repo": "https://github.com/FoundationAgents/MetaGPT",
@@ -3025,7 +3025,7 @@
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 35
+      "new_contributors_90d_count": 36
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -3385,127 +3385,127 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 4504
+      "new_contributors_90d_count": 4510
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 78
+      "new_contributors_90d_count": 100
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 163
+      "new_contributors_90d_count": 221
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 216
+      "new_contributors_90d_count": 294
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 157
+      "new_contributors_90d_count": 216
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 100
+      "new_contributors_90d_count": 134
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 61
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 46
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 37
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 50
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 58
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 72
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 82
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 100
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 122
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 127
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 133
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 101
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 95
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-09-01",
       "new_contributors_90d_count": 76
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 63
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 55
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 79
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 78
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 97
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 102
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 133
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 158
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 172
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 182
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 142
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 136
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 116
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 72
+      "new_contributors_90d_count": 113
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 58
+      "new_contributors_90d_count": 95
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 69
+      "new_contributors_90d_count": 105
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 81
+      "new_contributors_90d_count": 109
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 92
+      "new_contributors_90d_count": 118
     },
     {
       "repo": "https://github.com/cline/cline",
@@ -3890,27 +3890,27 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 3
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -3930,17 +3930,17 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 3
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -3950,17 +3950,17 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -4110,52 +4110,52 @@
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 46
+      "new_contributors_90d_count": 65
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 53
+      "new_contributors_90d_count": 75
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 51
+      "new_contributors_90d_count": 68
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-06-01",
+      "new_contributors_90d_count": 40
+    },
+    {
+      "repo": "https://github.com/OpenInterpreter/open-interpreter",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 25
+    },
+    {
+      "repo": "https://github.com/OpenInterpreter/open-interpreter",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 23
+    },
+    {
+      "repo": "https://github.com/OpenInterpreter/open-interpreter",
+      "month": "2024-09-01",
       "new_contributors_90d_count": 29
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/OpenInterpreter/open-interpreter",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 13
-    },
-    {
-      "repo": "https://github.com/OpenInterpreter/open-interpreter",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 16
+      "new_contributors_90d_count": 26
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 27
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 14
+      "new_contributors_90d_count": 17
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
@@ -4170,22 +4170,22 @@
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 5
+      "new_contributors_90d_count": 6
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 5
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
@@ -4195,17 +4195,17 @@
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
@@ -4225,37 +4225,37 @@
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 8
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 12
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 5
+      "new_contributors_90d_count": 6
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/sweepai/sweep",
@@ -4390,82 +4390,82 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 19
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 30
+      "new_contributors_90d_count": 33
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 94
+      "new_contributors_90d_count": 126
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
+      "new_contributors_90d_count": 196
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 286
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 278
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 254
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 192
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-07-01",
       "new_contributors_90d_count": 147
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 202
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 120
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 198
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 125
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 168
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 124
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 133
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 119
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-07-01",
+      "month": "2025-12-01",
       "new_contributors_90d_count": 104
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 91
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 89
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 90
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 88
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-12-01",
-      "new_contributors_90d_count": 79
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 74
+      "new_contributors_90d_count": 98
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 80
+      "new_contributors_90d_count": 106
     },
     {
       "repo": "https://github.com/firecrawl/firecrawl",
@@ -4600,232 +4600,232 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 3
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 13
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 10
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 9
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 18
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 27
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 35
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 39
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 43
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 43
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 45
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 47
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 52
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 49
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 42
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 34
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 21
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-11-01",
       "new_contributors_90d_count": 15
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 13
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 24
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 47
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 50
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 54
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 54
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 55
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 55
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 58
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 58
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 54
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 46
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 30
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 23
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 16
+      "new_contributors_90d_count": 22
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
+      "new_contributors_90d_count": 34
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2026-02-01",
+      "new_contributors_90d_count": 31
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-03-01",
+      "new_contributors_90d_count": 13
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 11
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-05-01",
+      "new_contributors_90d_count": 12
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 12
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 10
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 7
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 7
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 8
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 12
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 13
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 17
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 15
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 20
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 38
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 42
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-10-01",
       "new_contributors_90d_count": 26
     },
     {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2026-02-01",
-      "new_contributors_90d_count": 27
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-03-01",
-      "new_contributors_90d_count": 7
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 7
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 6
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 4
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 4
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 6
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 9
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 9
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 10
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 18
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 20
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 20
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 10
-    },
-    {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 24
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 19
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 19
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 5
+      "new_contributors_90d_count": 14
     },
     {
       "repo": "https://github.com/simular-ai/Agent-S",
@@ -5065,7 +5065,7 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -5105,42 +5105,42 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 27
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2024-11-01",
       "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 33
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 30
+      "new_contributors_90d_count": 33
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 18
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 25
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-04-01",
       "new_contributors_90d_count": 24
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 32
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 29
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 11
+      "new_contributors_90d_count": 12
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -5150,42 +5150,42 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 7
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-09-01",
       "new_contributors_90d_count": 8
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 9
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 3
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
@@ -5620,52 +5620,52 @@
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 14
+      "new_contributors_90d_count": 35
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 30
+      "new_contributors_90d_count": 64
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 43
+      "new_contributors_90d_count": 78
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 48
+      "new_contributors_90d_count": 77
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 49
+      "new_contributors_90d_count": 71
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 47
+      "new_contributors_90d_count": 79
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 47
+      "new_contributors_90d_count": 75
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 47
+      "new_contributors_90d_count": 83
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 61
+      "new_contributors_90d_count": 118
     },
     {
       "repo": "https://github.com/AmoyLab/Unla",
@@ -6035,67 +6035,67 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 8
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 8
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 46
+      "new_contributors_90d_count": 60
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 69
+      "new_contributors_90d_count": 98
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 72
+      "new_contributors_90d_count": 104
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 38
+      "new_contributors_90d_count": 62
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 29
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 21
+      "new_contributors_90d_count": 28
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 19
+      "new_contributors_90d_count": 26
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 18
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 14
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
@@ -6135,17 +6135,17 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 6
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 6
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -6265,7 +6265,7 @@
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 63
+      "new_contributors_90d_count": 65
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -7115,52 +7115,52 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 10
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 15
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 18
+      "new_contributors_90d_count": 20
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 29
+      "new_contributors_90d_count": 35
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 41
+      "new_contributors_90d_count": 48
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 33
+      "new_contributors_90d_count": 37
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 22
+      "new_contributors_90d_count": 24
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 10
+      "new_contributors_90d_count": 11
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -7175,57 +7175,57 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 27
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 29
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-06-01",
       "new_contributors_90d_count": 28
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 31
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 33
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 27
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 27
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 27
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 23
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 15
+      "new_contributors_90d_count": 21
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 16
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 10
+      "new_contributors_90d_count": 21
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 15
+      "new_contributors_90d_count": 31
     },
     {
       "repo": "https://github.com/567-labs/instructor",
@@ -7585,47 +7585,47 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 521
+      "new_contributors_90d_count": 523
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 13
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 6
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -7640,37 +7640,37 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 6
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 3
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -7690,22 +7690,22 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 4
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 11
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 21
+      "new_contributors_90d_count": 25
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 23
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
@@ -7980,212 +7980,212 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 19
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 9
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 15
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 19
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 24
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 27
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 25
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 26
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 30
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-11-01",
       "new_contributors_90d_count": 29
     },
     {
       "repo": "https://github.com/comet-ml/opik",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 40
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 17
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 22
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 24
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 29
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 33
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 44
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 45
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 41
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 35
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 26
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 42
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 42
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 34
+      "new_contributors_90d_count": 53
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 28
+      "new_contributors_90d_count": 45
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 30
+      "new_contributors_90d_count": 47
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 25
+      "new_contributors_90d_count": 32
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 31
+      "new_contributors_90d_count": 38
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 31
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 25
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 21
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 18
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 22
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 31
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 36
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 34
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 39
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 47
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 63
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 59
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 54
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-06-01",
       "new_contributors_90d_count": 42
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 45
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 47
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 47
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 55
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 46
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-12-01",
+      "month": "2024-06-01",
       "new_contributors_90d_count": 34
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 33
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 27
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 38
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 45
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 57
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 52
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 59
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 69
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 93
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 94
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 83
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 61
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 71
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 77
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 77
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 84
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 65
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-12-01",
+      "new_contributors_90d_count": 46
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 32
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 30
+      "new_contributors_90d_count": 39
     },
     {
       "repo": "https://github.com/SWE-bench/SWE-bench",
@@ -8430,602 +8430,602 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 35
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 41
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 28
+      "new_contributors_90d_count": 39
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 27
+      "new_contributors_90d_count": 35
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 14
+      "new_contributors_90d_count": 22
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 23
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 18
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
+      "new_contributors_90d_count": 53
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 53
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 48
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-01-01",
       "new_contributors_90d_count": 29
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 28
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 25
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 18
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 19
+      "new_contributors_90d_count": 27
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 22
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 16
+      "new_contributors_90d_count": 32
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
+      "new_contributors_90d_count": 48
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 42
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 38
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 26
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 37
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 34
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-12-01",
       "new_contributors_90d_count": 20
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 16
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 20
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 19
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-12-01",
-      "new_contributors_90d_count": 11
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 7
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2026-02-01",
-      "new_contributors_90d_count": 8
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-03-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 8
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 10
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-08-01",
       "new_contributors_90d_count": 12
     },
     {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 11
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 7
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 1
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 1
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-12-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2026-01-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
+      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-03-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2025-12-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2026-01-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
-      "month": "2026-02-01",
-      "new_contributors_90d_count": 0
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-03-01",
-      "new_contributors_90d_count": 11
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 11
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 12
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 12
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 15
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 9
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 4
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 4
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 1
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 2
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-10-01",
-      "new_contributors_90d_count": 1
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-11-01",
-      "new_contributors_90d_count": 3
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2025-12-01",
-      "new_contributors_90d_count": 4
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2026-01-01",
-      "new_contributors_90d_count": 4
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2026-02-01",
-      "new_contributors_90d_count": 5
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-03-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 15
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-06-01",
       "new_contributors_90d_count": 13
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-03-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-05-01",
+      "new_contributors_90d_count": 8
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 11
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-07-01",
+      "new_contributors_90d_count": 15
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 13
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 13
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-10-01",
       "new_contributors_90d_count": 9
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-08-01",
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 1
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 1
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-03-01",
       "new_contributors_90d_count": 3
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 3
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 3
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 1
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 3
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 6
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 4
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-12-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2026-01-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2026-02-01",
+      "new_contributors_90d_count": 3
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-03-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-05-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 0
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 20
+      "new_contributors_90d_count": 0
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 22
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2025-12-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2026-01-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2026-02-01",
+      "new_contributors_90d_count": 0
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-03-01",
+      "new_contributors_90d_count": 17
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 14
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-05-01",
+      "new_contributors_90d_count": 16
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 19
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 29
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 25
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 15
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 4
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 6
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 6
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 8
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 5
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 1
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 3
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 2
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-11-01",
+      "new_contributors_90d_count": 4
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2025-12-01",
+      "new_contributors_90d_count": 4
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2026-01-01",
+      "new_contributors_90d_count": 4
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2026-02-01",
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-12-01",
+      "month": "2024-03-01",
+      "new_contributors_90d_count": 28
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 30
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-05-01",
+      "new_contributors_90d_count": 28
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 23
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-07-01",
       "new_contributors_90d_count": 14
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 7
+      "month": "2024-08-01",
+      "new_contributors_90d_count": 11
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 10
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 17
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-04-01",
+      "month": "2024-09-01",
       "new_contributors_90d_count": 21
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 41
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 40
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 26
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 12
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 27
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 41
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 50
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 17
+      "new_contributors_90d_count": 38
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 29
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 25
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 26
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 18
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 14
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 5
+      "new_contributors_90d_count": 10
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 18
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 22
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 34
     },
     {
       "repo": "https://github.com/NVIDIA/garak",
@@ -9260,27 +9260,27 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 144
+      "new_contributors_90d_count": 145
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 152
+      "new_contributors_90d_count": 153
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 384
+      "new_contributors_90d_count": 383
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 357
+      "new_contributors_90d_count": 356
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 339
+      "new_contributors_90d_count": 338
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -9315,42 +9315,42 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 336
+      "new_contributors_90d_count": 335
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 316
+      "new_contributors_90d_count": 314
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 320
+      "new_contributors_90d_count": 318
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 358
+      "new_contributors_90d_count": 356
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 426
+      "new_contributors_90d_count": 425
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 443
+      "new_contributors_90d_count": 441
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-06-01",
-      "new_contributors_90d_count": 480
+      "new_contributors_90d_count": 479
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 486
+      "new_contributors_90d_count": 485
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -9630,22 +9630,22 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 21
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 11
+      "new_contributors_90d_count": 19
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 9
+      "new_contributors_90d_count": 16
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 7
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -9740,132 +9740,132 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-04-01",
-      "new_contributors_90d_count": 13
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-05-01",
-      "new_contributors_90d_count": 11
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-06-01",
-      "new_contributors_90d_count": 9
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-07-01",
-      "new_contributors_90d_count": 13
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-08-01",
-      "new_contributors_90d_count": 20
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-09-01",
-      "new_contributors_90d_count": 26
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-10-01",
-      "new_contributors_90d_count": 31
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-11-01",
-      "new_contributors_90d_count": 28
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-12-01",
       "new_contributors_90d_count": 22
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 18
+      "month": "2024-04-01",
+      "new_contributors_90d_count": 17
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-02-01",
+      "month": "2024-05-01",
+      "new_contributors_90d_count": 13
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-06-01",
+      "new_contributors_90d_count": 12
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 15
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-08-01",
       "new_contributors_90d_count": 21
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-03-01",
-      "new_contributors_90d_count": 27
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 31
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 30
+      "month": "2024-10-01",
+      "new_contributors_90d_count": 43
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 29
+      "month": "2024-11-01",
+      "new_contributors_90d_count": 43
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 39
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 33
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 39
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-09-01",
-      "new_contributors_90d_count": 30
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-10-01",
+      "month": "2024-12-01",
       "new_contributors_90d_count": 32
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 25
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-02-01",
+      "new_contributors_90d_count": 27
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-03-01",
+      "new_contributors_90d_count": 34
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 37
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 37
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 47
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 48
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 61
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 55
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-10-01",
+      "new_contributors_90d_count": 53
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 38
+      "new_contributors_90d_count": 62
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 42
+      "new_contributors_90d_count": 66
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 54
+      "new_contributors_90d_count": 78
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 56
+      "new_contributors_90d_count": 73
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -9985,127 +9985,127 @@
     {
       "repo": "https://github.com/kserve/kserve",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 47
+      "new_contributors_90d_count": 48
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 38
+      "new_contributors_90d_count": 42
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 41
+      "new_contributors_90d_count": 46
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 38
+      "new_contributors_90d_count": 39
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 16
+      "new_contributors_90d_count": 18
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 24
+      "new_contributors_90d_count": 28
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 25
+      "new_contributors_90d_count": 31
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 23
+      "new_contributors_90d_count": 31
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 11
+      "new_contributors_90d_count": 15
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 10
+      "new_contributors_90d_count": 13
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 156
+      "new_contributors_90d_count": 267
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 156
+      "new_contributors_90d_count": 270
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 151
+      "new_contributors_90d_count": 265
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 1
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-04-01",
       "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 6
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "new_contributors_90d_count": 7
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-06-01",
-      "new_contributors_90d_count": 15
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-07-01",
-      "new_contributors_90d_count": 14
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-08-01",
-      "new_contributors_90d_count": 15
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-09-01",
       "new_contributors_90d_count": 11
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 20
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-07-01",
+      "new_contributors_90d_count": 21
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-08-01",
+      "new_contributors_90d_count": 22
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-09-01",
+      "new_contributors_90d_count": 17
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 12
+      "new_contributors_90d_count": 18
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 16
+      "new_contributors_90d_count": 24
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 18
+      "new_contributors_90d_count": 30
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 18
+      "new_contributors_90d_count": 33
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 15
+      "new_contributors_90d_count": 31
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -10195,17 +10195,17 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 301
+      "new_contributors_90d_count": 300
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 239
+      "new_contributors_90d_count": 238
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 228
+      "new_contributors_90d_count": 227
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -10350,242 +10350,242 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 17
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 16
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 13
+      "new_contributors_90d_count": 15
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "new_contributors_90d_count": 18
+      "new_contributors_90d_count": 24
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 21
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-09-01",
       "new_contributors_90d_count": 32
     },
     {
       "repo": "https://github.com/livekit/agents",
+      "month": "2024-09-01",
+      "new_contributors_90d_count": 48
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 46
+      "new_contributors_90d_count": 72
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
+      "new_contributors_90d_count": 74
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-12-01",
+      "new_contributors_90d_count": 67
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-01-01",
+      "new_contributors_90d_count": 40
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-02-01",
       "new_contributors_90d_count": 52
     },
     {
       "repo": "https://github.com/livekit/agents",
-      "month": "2024-12-01",
-      "new_contributors_90d_count": 47
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-01-01",
-      "new_contributors_90d_count": 30
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-02-01",
-      "new_contributors_90d_count": 39
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 54
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 72
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 85
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-06-01",
       "new_contributors_90d_count": 79
     },
     {
       "repo": "https://github.com/livekit/agents",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 103
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 130
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 137
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 81
+      "new_contributors_90d_count": 145
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 77
+      "new_contributors_90d_count": 136
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 69
+      "new_contributors_90d_count": 112
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 72
+      "new_contributors_90d_count": 115
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 92
+      "new_contributors_90d_count": 187
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 108
+      "new_contributors_90d_count": 220
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 116
+      "new_contributors_90d_count": 237
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 109
+      "new_contributors_90d_count": 182
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 8
+      "new_contributors_90d_count": 12
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 5
+      "new_contributors_90d_count": 9
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 10
+      "new_contributors_90d_count": 15
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-06-01",
-      "new_contributors_90d_count": 10
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2024-07-01",
       "new_contributors_90d_count": 17
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2024-07-01",
+      "new_contributors_90d_count": 24
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 22
+      "new_contributors_90d_count": 37
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 32
+      "new_contributors_90d_count": 52
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 42
+      "new_contributors_90d_count": 73
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 40
+      "new_contributors_90d_count": 67
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 33
+      "new_contributors_90d_count": 55
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "new_contributors_90d_count": 33
+      "new_contributors_90d_count": 58
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 33
+      "new_contributors_90d_count": 59
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 43
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-04-01",
-      "new_contributors_90d_count": 47
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-05-01",
-      "new_contributors_90d_count": 69
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-06-01",
       "new_contributors_90d_count": 70
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-04-01",
+      "new_contributors_90d_count": 76
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-05-01",
+      "new_contributors_90d_count": 110
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-06-01",
+      "new_contributors_90d_count": 109
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "new_contributors_90d_count": 69
+      "new_contributors_90d_count": 109
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 65
+      "new_contributors_90d_count": 102
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 65
+      "new_contributors_90d_count": 108
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 64
+      "new_contributors_90d_count": 98
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "new_contributors_90d_count": 57
+      "new_contributors_90d_count": 92
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 68
+      "new_contributors_90d_count": 95
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 89
+      "new_contributors_90d_count": 121
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 100
+      "new_contributors_90d_count": 130
     },
     {
       "repo": "https://github.com/qodo-ai/pr-agent",
@@ -10830,17 +10830,17 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-03-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "new_contributors_90d_count": 6
+      "new_contributors_90d_count": 7
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -10855,27 +10855,27 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-08-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 5
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 4
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-12-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -10885,17 +10885,17 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-02-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-03-01",
-      "new_contributors_90d_count": 2
+      "new_contributors_90d_count": 3
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-04-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -10915,17 +10915,17 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-08-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-09-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-10-01",
-      "new_contributors_90d_count": 0
+      "new_contributors_90d_count": 1
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -10935,17 +10935,17 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-01-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-02-01",
-      "new_contributors_90d_count": 1
+      "new_contributors_90d_count": 2
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/open_issues_count.json
+++ b/frontend/public/data/agentic-ai-momentum/open_issues_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:18.521867",
+    "fetched_at": "2026-04-01T07:13:54.299505",
     "schema": {
       "name": "open_issues_count",
       "description": "Monthly count of issues opened for tracked repositories.",
@@ -150,42 +150,42 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-05-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "open_issues_count": 5
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "open_issues_count": 9
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "open_issues_count": 5
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "open_issues_count": 18
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "open_issues_count": 17
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
@@ -195,42 +195,42 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "open_issues_count": 3
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-01-01",
       "open_issues_count": 6
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-01-01",
+      "open_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "open_issues_count": 10
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-03-01",
-      "open_issues_count": 21
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-04-01",
-      "open_issues_count": 7
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-05-01",
-      "open_issues_count": 4
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-06-01",
       "open_issues_count": 15
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-03-01",
+      "open_issues_count": 24
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-04-01",
+      "open_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-05-01",
+      "open_issues_count": 5
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-06-01",
+      "open_issues_count": 17
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "open_issues_count": 4
+      "open_issues_count": 5
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
@@ -245,22 +245,22 @@
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "open_issues_count": 6
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "open_issues_count": 10
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
@@ -385,7 +385,7 @@
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "open_issues_count": 470
+      "open_issues_count": 473
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -415,12 +415,12 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "open_issues_count": 11
+      "open_issues_count": 14
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "open_issues_count": 12
+      "open_issues_count": 23
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -435,22 +435,22 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "open_issues_count": 29
+      "open_issues_count": 30
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "open_issues_count": 62
+      "open_issues_count": 64
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "open_issues_count": 31
+      "open_issues_count": 33
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "open_issues_count": 19
+      "open_issues_count": 22
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -465,12 +465,12 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "open_issues_count": 17
+      "open_issues_count": 18
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "open_issues_count": 14
+      "open_issues_count": 16
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -480,27 +480,27 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "open_issues_count": 47
+      "open_issues_count": 50
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "open_issues_count": 13
+      "open_issues_count": 15
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "open_issues_count": 15
+      "open_issues_count": 17
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "open_issues_count": 15
+      "open_issues_count": 18
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "open_issues_count": 15
+      "open_issues_count": 20
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -710,22 +710,27 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "open_issues_count": 10
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "open_issues_count": 6
+      "open_issues_count": 7
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-09-01",
-      "open_issues_count": 1
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-10-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
+    },
+    {
+      "repo": "https://github.com/OpenAutoCoder/Agentless",
+      "month": "2024-11-01",
+      "open_issues_count": 1
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -740,7 +745,7 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-02-01",
-      "open_issues_count": 4
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
@@ -770,122 +775,122 @@
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "open_issues_count": 178
+      "open_issues_count": 205
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "open_issues_count": 441
+      "open_issues_count": 522
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "open_issues_count": 212
+      "open_issues_count": 227
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "open_issues_count": 130
+      "open_issues_count": 139
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "open_issues_count": 90
+      "open_issues_count": 96
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-08-01",
-      "open_issues_count": 82
+      "open_issues_count": 87
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "open_issues_count": 86
+      "open_issues_count": 90
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "open_issues_count": 108
+      "open_issues_count": 114
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "open_issues_count": 214
+      "open_issues_count": 224
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "open_issues_count": 185
+      "open_issues_count": 195
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "open_issues_count": 202
+      "open_issues_count": 220
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "open_issues_count": 146
+      "open_issues_count": 153
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "open_issues_count": 152
+      "open_issues_count": 158
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "open_issues_count": 121
+      "open_issues_count": 130
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "open_issues_count": 150
+      "open_issues_count": 164
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "open_issues_count": 196
+      "open_issues_count": 206
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "open_issues_count": 136
+      "open_issues_count": 144
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "open_issues_count": 173
+      "open_issues_count": 183
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "open_issues_count": 82
+      "open_issues_count": 88
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "open_issues_count": 74
+      "open_issues_count": 78
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "open_issues_count": 42
+      "open_issues_count": 45
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "open_issues_count": 98
+      "open_issues_count": 101
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "open_issues_count": 118
+      "open_issues_count": 130
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "open_issues_count": 66
+      "open_issues_count": 73
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1010,27 +1015,27 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "open_issues_count": 17
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "open_issues_count": 23
+      "open_issues_count": 24
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "open_issues_count": 18
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "open_issues_count": 13
+      "open_issues_count": 15
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "open_issues_count": 21
+      "open_issues_count": 24
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1045,22 +1050,22 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "open_issues_count": 11
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "open_issues_count": 19
+      "open_issues_count": 23
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "open_issues_count": 14
+      "open_issues_count": 16
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "open_issues_count": 7
+      "open_issues_count": 9
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1070,7 +1075,7 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "open_issues_count": 8
+      "open_issues_count": 14
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1080,37 +1085,37 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "open_issues_count": 12
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "open_issues_count": 10
+      "open_issues_count": 12
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "open_issues_count": 16
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "open_issues_count": 10
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-09-01",
-      "open_issues_count": 14
+      "open_issues_count": 15
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-10-01",
-      "open_issues_count": 10
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
@@ -1120,12 +1125,12 @@
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "open_issues_count": 3
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
@@ -1600,82 +1605,82 @@
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-11-01",
-      "open_issues_count": 23
+      "open_issues_count": 26
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2024-12-01",
-      "open_issues_count": 25
+      "open_issues_count": 28
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-01-01",
-      "open_issues_count": 157
+      "open_issues_count": 170
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-02-01",
-      "open_issues_count": 144
+      "open_issues_count": 165
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-03-01",
-      "open_issues_count": 117
+      "open_issues_count": 143
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-04-01",
-      "open_issues_count": 99
+      "open_issues_count": 116
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-05-01",
-      "open_issues_count": 112
+      "open_issues_count": 137
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-06-01",
-      "open_issues_count": 82
+      "open_issues_count": 92
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-07-01",
-      "open_issues_count": 82
+      "open_issues_count": 99
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-08-01",
-      "open_issues_count": 51
+      "open_issues_count": 59
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-09-01",
-      "open_issues_count": 81
+      "open_issues_count": 101
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-10-01",
-      "open_issues_count": 34
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-11-01",
-      "open_issues_count": 29
+      "open_issues_count": 40
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2025-12-01",
-      "open_issues_count": 35
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-01-01",
-      "open_issues_count": 20
+      "open_issues_count": 30
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
       "month": "2026-02-01",
-      "open_issues_count": 30
+      "open_issues_count": 41
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1685,7 +1690,7 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-04-01",
-      "open_issues_count": 17
+      "open_issues_count": 18
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1695,12 +1700,12 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "open_issues_count": 47
+      "open_issues_count": 48
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "open_issues_count": 44
+      "open_issues_count": 47
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1715,87 +1720,87 @@
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "open_issues_count": 50
+      "open_issues_count": 55
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "open_issues_count": 58
+      "open_issues_count": 61
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "open_issues_count": 47
+      "open_issues_count": 48
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "open_issues_count": 58
+      "open_issues_count": 61
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "open_issues_count": 58
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-03-01",
-      "open_issues_count": 132
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-04-01",
-      "open_issues_count": 89
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-05-01",
-      "open_issues_count": 82
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-06-01",
       "open_issues_count": 63
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-03-01",
+      "open_issues_count": 144
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-04-01",
+      "open_issues_count": 93
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-05-01",
+      "open_issues_count": 87
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2025-06-01",
+      "open_issues_count": 66
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "open_issues_count": 47
+      "open_issues_count": 52
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "open_issues_count": 43
+      "open_issues_count": 45
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "open_issues_count": 30
+      "open_issues_count": 37
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "open_issues_count": 35
+      "open_issues_count": 40
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "open_issues_count": 35
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "open_issues_count": 32
+      "open_issues_count": 38
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "open_issues_count": 20
+      "open_issues_count": 23
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "open_issues_count": 25
+      "open_issues_count": 26
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -2040,92 +2045,92 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "open_issues_count": 15
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "open_issues_count": 38
+      "open_issues_count": 40
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "open_issues_count": 23
+      "open_issues_count": 27
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "open_issues_count": 29
+      "open_issues_count": 34
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "open_issues_count": 25
+      "open_issues_count": 29
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "open_issues_count": 43
+      "open_issues_count": 47
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "open_issues_count": 30
+      "open_issues_count": 35
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "open_issues_count": 43
+      "open_issues_count": 51
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "open_issues_count": 39
+      "open_issues_count": 44
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "open_issues_count": 25
+      "open_issues_count": 30
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "open_issues_count": 14
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "open_issues_count": 41
+      "open_issues_count": 50
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "open_issues_count": 31
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-11-01",
-      "open_issues_count": 21
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-12-01",
-      "open_issues_count": 24
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2026-01-01",
       "open_issues_count": 33
     },
     {
       "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-11-01",
+      "open_issues_count": 26
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2025-12-01",
+      "open_issues_count": 32
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2026-01-01",
+      "open_issues_count": 36
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "open_issues_count": 24
+      "open_issues_count": 27
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "open_issues_count": 16
+      "open_issues_count": 18
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2135,37 +2140,37 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "open_issues_count": 18
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "open_issues_count": 12
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "open_issues_count": 11
+      "open_issues_count": 14
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "open_issues_count": 18
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-09-01",
-      "open_issues_count": 10
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-10-01",
       "open_issues_count": 22
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2024-11-01",
+      "month": "2024-09-01",
       "open_issues_count": 11
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-10-01",
+      "open_issues_count": 25
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2024-11-01",
+      "open_issues_count": 15
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -2175,72 +2180,72 @@
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "open_issues_count": 15
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-02-01",
-      "open_issues_count": 11
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-03-01",
-      "open_issues_count": 20
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-04-01",
-      "open_issues_count": 6
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-05-01",
-      "open_issues_count": 18
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-06-01",
-      "open_issues_count": 16
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-07-01",
-      "open_issues_count": 21
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-08-01",
       "open_issues_count": 17
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-02-01",
+      "open_issues_count": 16
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-03-01",
+      "open_issues_count": 25
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-04-01",
+      "open_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-05-01",
+      "open_issues_count": 22
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-06-01",
+      "open_issues_count": 21
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-07-01",
+      "open_issues_count": 29
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
+      "month": "2025-08-01",
+      "open_issues_count": 20
+    },
+    {
+      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "open_issues_count": 18
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "open_issues_count": 32
+      "open_issues_count": 40
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "open_issues_count": 14
+      "open_issues_count": 23
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "open_issues_count": 7
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "open_issues_count": 8
+      "open_issues_count": 12
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "open_issues_count": 11
+      "open_issues_count": 12
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -2360,7 +2365,7 @@
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
-      "open_issues_count": 648
+      "open_issues_count": 649
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
@@ -2485,7 +2490,7 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "open_issues_count": 122
+      "open_issues_count": 125
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
@@ -2495,27 +2500,27 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "open_issues_count": 84
+      "open_issues_count": 85
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "open_issues_count": 48
+      "open_issues_count": 49
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "open_issues_count": 57
+      "open_issues_count": 60
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "open_issues_count": 68
+      "open_issues_count": 69
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "open_issues_count": 47
+      "open_issues_count": 49
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
@@ -2525,17 +2530,17 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "open_issues_count": 32
+      "open_issues_count": 34
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "open_issues_count": 26
+      "open_issues_count": 29
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "open_issues_count": 12
+      "open_issues_count": 20
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
@@ -2550,52 +2555,52 @@
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "open_issues_count": 25
+      "open_issues_count": 47
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "open_issues_count": 30
+      "open_issues_count": 36
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "open_issues_count": 16
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-08-01",
-      "open_issues_count": 19
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-09-01",
-      "open_issues_count": 14
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-10-01",
-      "open_issues_count": 43
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-11-01",
-      "open_issues_count": 41
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-12-01",
       "open_issues_count": 20
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
-      "month": "2026-01-01",
+      "month": "2025-08-01",
+      "open_issues_count": 21
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-09-01",
+      "open_issues_count": 26
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-10-01",
+      "open_issues_count": 61
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-11-01",
+      "open_issues_count": 55
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2025-12-01",
       "open_issues_count": 25
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
+      "month": "2026-01-01",
+      "open_issues_count": 39
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "open_issues_count": 28
+      "open_issues_count": 49
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2655,7 +2660,7 @@
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-02-01",
-      "open_issues_count": 61
+      "open_issues_count": 62
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -2750,7 +2755,7 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-10-01",
-      "open_issues_count": 1
+      "open_issues_count": 2
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2785,7 +2790,7 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-05-01",
-      "open_issues_count": 1
+      "open_issues_count": 2
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2815,7 +2820,7 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-11-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2825,67 +2830,67 @@
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "open_issues_count": 229
+      "open_issues_count": 266
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "open_issues_count": 278
+      "open_issues_count": 330
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "open_issues_count": 209
+      "open_issues_count": 249
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "open_issues_count": 182
+      "open_issues_count": 220
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "open_issues_count": 145
+      "open_issues_count": 180
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "open_issues_count": 118
+      "open_issues_count": 147
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "open_issues_count": 119
+      "open_issues_count": 154
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "open_issues_count": 171
+      "open_issues_count": 212
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "open_issues_count": 119
+      "open_issues_count": 143
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "open_issues_count": 103
+      "open_issues_count": 137
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "open_issues_count": 93
+      "open_issues_count": 124
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "open_issues_count": 20
+      "open_issues_count": 23
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "open_issues_count": 10
+      "open_issues_count": 15
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2895,52 +2900,52 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-06-01",
-      "open_issues_count": 24
+      "open_issues_count": 25
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "open_issues_count": 17
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "open_issues_count": 12
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "open_issues_count": 14
+      "open_issues_count": 16
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "open_issues_count": 8
+      "open_issues_count": 9
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "open_issues_count": 4
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "open_issues_count": 14
+      "open_issues_count": 15
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "open_issues_count": 5
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "open_issues_count": 3
+      "open_issues_count": 4
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2950,17 +2955,17 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-05-01",
-      "open_issues_count": 4
+      "open_issues_count": 5
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "open_issues_count": 12
+      "open_issues_count": 16
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2975,7 +2980,7 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "open_issues_count": 7
+      "open_issues_count": 9
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2985,7 +2990,7 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "open_issues_count": 6
+      "open_issues_count": 7
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
@@ -2995,7 +3000,7 @@
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "open_issues_count": 3
+      "open_issues_count": 4
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -3125,7 +3130,7 @@
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-01-01",
-      "open_issues_count": 175
+      "open_issues_count": 174
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -3310,7 +3315,7 @@
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-02-01",
-      "open_issues_count": 124
+      "open_issues_count": 125
     },
     {
       "repo": "https://github.com/janhq/jan",
@@ -3434,6 +3439,11 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-03-01",
+      "open_issues_count": 2
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
       "open_issues_count": 4
     },
@@ -3444,18 +3454,28 @@
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-07-01",
+      "open_issues_count": 2
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2024-08-01",
+      "open_issues_count": 2
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
       "open_issues_count": 2
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "open_issues_count": 1
+      "open_issues_count": 2
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "open_issues_count": 3
+      "open_issues_count": 4
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -3465,12 +3485,17 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-02-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-04-01",
       "open_issues_count": 2
+    },
+    {
+      "repo": "https://github.com/joonspk-research/generative_agents",
+      "month": "2025-07-01",
+      "open_issues_count": 1
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
@@ -3485,7 +3510,7 @@
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-02-01",
-      "open_issues_count": 1
+      "open_issues_count": 2
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -4095,117 +4120,117 @@
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-04-01",
-      "open_issues_count": 5
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-05-01",
-      "open_issues_count": 24
+      "open_issues_count": 28
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-06-01",
-      "open_issues_count": 23
+      "open_issues_count": 24
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
-      "open_issues_count": 20
+      "open_issues_count": 25
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-08-01",
-      "open_issues_count": 22
+      "open_issues_count": 25
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-09-01",
-      "open_issues_count": 32
+      "open_issues_count": 37
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-10-01",
-      "open_issues_count": 73
+      "open_issues_count": 80
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-11-01",
-      "open_issues_count": 45
+      "open_issues_count": 55
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-12-01",
-      "open_issues_count": 52
+      "open_issues_count": 63
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-01-01",
-      "open_issues_count": 38
+      "open_issues_count": 48
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-02-01",
-      "open_issues_count": 40
+      "open_issues_count": 45
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-03-01",
-      "open_issues_count": 65
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-04-01",
-      "open_issues_count": 98
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-05-01",
-      "open_issues_count": 107
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-06-01",
-      "open_issues_count": 90
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-07-01",
-      "open_issues_count": 79
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-08-01",
-      "open_issues_count": 96
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-09-01",
       "open_issues_count": 74
     },
     {
       "repo": "https://github.com/livekit/agents",
+      "month": "2025-04-01",
+      "open_issues_count": 120
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-05-01",
+      "open_issues_count": 138
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-06-01",
+      "open_issues_count": 108
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-07-01",
+      "open_issues_count": 98
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-08-01",
+      "open_issues_count": 108
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-09-01",
+      "open_issues_count": 92
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "open_issues_count": 73
+      "open_issues_count": 88
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "open_issues_count": 81
+      "open_issues_count": 92
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "open_issues_count": 70
+      "open_issues_count": 95
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "open_issues_count": 58
+      "open_issues_count": 77
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "open_issues_count": 60
+      "open_issues_count": 69
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4225,112 +4250,112 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "open_issues_count": 50
+      "open_issues_count": 51
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "open_issues_count": 151
+      "open_issues_count": 154
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "open_issues_count": 90
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-05-01",
-      "open_issues_count": 108
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-06-01",
-      "open_issues_count": 362
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-07-01",
-      "open_issues_count": 265
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-08-01",
-      "open_issues_count": 247
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-09-01",
-      "open_issues_count": 357
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-10-01",
-      "open_issues_count": 405
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-11-01",
       "open_issues_count": 93
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-05-01",
+      "open_issues_count": 110
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-06-01",
+      "open_issues_count": 368
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-07-01",
+      "open_issues_count": 273
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-08-01",
+      "open_issues_count": 253
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-09-01",
+      "open_issues_count": 364
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-10-01",
+      "open_issues_count": 432
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-11-01",
+      "open_issues_count": 299
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "open_issues_count": 105
+      "open_issues_count": 250
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "open_issues_count": 113
+      "open_issues_count": 261
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "open_issues_count": 115
+      "open_issues_count": 246
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "open_issues_count": 27
+      "open_issues_count": 28
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "open_issues_count": 24
+      "open_issues_count": 26
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "open_issues_count": 10
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-01-01",
       "open_issues_count": 11
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-01-01",
+      "open_issues_count": 12
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "open_issues_count": 57
+      "open_issues_count": 67
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "open_issues_count": 20
+      "open_issues_count": 36
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "open_issues_count": 8
-    },
-    {
-      "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2025-05-01",
       "open_issues_count": 10
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
+      "month": "2025-05-01",
+      "open_issues_count": 12
+    },
+    {
+      "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-06-01",
-      "open_issues_count": 3
+      "open_issues_count": 5
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4350,12 +4375,12 @@
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-10-01",
-      "open_issues_count": 2
+      "open_issues_count": 4
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-12-01",
-      "open_issues_count": 1
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
@@ -4365,42 +4390,42 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "open_issues_count": 20
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2024-04-01",
       "open_issues_count": 22
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2024-04-01",
+      "open_issues_count": 26
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "open_issues_count": 12
+      "open_issues_count": 17
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "open_issues_count": 12
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "open_issues_count": 9
+      "open_issues_count": 12
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-08-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-09-01",
-      "open_issues_count": 5
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "open_issues_count": 7
+      "open_issues_count": 9
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4415,7 +4440,7 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "open_issues_count": 4
+      "open_issues_count": 5
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -4440,6 +4465,11 @@
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-06-01",
+      "open_issues_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-07-01",
       "open_issues_count": 1
     },
     {
@@ -4585,72 +4615,72 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-06-01",
-      "open_issues_count": 3
+      "open_issues_count": 4
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "open_issues_count": 234
+      "open_issues_count": 271
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "open_issues_count": 91
+      "open_issues_count": 105
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "open_issues_count": 34
+      "open_issues_count": 45
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "open_issues_count": 21
+      "open_issues_count": 22
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "open_issues_count": 39
+      "open_issues_count": 44
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "open_issues_count": 34
+      "open_issues_count": 37
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "open_issues_count": 23
+      "open_issues_count": 26
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "open_issues_count": 19
+      "open_issues_count": 29
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "open_issues_count": 28
+      "open_issues_count": 41
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "open_issues_count": 13
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "open_issues_count": 14
+      "open_issues_count": 17
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "open_issues_count": 12
+      "open_issues_count": 16
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "open_issues_count": 6
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
@@ -4660,22 +4690,22 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "open_issues_count": 6
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "open_issues_count": 6
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "open_issues_count": 6
+      "open_issues_count": 7
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "open_issues_count": 3
+      "open_issues_count": 7
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
@@ -4685,7 +4715,7 @@
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "open_issues_count": 6
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -4810,122 +4840,122 @@
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "open_issues_count": 152
+      "open_issues_count": 162
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "open_issues_count": 131
+      "open_issues_count": 138
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "open_issues_count": 122
+      "open_issues_count": 134
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "open_issues_count": 290
+      "open_issues_count": 297
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "open_issues_count": 160
+      "open_issues_count": 184
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "open_issues_count": 91
+      "open_issues_count": 112
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "open_issues_count": 93
+      "open_issues_count": 121
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "open_issues_count": 104
+      "open_issues_count": 127
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "open_issues_count": 123
+      "open_issues_count": 133
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "open_issues_count": 73
+      "open_issues_count": 80
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "open_issues_count": 141
+      "open_issues_count": 154
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "open_issues_count": 147
+      "open_issues_count": 165
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "open_issues_count": 175
+      "open_issues_count": 195
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "open_issues_count": 153
+      "open_issues_count": 177
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "open_issues_count": 135
+      "open_issues_count": 155
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "open_issues_count": 110
+      "open_issues_count": 133
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "open_issues_count": 79
+      "open_issues_count": 94
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "open_issues_count": 83
+      "open_issues_count": 96
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "open_issues_count": 50
+      "open_issues_count": 62
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "open_issues_count": 31
+      "open_issues_count": 39
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "open_issues_count": 25
+      "open_issues_count": 31
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "open_issues_count": 11
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2026-01-01",
       "open_issues_count": 13
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-01-01",
+      "open_issues_count": 20
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "open_issues_count": 21
+      "open_issues_count": 34
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -5050,7 +5080,7 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "open_issues_count": 10
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -5060,7 +5090,7 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-05-01",
-      "open_issues_count": 7
+      "open_issues_count": 8
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -5080,12 +5110,12 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-09-01",
-      "open_issues_count": 2
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-10-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
@@ -5095,6 +5125,11 @@
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-12-01",
+      "open_issues_count": 1
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-01-01",
       "open_issues_count": 1
     },
     {
@@ -5415,7 +5450,7 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-11-01",
-      "open_issues_count": 230
+      "open_issues_count": 231
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -5425,7 +5460,7 @@
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "open_issues_count": 217
+      "open_issues_count": 218
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -5570,7 +5605,7 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-06-01",
-      "open_issues_count": 12
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -5675,62 +5710,62 @@
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "open_issues_count": 190
+      "open_issues_count": 202
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "open_issues_count": 116
+      "open_issues_count": 132
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "open_issues_count": 79
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-06-01",
-      "open_issues_count": 83
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-07-01",
-      "open_issues_count": 106
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-08-01",
       "open_issues_count": 92
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-06-01",
+      "open_issues_count": 98
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-07-01",
+      "open_issues_count": 127
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-08-01",
+      "open_issues_count": 107
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "open_issues_count": 66
+      "open_issues_count": 79
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "open_issues_count": 60
+      "open_issues_count": 71
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "open_issues_count": 43
+      "open_issues_count": 51
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "open_issues_count": 43
+      "open_issues_count": 46
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "open_issues_count": 35
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "open_issues_count": 21
+      "open_issues_count": 31
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5750,12 +5785,12 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "open_issues_count": 10831
+      "open_issues_count": 10830
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "open_issues_count": 23
+      "open_issues_count": 25
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5776,6 +5811,11 @@
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-07-01",
       "open_issues_count": 3
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-08-01",
+      "open_issues_count": 1
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5800,22 +5840,22 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-01-01",
-      "open_issues_count": 5
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "open_issues_count": 1
+      "open_issues_count": 2
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "open_issues_count": 2
+      "open_issues_count": 3
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5830,7 +5870,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "open_issues_count": 5
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5860,7 +5900,7 @@
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "open_issues_count": 13
+      "open_issues_count": 14
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
@@ -5885,12 +5925,12 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "open_issues_count": 23
+      "open_issues_count": 25
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "open_issues_count": 35
+      "open_issues_count": 37
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -5900,87 +5940,87 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "open_issues_count": 19
+      "open_issues_count": 22
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "open_issues_count": 18
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "open_issues_count": 29
+      "open_issues_count": 31
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "open_issues_count": 54
+      "open_issues_count": 64
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "open_issues_count": 53
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-03-01",
-      "open_issues_count": 50
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-04-01",
-      "open_issues_count": 61
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-05-01",
-      "open_issues_count": 57
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-06-01",
-      "open_issues_count": 36
-    },
-    {
-      "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2025-07-01",
       "open_issues_count": 56
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-03-01",
+      "open_issues_count": 60
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-04-01",
+      "open_issues_count": 66
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-05-01",
+      "open_issues_count": 63
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-06-01",
+      "open_issues_count": 44
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2025-07-01",
+      "open_issues_count": 66
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "open_issues_count": 38
+      "open_issues_count": 49
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "open_issues_count": 43
+      "open_issues_count": 52
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "open_issues_count": 30
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "open_issues_count": 37
+      "open_issues_count": 54
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "open_issues_count": 29
+      "open_issues_count": 34
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "open_issues_count": 57
+      "open_issues_count": 68
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "open_issues_count": 47
+      "open_issues_count": 54
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -6425,7 +6465,7 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-03-01",
-      "open_issues_count": 59
+      "open_issues_count": 61
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6440,7 +6480,7 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-06-01",
-      "open_issues_count": 32
+      "open_issues_count": 33
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6460,7 +6500,7 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-10-01",
-      "open_issues_count": 88
+      "open_issues_count": 89
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6470,7 +6510,7 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2024-12-01",
-      "open_issues_count": 30
+      "open_issues_count": 31
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6485,17 +6525,17 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-03-01",
-      "open_issues_count": 85
+      "open_issues_count": 91
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-04-01",
-      "open_issues_count": 133
+      "open_issues_count": 146
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-05-01",
-      "open_issues_count": 107
+      "open_issues_count": 114
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6505,37 +6545,37 @@
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-07-01",
-      "open_issues_count": 71
+      "open_issues_count": 76
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-08-01",
-      "open_issues_count": 137
+      "open_issues_count": 142
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-09-01",
-      "open_issues_count": 108
+      "open_issues_count": 114
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-10-01",
-      "open_issues_count": 64
+      "open_issues_count": 67
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-11-01",
-      "open_issues_count": 59
+      "open_issues_count": 61
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2025-12-01",
-      "open_issues_count": 62
+      "open_issues_count": 64
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
       "month": "2026-01-01",
-      "open_issues_count": 32
+      "open_issues_count": 33
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
@@ -6670,17 +6710,17 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "open_issues_count": 33
+      "open_issues_count": 34
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "open_issues_count": 46
+      "open_issues_count": 47
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "open_issues_count": 5
+      "open_issues_count": 7
     },
     {
       "repo": "https://github.com/sweepai/sweep",
@@ -6704,7 +6744,17 @@
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-05-01",
+      "open_issues_count": 1
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-06-01",
+      "open_issues_count": 3
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-07-01",
       "open_issues_count": 1
     },
     {
@@ -6720,6 +6770,11 @@
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-12-01",
+      "open_issues_count": 1
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2026-01-01",
       "open_issues_count": 1
     },
     {
@@ -6850,7 +6905,7 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "open_issues_count": 10
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6870,82 +6925,82 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "open_issues_count": 25
+      "open_issues_count": 26
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "open_issues_count": 66
+      "open_issues_count": 76
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "open_issues_count": 61
+      "open_issues_count": 68
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "open_issues_count": 57
+      "open_issues_count": 72
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "open_issues_count": 70
+      "open_issues_count": 87
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "open_issues_count": 53
+      "open_issues_count": 68
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "open_issues_count": 48
+      "open_issues_count": 62
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "open_issues_count": 57
+      "open_issues_count": 73
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "open_issues_count": 46
+      "open_issues_count": 52
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "open_issues_count": 41
+      "open_issues_count": 47
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "open_issues_count": 38
+      "open_issues_count": 44
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "open_issues_count": 30
+      "open_issues_count": 42
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "open_issues_count": 28
+      "open_issues_count": 32
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "open_issues_count": 16
+      "open_issues_count": 17
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "open_issues_count": 19
+      "open_issues_count": 22
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "open_issues_count": 17
+      "open_issues_count": 19
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
@@ -6955,7 +7010,7 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "open_issues_count": 11
+      "open_issues_count": 14
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
@@ -7095,12 +7150,12 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "open_issues_count": 8
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "open_issues_count": 3
+      "open_issues_count": 5
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -7110,12 +7165,12 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-07-01",
-      "open_issues_count": 4
+      "open_issues_count": 7
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-08-01",
-      "open_issues_count": 3
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -7125,12 +7180,12 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-10-01",
-      "open_issues_count": 9
+      "open_issues_count": 10
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "open_issues_count": 8
+      "open_issues_count": 11
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -7145,67 +7200,67 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "open_issues_count": 7
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-03-01",
-      "open_issues_count": 18
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-04-01",
-      "open_issues_count": 12
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-05-01",
       "open_issues_count": 8
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-03-01",
+      "open_issues_count": 19
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-04-01",
+      "open_issues_count": 15
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-05-01",
+      "open_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "open_issues_count": 5
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-07-01",
-      "open_issues_count": 10
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-08-01",
-      "open_issues_count": 16
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-09-01",
-      "open_issues_count": 7
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-10-01",
       "open_issues_count": 6
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2025-11-01",
+      "month": "2025-07-01",
       "open_issues_count": 11
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-08-01",
+      "open_issues_count": 19
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-09-01",
+      "open_issues_count": 9
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-10-01",
+      "open_issues_count": 12
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2025-11-01",
+      "open_issues_count": 13
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "open_issues_count": 10
+      "open_issues_count": 13
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "open_issues_count": 3
+      "open_issues_count": 6
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "open_issues_count": 4
+      "open_issues_count": 5
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/package_downloads_count.json
+++ b/frontend/public/data/agentic-ai-momentum/package_downloads_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:56.731712",
+    "fetched_at": "2026-04-01T07:13:33.943972",
     "schema": {
       "name": "package_downloads_count",
       "description": "Monthly package download counts from Tinybird, broken out by ecosystem.",
@@ -235,7 +235,7 @@
       "repo": "https://github.com/ComposioHQ/composio",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 773516
+      "download_counts": 773558
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -307,7 +307,7 @@
       "repo": "https://github.com/PrefectHQ/prefect",
       "ecosystem": "nixpkgs",
       "month": "2026-03-01",
-      "download_counts": 1101801
+      "download_counts": 6969639
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -379,7 +379,7 @@
       "repo": "https://github.com/agntcy/slim",
       "ecosystem": "cargo",
       "month": "2026-03-01",
-      "download_counts": 12
+      "download_counts": 74
     },
     {
       "repo": "https://github.com/agntcy/slim",
@@ -397,7 +397,7 @@
       "repo": "https://github.com/agntcy/slim",
       "ecosystem": "nuget",
       "month": "2026-03-01",
-      "download_counts": 693
+      "download_counts": 814
     },
     {
       "repo": "https://github.com/agntcy/slim",
@@ -589,7 +589,7 @@
       "repo": "https://github.com/block/goose",
       "ecosystem": "npm",
       "month": "2026-03-01",
-      "download_counts": 8
+      "download_counts": 382
     },
     {
       "repo": "https://github.com/block/goose",
@@ -691,7 +691,7 @@
       "repo": "https://github.com/chroma-core/chroma",
       "ecosystem": "cargo",
       "month": "2026-03-01",
-      "download_counts": 1392446
+      "download_counts": 1805599
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -811,7 +811,7 @@
       "repo": "https://github.com/chroma-core/chroma",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 15065558
+      "download_counts": 15065613
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
@@ -853,7 +853,7 @@
       "repo": "https://github.com/cline/cline",
       "ecosystem": "openvsx",
       "month": "2026-03-01",
-      "download_counts": 3028185
+      "download_counts": 3126267
     },
     {
       "repo": "https://github.com/comet-ml/opik",
@@ -961,7 +961,7 @@
       "repo": "https://github.com/continuedev/continue",
       "ecosystem": "openvsx",
       "month": "2026-03-01",
-      "download_counts": 986498
+      "download_counts": 1046603
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -1091,6 +1091,12 @@
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
+      "ecosystem": "cargo",
+      "month": "2026-03-01",
+      "download_counts": 7633
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
       "ecosystem": "npm",
       "month": "2026-03-01",
       "download_counts": 1203448
@@ -1099,19 +1105,19 @@
       "repo": "https://github.com/daytonaio/daytona",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 1665707
+      "download_counts": 2894760
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "ecosystem": "rubygems",
       "month": "2026-03-01",
-      "download_counts": 16372
+      "download_counts": 3946754
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "ecosystem": "conda",
       "month": "2026-03-01",
-      "download_counts": 647921
+      "download_counts": 663628
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -1195,7 +1201,7 @@
       "repo": "https://github.com/guardrails-ai/guardrails",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 232729
+      "download_counts": 261178
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -1267,7 +1273,7 @@
       "repo": "https://github.com/huggingface/transformers",
       "ecosystem": "conda",
       "month": "2026-03-01",
-      "download_counts": 118527191
+      "download_counts": 124890462
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -1387,7 +1393,7 @@
       "repo": "https://github.com/kserve/kserve",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 126648
+      "download_counts": 134308
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -1447,7 +1453,7 @@
       "repo": "https://github.com/langchain-ai/langchain",
       "ecosystem": "conda",
       "month": "2026-03-01",
-      "download_counts": 197819530
+      "download_counts": 199743405
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -1507,7 +1513,7 @@
       "repo": "https://github.com/langchain-ai/langchain",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 303628879
+      "download_counts": 304384700
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
@@ -1543,7 +1549,7 @@
       "repo": "https://github.com/langchain-ai/langgraph",
       "ecosystem": "conda",
       "month": "2026-03-01",
-      "download_counts": 40634518
+      "download_counts": 70790692
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
@@ -1639,7 +1645,7 @@
       "repo": "https://github.com/langchain-ai/langgraph",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 4593145
+      "download_counts": 4593795
     },
     {
       "repo": "https://github.com/letta-ai/letta",
@@ -1663,7 +1669,7 @@
       "repo": "https://github.com/mastra-ai/mastra",
       "ecosystem": "npm",
       "month": "2026-03-01",
-      "download_counts": 14238767
+      "download_counts": 14947523
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
@@ -1723,7 +1729,7 @@
       "repo": "https://github.com/microsoft/autogen",
       "ecosystem": "nuget",
       "month": "2026-03-01",
-      "download_counts": 859140
+      "download_counts": 872875
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -1849,13 +1855,13 @@
       "repo": "https://github.com/microsoft/playwright",
       "ecosystem": "npm",
       "month": "2026-03-01",
-      "download_counts": 329794211
+      "download_counts": 330258657
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "ecosystem": "nuget",
       "month": "2026-03-01",
-      "download_counts": 70295056
+      "download_counts": 71061676
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
@@ -1945,7 +1951,7 @@
       "repo": "https://github.com/openclaw/openclaw",
       "ecosystem": "npm",
       "month": "2026-03-01",
-      "download_counts": 8796352
+      "download_counts": 8936104
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -2089,7 +2095,7 @@
       "repo": "https://github.com/pydantic/pydantic-ai",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 130986801
+      "download_counts": 210366108
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
@@ -2126,6 +2132,12 @@
       "ecosystem": "cargo",
       "month": "2025-11-01",
       "download_counts": 2199
+    },
+    {
+      "repo": "https://github.com/qdrant/qdrant",
+      "ecosystem": "cargo",
+      "month": "2026-03-01",
+      "download_counts": 215
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
@@ -2227,7 +2239,7 @@
       "repo": "https://github.com/run-llama/llama_index",
       "ecosystem": "pypi",
       "month": "2026-03-01",
-      "download_counts": 9459490
+      "download_counts": 9459526
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",

--- a/frontend/public/data/agentic-ai-momentum/project_value_cocomo.json
+++ b/frontend/public/data/agentic-ai-momentum/project_value_cocomo.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:57.485659",
+    "fetched_at": "2026-04-01T07:13:34.758845",
     "schema": {
       "name": "project_value_cocomo",
       "description": "COCOMO-model estimated development cost per project from Tinybird softwareValueProjectCosts.",
@@ -34,13 +34,13 @@
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 7336287.0
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 8029428.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 2584.0
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
@@ -49,18 +49,18 @@
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 59228098.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 59478602.0
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 21291588.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 21457431.0
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 3737778.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 3826499.0
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
@@ -69,22 +69,22 @@
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 1335627.0
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 1165766.0
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 12684112.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 12741261.0
     },
     {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 1322890.0
     },
     {
@@ -94,12 +94,12 @@
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 37211598.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 37365966.0
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 21662686.0
     },
     {
@@ -109,7 +109,7 @@
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 42796527.0
     },
     {
@@ -119,7 +119,7 @@
     },
     {
       "repo": "https://github.com/agntcy/acp-spec",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 117090.0
     },
     {
@@ -129,8 +129,8 @@
     },
     {
       "repo": "https://github.com/agntcy/oasf",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 1795042.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 1800377.0
     },
     {
       "repo": "https://github.com/agntcy/slim",
@@ -139,12 +139,12 @@
     },
     {
       "repo": "https://github.com/agntcy/slim",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 4194754.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 4278688.0
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 6596271.0
     },
     {
@@ -154,17 +154,17 @@
     },
     {
       "repo": "https://github.com/block/goose",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 19268808.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 19755102.0
     },
     {
       "repo": "https://github.com/browser-use/browser-use",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 2759480.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 2759692.0
     },
     {
       "repo": "https://github.com/camel-ai/camel",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 13009528.0
     },
     {
@@ -174,23 +174,23 @@
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 12845401.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 12872451.0
     },
     {
       "repo": "https://github.com/cline/cline",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 21154672.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 21171346.0
     },
     {
       "repo": "https://github.com/comet-ml/opik",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 46140623.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 46620817.0
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 9016381.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 9033588.0
     },
     {
       "repo": "https://github.com/continuedev/continue",
@@ -199,43 +199,43 @@
     },
     {
       "repo": "https://github.com/continuedev/continue",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 16011980.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 16017093.0
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 22223551.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 22355945.0
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 21430066.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 21508697.0
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 31097087.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 33976260.0
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 254450.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 257165.0
     },
     {
       "repo": "https://github.com/google/adk-python",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 9646696.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 9730662.0
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 2416493.0
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 1233149.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 1233421.0
     },
     {
       "repo": "https://github.com/huggingface/transformers",
@@ -244,13 +244,13 @@
     },
     {
       "repo": "https://github.com/huggingface/transformers",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 51128540.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 51281560.0
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 32722947.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 33389692.0
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -259,8 +259,8 @@
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 19259345.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 19337695.0
     },
     {
       "repo": "https://github.com/janhq/jan",
@@ -269,12 +269,12 @@
     },
     {
       "repo": "https://github.com/janhq/jan",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 4836063.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 4885824.0
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 237297741.0
     },
     {
@@ -284,8 +284,8 @@
     },
     {
       "repo": "https://github.com/kserve/kserve",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 150533296.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 169787947.0
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -294,13 +294,13 @@
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 10035433.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 10061941.0
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 4334989.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 4355365.0
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
@@ -309,32 +309,32 @@
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 19106723.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 19377069.0
     },
     {
       "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 10093116.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 10434530.0
     },
     {
       "repo": "https://github.com/livekit/agents",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 3793648.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 3819641.0
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 56844204.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 57861862.0
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 315849.0
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 1094338.0
     },
     {
@@ -344,13 +344,13 @@
     },
     {
       "repo": "https://github.com/microsoft/autogen",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 6764279.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 6764242.0
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 2250451.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 2250871.0
     },
     {
       "repo": "https://github.com/microsoft/playwright",
@@ -359,13 +359,13 @@
     },
     {
       "repo": "https://github.com/microsoft/playwright",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 18213383.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 18247384.0
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 21657889.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 21657967.0
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -374,12 +374,12 @@
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 52657347.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 53263937.0
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 87328.0
     },
     {
@@ -389,7 +389,7 @@
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 963154.0
     },
     {
@@ -399,8 +399,8 @@
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 2396155.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 2413788.0
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -409,8 +409,8 @@
     },
     {
       "repo": "https://github.com/ollama/ollama",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 32754489.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 32803495.0
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -419,8 +419,8 @@
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 2440319.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 2451111.0
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -429,28 +429,28 @@
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 14696971.0
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 5297129.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 5313105.0
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 69771460.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 75641912.0
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 8933169.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 8932945.0
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 5025284.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 4940735.0
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
@@ -459,13 +459,13 @@
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 30531918.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 30595629.0
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 36991686.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 37253179.0
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
@@ -474,7 +474,7 @@
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 26451440.0
     },
     {
@@ -484,13 +484,13 @@
     },
     {
       "repo": "https://github.com/run-llama/llama_index",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 62908569.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 62920715.0
     },
     {
       "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 14285126.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 14479271.0
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -500,37 +500,37 @@
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2026-03-01",
-      "estimated_cost_usd": 2559683.0
+      "estimated_cost_usd": 2569126.0
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 2158280.0
     },
     {
       "repo": "https://github.com/temporalio/temporal",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 26973385.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 27001800.0
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 8921280.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 8927075.0
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 28128243.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 28522081.0
     },
     {
       "repo": "https://github.com/wong2/litemcp",
-      "month": "2026-03-01",
+      "month": "2026-04-01",
       "estimated_cost_usd": 17212.0
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2026-03-01",
-      "estimated_cost_usd": 6135571.0
+      "month": "2026-04-01",
+      "estimated_cost_usd": 6140602.0
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T18:21:33.047998+00:00",
+    "fetched_at": "2026-04-01T14:13:24.870603+00:00",
     "schema": {
       "name": "projects",
       "description": "Top-100 agentic AI projects metadata.",

--- a/frontend/public/data/agentic-ai-momentum/pull_request_count.json
+++ b/frontend/public/data/agentic-ai-momentum/pull_request_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:23.909937",
+    "fetched_at": "2026-04-01T07:14:01.300136",
     "schema": {
       "name": "pull_request_count",
       "description": "Cumulative monthly pull request counts for tracked repositories.",

--- a/frontend/public/data/agentic-ai-momentum/pull_request_merge_rate.json
+++ b/frontend/public/data/agentic-ai-momentum/pull_request_merge_rate.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T11:21:38.609907",
+    "fetched_at": "2026-04-01T07:14:00.887848",
     "schema": {
       "name": "pull_request_merge_rate",
       "description": "3-month trailing average of the monthly PR merge rate per repo.",

--- a/frontend/public/data/agentic-ai-momentum/pull_request_time_to_resolve.json
+++ b/frontend/public/data/agentic-ai-momentum/pull_request_time_to_resolve.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T11:21:37.860567",
+    "fetched_at": "2026-04-01T07:13:59.939679",
     "schema": {
       "name": "pull_request_time_to_resolve",
       "description": "3-month trailing average of the monthly median time to resolve pull requests (days) per repo.",

--- a/frontend/public/data/agentic-ai-momentum/research_papers_count.json
+++ b/frontend/public/data/agentic-ai-momentum/research_papers_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:43:24.226770",
+    "fetched_at": "2026-04-01T07:29:21.706084",
     "schema": {
       "name": "research_papers_count",
       "description": "Monthly arXiv paper counts for agentic-AI topics.",
@@ -100,7 +100,7 @@
     {
       "topic": "autonomous_agents",
       "month": "2025-04",
-      "paper_count": 57
+      "paper_count": 56
     },
     {
       "topic": "autonomous_agents",
@@ -125,7 +125,7 @@
     {
       "topic": "autonomous_agents",
       "month": "2025-09",
-      "paper_count": 110
+      "paper_count": 111
     },
     {
       "topic": "autonomous_agents",
@@ -140,12 +140,12 @@
     {
       "topic": "autonomous_agents",
       "month": "2025-12",
-      "paper_count": 108
+      "paper_count": 109
     },
     {
       "topic": "autonomous_agents",
       "month": "2026-01",
-      "paper_count": 134
+      "paper_count": 135
     },
     {
       "topic": "autonomous_agents",
@@ -155,7 +155,7 @@
     {
       "topic": "autonomous_agents",
       "month": "2026-03",
-      "paper_count": 160
+      "paper_count": 182
     },
     {
       "topic": "multi_agent_systems",
@@ -275,17 +275,17 @@
     {
       "topic": "multi_agent_systems",
       "month": "2026-01",
-      "paper_count": 319
+      "paper_count": 320
     },
     {
       "topic": "multi_agent_systems",
       "month": "2026-02",
-      "paper_count": 337
+      "paper_count": 336
     },
     {
       "topic": "multi_agent_systems",
       "month": "2026-03",
-      "paper_count": 383
+      "paper_count": 440
     },
     {
       "topic": "llm_tool_use",
@@ -510,7 +510,7 @@
     {
       "topic": "agent_memory_planning",
       "month": "2025-08",
-      "paper_count": 62
+      "paper_count": 63
     },
     {
       "topic": "agent_memory_planning",
@@ -520,7 +520,7 @@
     {
       "topic": "agent_memory_planning",
       "month": "2025-10",
-      "paper_count": 81
+      "paper_count": 82
     },
     {
       "topic": "agent_memory_planning",
@@ -545,7 +545,7 @@
     {
       "topic": "agent_memory_planning",
       "month": "2026-03",
-      "paper_count": 97
+      "paper_count": 105
     },
     {
       "topic": "agent_safety_alignment",
@@ -665,7 +665,7 @@
     {
       "topic": "agent_safety_alignment",
       "month": "2026-01",
-      "paper_count": 15
+      "paper_count": 16
     },
     {
       "topic": "agent_safety_alignment",
@@ -675,7 +675,7 @@
     {
       "topic": "agent_safety_alignment",
       "month": "2026-03",
-      "paper_count": 19
+      "paper_count": 20
     },
     {
       "topic": "agentic_rag",
@@ -750,7 +750,7 @@
     {
       "topic": "agentic_rag",
       "month": "2025-04",
-      "paper_count": 49
+      "paper_count": 50
     },
     {
       "topic": "agentic_rag",
@@ -805,7 +805,7 @@
     {
       "topic": "agentic_rag",
       "month": "2026-03",
-      "paper_count": 170
+      "paper_count": 190
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/stargazers_count.json
+++ b/frontend/public/data/agentic-ai-momentum/stargazers_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:49.920123",
+    "fetched_at": "2026-04-01T07:13:27.913835",
     "schema": {
       "name": "stargazers_count",
       "description": "Cumulative monthly GitHub star counts for tracked repositories.",
@@ -30,362 +30,362 @@
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-03-01",
-      "cumulative_stars": 6893
+      "cumulative_stars": 6899
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-04-01",
-      "cumulative_stars": 9372
+      "cumulative_stars": 9380
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-05-01",
-      "cumulative_stars": 10107
+      "cumulative_stars": 10115
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-06-01",
-      "cumulative_stars": 12209
+      "cumulative_stars": 12218
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-07-01",
-      "cumulative_stars": 14840
+      "cumulative_stars": 14852
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-08-01",
-      "cumulative_stars": 16829
+      "cumulative_stars": 16844
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-09-01",
-      "cumulative_stars": 19269
+      "cumulative_stars": 19289
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-10-01",
-      "cumulative_stars": 20830
+      "cumulative_stars": 20854
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-11-01",
-      "cumulative_stars": 22346
+      "cumulative_stars": 22375
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2024-12-01",
-      "cumulative_stars": 23733
+      "cumulative_stars": 23763
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-01-01",
-      "cumulative_stars": 25756
+      "cumulative_stars": 25786
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-02-01",
-      "cumulative_stars": 28079
+      "cumulative_stars": 28112
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-03-01",
-      "cumulative_stars": 30132
+      "cumulative_stars": 30167
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-04-01",
-      "cumulative_stars": 32029
+      "cumulative_stars": 32070
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-05-01",
-      "cumulative_stars": 33586
+      "cumulative_stars": 33631
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-06-01",
-      "cumulative_stars": 34933
+      "cumulative_stars": 34984
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-07-01",
-      "cumulative_stars": 36218
+      "cumulative_stars": 36273
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-08-01",
-      "cumulative_stars": 37206
+      "cumulative_stars": 37263
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-09-01",
-      "cumulative_stars": 37916
+      "cumulative_stars": 37974
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-10-01",
-      "cumulative_stars": 38427
+      "cumulative_stars": 38486
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-11-01",
-      "cumulative_stars": 39086
+      "cumulative_stars": 39149
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2025-12-01",
-      "cumulative_stars": 39816
+      "cumulative_stars": 39880
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2026-01-01",
-      "cumulative_stars": 40825
+      "cumulative_stars": 40890
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
       "month": "2026-02-01",
-      "cumulative_stars": 41783
+      "cumulative_stars": 41860
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-03-01",
-      "cumulative_stars": 1105
+      "cumulative_stars": 1143
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-04-01",
-      "cumulative_stars": 1174
+      "cumulative_stars": 1212
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-05-01",
-      "cumulative_stars": 1287
+      "cumulative_stars": 1329
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-06-01",
-      "cumulative_stars": 1355
+      "cumulative_stars": 1401
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-07-01",
-      "cumulative_stars": 1442
+      "cumulative_stars": 1493
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-08-01",
-      "cumulative_stars": 1572
+      "cumulative_stars": 1628
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-09-01",
-      "cumulative_stars": 1648
+      "cumulative_stars": 1705
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-10-01",
-      "cumulative_stars": 1748
+      "cumulative_stars": 1810
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-11-01",
-      "cumulative_stars": 1826
+      "cumulative_stars": 1889
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2024-12-01",
-      "cumulative_stars": 1912
+      "cumulative_stars": 1976
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-01-01",
-      "cumulative_stars": 2037
+      "cumulative_stars": 2107
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-02-01",
-      "cumulative_stars": 2124
+      "cumulative_stars": 2201
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-03-01",
-      "cumulative_stars": 2218
+      "cumulative_stars": 2305
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-04-01",
-      "cumulative_stars": 2324
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-05-01",
       "cumulative_stars": 2414
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
+      "month": "2025-05-01",
+      "cumulative_stars": 2507
+    },
+    {
+      "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-06-01",
-      "cumulative_stars": 2491
+      "cumulative_stars": 2588
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-07-01",
-      "cumulative_stars": 2586
+      "cumulative_stars": 2693
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-08-01",
-      "cumulative_stars": 2699
+      "cumulative_stars": 2815
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-09-01",
-      "cumulative_stars": 2786
+      "cumulative_stars": 2913
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-10-01",
-      "cumulative_stars": 2876
+      "cumulative_stars": 3011
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-11-01",
-      "cumulative_stars": 3001
+      "cumulative_stars": 3140
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2025-12-01",
-      "cumulative_stars": 3094
+      "cumulative_stars": 3241
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-01-01",
-      "cumulative_stars": 3205
+      "cumulative_stars": 3359
     },
     {
       "repo": "https://github.com/Azure/PyRIT",
       "month": "2026-02-01",
-      "cumulative_stars": 3321
+      "cumulative_stars": 3494
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-03-01",
-      "cumulative_stars": 6892
+      "cumulative_stars": 6897
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-04-01",
-      "cumulative_stars": 8107
+      "cumulative_stars": 8112
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-05-01",
-      "cumulative_stars": 9105
+      "cumulative_stars": 9110
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-06-01",
-      "cumulative_stars": 9863
+      "cumulative_stars": 9868
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-07-01",
-      "cumulative_stars": 10616
+      "cumulative_stars": 10624
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-08-01",
-      "cumulative_stars": 11471
+      "cumulative_stars": 11481
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-09-01",
-      "cumulative_stars": 12325
+      "cumulative_stars": 12336
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-10-01",
-      "cumulative_stars": 13190
+      "cumulative_stars": 13201
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-11-01",
-      "cumulative_stars": 14215
+      "cumulative_stars": 14227
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-12-01",
-      "cumulative_stars": 15322
+      "cumulative_stars": 15337
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-01-01",
-      "cumulative_stars": 16658
+      "cumulative_stars": 16674
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-02-01",
-      "cumulative_stars": 18049
+      "cumulative_stars": 18067
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-03-01",
-      "cumulative_stars": 19827
+      "cumulative_stars": 19847
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-04-01",
-      "cumulative_stars": 21637
+      "cumulative_stars": 21660
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-05-01",
-      "cumulative_stars": 23397
+      "cumulative_stars": 23423
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-06-01",
-      "cumulative_stars": 24773
+      "cumulative_stars": 24801
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-07-01",
-      "cumulative_stars": 26758
+      "cumulative_stars": 26790
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-08-01",
-      "cumulative_stars": 28338
+      "cumulative_stars": 28372
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-09-01",
-      "cumulative_stars": 29682
+      "cumulative_stars": 29717
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-10-01",
-      "cumulative_stars": 30884
+      "cumulative_stars": 30921
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-11-01",
-      "cumulative_stars": 32267
+      "cumulative_stars": 32310
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-12-01",
-      "cumulative_stars": 33664
+      "cumulative_stars": 33714
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-01-01",
-      "cumulative_stars": 35557
+      "cumulative_stars": 35611
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "cumulative_stars": 38047
+      "cumulative_stars": 38127
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -400,192 +400,192 @@
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-06-01",
-      "cumulative_stars": 554
+      "cumulative_stars": 642
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-07-01",
-      "cumulative_stars": 2593
+      "cumulative_stars": 3592
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-08-01",
-      "cumulative_stars": 3974
+      "cumulative_stars": 5252
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-09-01",
-      "cumulative_stars": 5514
+      "cumulative_stars": 7308
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-10-01",
-      "cumulative_stars": 7682
+      "cumulative_stars": 9899
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-11-01",
-      "cumulative_stars": 9250
+      "cumulative_stars": 11483
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2024-12-01",
-      "cumulative_stars": 10302
+      "cumulative_stars": 12546
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-01-01",
-      "cumulative_stars": 10877
+      "cumulative_stars": 13142
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-02-01",
-      "cumulative_stars": 11423
+      "cumulative_stars": 13709
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-03-01",
-      "cumulative_stars": 16305
+      "cumulative_stars": 22449
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-04-01",
-      "cumulative_stars": 16879
+      "cumulative_stars": 23043
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-05-01",
-      "cumulative_stars": 17261
+      "cumulative_stars": 23444
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-06-01",
-      "cumulative_stars": 17585
+      "cumulative_stars": 23786
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "cumulative_stars": 17795
+      "cumulative_stars": 24005
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-08-01",
-      "cumulative_stars": 18030
+      "cumulative_stars": 24249
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "cumulative_stars": 18201
+      "cumulative_stars": 24426
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "cumulative_stars": 18388
+      "cumulative_stars": 24624
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "cumulative_stars": 18796
+      "cumulative_stars": 25040
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "cumulative_stars": 18932
+      "cumulative_stars": 25182
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "cumulative_stars": 19238
+      "cumulative_stars": 25498
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "cumulative_stars": 20009
+      "cumulative_stars": 26317
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2024-10-01",
-      "cumulative_stars": 5862
+      "cumulative_stars": 5869
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2024-11-01",
-      "cumulative_stars": 8573
+      "cumulative_stars": 8585
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2024-12-01",
-      "cumulative_stars": 10435
+      "cumulative_stars": 10449
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-01-01",
-      "cumulative_stars": 11179
+      "cumulative_stars": 11194
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-02-01",
-      "cumulative_stars": 12099
+      "cumulative_stars": 12115
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-03-01",
-      "cumulative_stars": 13065
+      "cumulative_stars": 13081
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-04-01",
-      "cumulative_stars": 15639
+      "cumulative_stars": 15660
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-05-01",
-      "cumulative_stars": 16708
+      "cumulative_stars": 16731
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-06-01",
-      "cumulative_stars": 17745
+      "cumulative_stars": 17770
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-07-01",
-      "cumulative_stars": 18788
+      "cumulative_stars": 18813
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-08-01",
-      "cumulative_stars": 20021
+      "cumulative_stars": 20048
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-09-01",
-      "cumulative_stars": 21329
+      "cumulative_stars": 21361
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-10-01",
-      "cumulative_stars": 22206
+      "cumulative_stars": 22238
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-11-01",
-      "cumulative_stars": 24810
+      "cumulative_stars": 24846
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-12-01",
-      "cumulative_stars": 26866
+      "cumulative_stars": 26909
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-01-01",
-      "cumulative_stars": 27848
+      "cumulative_stars": 27896
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-02-01",
-      "cumulative_stars": 28930
+      "cumulative_stars": 28981
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
@@ -710,582 +710,582 @@
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-07-01",
-      "cumulative_stars": 500
+      "cumulative_stars": 504
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-08-01",
-      "cumulative_stars": 613
+      "cumulative_stars": 617
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-09-01",
-      "cumulative_stars": 649
+      "cumulative_stars": 653
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-10-01",
-      "cumulative_stars": 676
+      "cumulative_stars": 680
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-11-01",
-      "cumulative_stars": 718
+      "cumulative_stars": 725
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2024-12-01",
-      "cumulative_stars": 928
+      "cumulative_stars": 938
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-01-01",
-      "cumulative_stars": 1337
+      "cumulative_stars": 1352
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-02-01",
-      "cumulative_stars": 1474
+      "cumulative_stars": 1492
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-03-01",
-      "cumulative_stars": 1558
+      "cumulative_stars": 1577
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-04-01",
-      "cumulative_stars": 1608
+      "cumulative_stars": 1629
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-05-01",
-      "cumulative_stars": 1659
+      "cumulative_stars": 1680
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-06-01",
-      "cumulative_stars": 1716
+      "cumulative_stars": 1738
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-07-01",
-      "cumulative_stars": 1802
+      "cumulative_stars": 1825
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-08-01",
-      "cumulative_stars": 1845
+      "cumulative_stars": 1868
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-09-01",
-      "cumulative_stars": 1876
+      "cumulative_stars": 1901
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-10-01",
-      "cumulative_stars": 1903
+      "cumulative_stars": 1928
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-11-01",
-      "cumulative_stars": 1931
+      "cumulative_stars": 1959
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2025-12-01",
-      "cumulative_stars": 1951
+      "cumulative_stars": 1980
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2026-01-01",
-      "cumulative_stars": 1964
+      "cumulative_stars": 1995
     },
     {
       "repo": "https://github.com/OpenAutoCoder/Agentless",
       "month": "2026-02-01",
-      "cumulative_stars": 1970
+      "cumulative_stars": 2001
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-03-01",
-      "cumulative_stars": 10581
+      "cumulative_stars": 11347
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-04-01",
-      "cumulative_stars": 20475
+      "cumulative_stars": 21909
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-05-01",
-      "cumulative_stars": 23462
+      "cumulative_stars": 24994
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-06-01",
-      "cumulative_stars": 24848
+      "cumulative_stars": 26422
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-07-01",
-      "cumulative_stars": 26001
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2024-08-01",
       "cumulative_stars": 27608
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2024-08-01",
+      "cumulative_stars": 29256
+    },
+    {
+      "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-09-01",
-      "cumulative_stars": 28989
+      "cumulative_stars": 30679
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-10-01",
-      "cumulative_stars": 30084
+      "cumulative_stars": 31806
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-11-01",
-      "cumulative_stars": 34246
+      "cumulative_stars": 36075
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2024-12-01",
-      "cumulative_stars": 36118
+      "cumulative_stars": 38003
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-01-01",
-      "cumulative_stars": 41243
+      "cumulative_stars": 43342
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-02-01",
-      "cumulative_stars": 44471
+      "cumulative_stars": 46645
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-03-01",
-      "cumulative_stars": 47822
+      "cumulative_stars": 50091
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-04-01",
-      "cumulative_stars": 49767
+      "cumulative_stars": 52104
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-05-01",
-      "cumulative_stars": 53064
+      "cumulative_stars": 55492
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-06-01",
-      "cumulative_stars": 55643
+      "cumulative_stars": 58136
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-07-01",
-      "cumulative_stars": 57626
+      "cumulative_stars": 60183
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-08-01",
-      "cumulative_stars": 59111
+      "cumulative_stars": 61740
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "cumulative_stars": 60095
+      "cumulative_stars": 62764
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "cumulative_stars": 60907
+      "cumulative_stars": 63613
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "cumulative_stars": 61723
+      "cumulative_stars": 64463
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-12-01",
-      "cumulative_stars": 62540
+      "cumulative_stars": 65305
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "cumulative_stars": 63919
+      "cumulative_stars": 66735
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "cumulative_stars": 65016
+      "cumulative_stars": 67868
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-03-01",
-      "cumulative_stars": 14072
+      "cumulative_stars": 14090
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-04-01",
-      "cumulative_stars": 14363
+      "cumulative_stars": 14381
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-05-01",
-      "cumulative_stars": 14783
+      "cumulative_stars": 14801
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-06-01",
-      "cumulative_stars": 15031
+      "cumulative_stars": 15049
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-07-01",
-      "cumulative_stars": 15270
+      "cumulative_stars": 15288
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-08-01",
-      "cumulative_stars": 15487
+      "cumulative_stars": 15505
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-09-01",
-      "cumulative_stars": 15727
+      "cumulative_stars": 15746
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-10-01",
-      "cumulative_stars": 16108
+      "cumulative_stars": 16129
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-11-01",
-      "cumulative_stars": 17394
+      "cumulative_stars": 17416
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2024-12-01",
-      "cumulative_stars": 17695
+      "cumulative_stars": 17717
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-01-01",
-      "cumulative_stars": 17999
+      "cumulative_stars": 18022
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-02-01",
-      "cumulative_stars": 18339
+      "cumulative_stars": 18364
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-03-01",
-      "cumulative_stars": 18724
+      "cumulative_stars": 18749
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-04-01",
-      "cumulative_stars": 19089
+      "cumulative_stars": 19114
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-05-01",
-      "cumulative_stars": 19369
+      "cumulative_stars": 19395
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-06-01",
-      "cumulative_stars": 19639
+      "cumulative_stars": 19665
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-07-01",
-      "cumulative_stars": 19907
+      "cumulative_stars": 19933
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-08-01",
-      "cumulative_stars": 20277
+      "cumulative_stars": 20303
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-09-01",
-      "cumulative_stars": 20584
+      "cumulative_stars": 20610
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-10-01",
-      "cumulative_stars": 20842
+      "cumulative_stars": 20869
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-11-01",
-      "cumulative_stars": 21138
+      "cumulative_stars": 21165
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2025-12-01",
-      "cumulative_stars": 21430
+      "cumulative_stars": 21457
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-01-01",
-      "cumulative_stars": 21762
+      "cumulative_stars": 21789
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-02-01",
-      "cumulative_stars": 22001
+      "cumulative_stars": 22031
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
-      "cumulative_stars": 9257
+      "cumulative_stars": 9381
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "cumulative_stars": 9687
+      "cumulative_stars": 9816
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "cumulative_stars": 9995
+      "cumulative_stars": 10125
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-06-01",
-      "cumulative_stars": 10260
+      "cumulative_stars": 10393
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-07-01",
-      "cumulative_stars": 10577
+      "cumulative_stars": 10715
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "cumulative_stars": 10777
+      "cumulative_stars": 10919
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "cumulative_stars": 10904
+      "cumulative_stars": 11047
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "cumulative_stars": 11049
+      "cumulative_stars": 11198
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "cumulative_stars": 11164
+      "cumulative_stars": 11314
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "cumulative_stars": 11275
+      "cumulative_stars": 11428
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-01-01",
-      "cumulative_stars": 11388
+      "cumulative_stars": 11542
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
-      "cumulative_stars": 11506
+      "cumulative_stars": 11662
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-03-01",
-      "cumulative_stars": 11611
+      "cumulative_stars": 11767
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-04-01",
-      "cumulative_stars": 11711
+      "cumulative_stars": 11870
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-05-01",
-      "cumulative_stars": 11792
+      "cumulative_stars": 11953
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-06-01",
-      "cumulative_stars": 11894
+      "cumulative_stars": 12056
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-07-01",
-      "cumulative_stars": 11992
+      "cumulative_stars": 12156
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-08-01",
-      "cumulative_stars": 12069
+      "cumulative_stars": 12233
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-09-01",
-      "cumulative_stars": 12155
+      "cumulative_stars": 12323
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-10-01",
-      "cumulative_stars": 12237
+      "cumulative_stars": 12409
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "cumulative_stars": 12303
+      "cumulative_stars": 12477
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-12-01",
-      "cumulative_stars": 12384
+      "cumulative_stars": 12561
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "cumulative_stars": 12446
+      "cumulative_stars": 12625
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "cumulative_stars": 12485
+      "cumulative_stars": 12667
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-03-01",
-      "cumulative_stars": 156790
+      "cumulative_stars": 157031
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-04-01",
-      "cumulative_stars": 158329
+      "cumulative_stars": 158573
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-05-01",
-      "cumulative_stars": 159753
+      "cumulative_stars": 159997
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-06-01",
-      "cumulative_stars": 160889
+      "cumulative_stars": 161137
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-07-01",
-      "cumulative_stars": 163008
+      "cumulative_stars": 163260
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-08-01",
-      "cumulative_stars": 164049
+      "cumulative_stars": 164303
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-09-01",
-      "cumulative_stars": 165250
+      "cumulative_stars": 165505
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-10-01",
-      "cumulative_stars": 166330
+      "cumulative_stars": 166587
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-11-01",
-      "cumulative_stars": 167423
+      "cumulative_stars": 167686
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-12-01",
-      "cumulative_stars": 168891
+      "cumulative_stars": 169157
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-01-01",
-      "cumulative_stars": 170235
+      "cumulative_stars": 170502
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-02-01",
-      "cumulative_stars": 171635
+      "cumulative_stars": 171903
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-03-01",
-      "cumulative_stars": 173934
+      "cumulative_stars": 174208
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-04-01",
-      "cumulative_stars": 175144
+      "cumulative_stars": 175422
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-05-01",
-      "cumulative_stars": 176305
+      "cumulative_stars": 176585
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-06-01",
-      "cumulative_stars": 177298
+      "cumulative_stars": 177579
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-07-01",
-      "cumulative_stars": 178460
+      "cumulative_stars": 178743
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-08-01",
-      "cumulative_stars": 179521
+      "cumulative_stars": 179806
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-09-01",
-      "cumulative_stars": 180440
+      "cumulative_stars": 180726
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-10-01",
-      "cumulative_stars": 181382
+      "cumulative_stars": 181675
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-11-01",
-      "cumulative_stars": 182281
+      "cumulative_stars": 182574
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-12-01",
-      "cumulative_stars": 183278
+      "cumulative_stars": 183574
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-01-01",
-      "cumulative_stars": 184544
+      "cumulative_stars": 184843
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "cumulative_stars": 185458
+      "cumulative_stars": 185776
     },
     {
       "repo": "https://github.com/agntcy/acp-spec",
@@ -1475,122 +1475,122 @@
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-03-01",
-      "cumulative_stars": 7535
+      "cumulative_stars": 7549
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-04-01",
-      "cumulative_stars": 8378
+      "cumulative_stars": 8393
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-05-01",
-      "cumulative_stars": 11617
+      "cumulative_stars": 11640
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-06-01",
-      "cumulative_stars": 12541
+      "cumulative_stars": 12566
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-07-01",
-      "cumulative_stars": 12988
+      "cumulative_stars": 13014
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-08-01",
-      "cumulative_stars": 13399
+      "cumulative_stars": 13426
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-09-01",
-      "cumulative_stars": 13865
+      "cumulative_stars": 13892
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-10-01",
-      "cumulative_stars": 14343
+      "cumulative_stars": 14372
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-11-01",
-      "cumulative_stars": 14744
+      "cumulative_stars": 14773
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-12-01",
-      "cumulative_stars": 15120
+      "cumulative_stars": 15151
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-01-01",
-      "cumulative_stars": 15667
+      "cumulative_stars": 15699
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-02-01",
-      "cumulative_stars": 19139
+      "cumulative_stars": 19182
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-03-01",
-      "cumulative_stars": 20353
+      "cumulative_stars": 20402
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-04-01",
-      "cumulative_stars": 20932
+      "cumulative_stars": 20981
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-05-01",
-      "cumulative_stars": 21404
+      "cumulative_stars": 21454
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-06-01",
-      "cumulative_stars": 21949
+      "cumulative_stars": 22000
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-07-01",
-      "cumulative_stars": 22476
+      "cumulative_stars": 22528
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-08-01",
-      "cumulative_stars": 23149
+      "cumulative_stars": 23203
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-09-01",
-      "cumulative_stars": 23604
+      "cumulative_stars": 23658
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-10-01",
-      "cumulative_stars": 23973
+      "cumulative_stars": 24027
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-11-01",
-      "cumulative_stars": 24346
+      "cumulative_stars": 24401
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-12-01",
-      "cumulative_stars": 24754
+      "cumulative_stars": 24810
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2026-01-01",
-      "cumulative_stars": 25277
+      "cumulative_stars": 25334
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2026-02-01",
-      "cumulative_stars": 25671
+      "cumulative_stars": 25731
     },
     {
       "repo": "https://github.com/block/goose",
@@ -1620,392 +1620,392 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2025-01-01",
+      "cumulative_stars": 4456
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-02-01",
+      "cumulative_stars": 8890
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-03-01",
+      "cumulative_stars": 10927
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-04-01",
+      "cumulative_stars": 12021
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-05-01",
+      "cumulative_stars": 13099
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-06-01",
+      "cumulative_stars": 15171
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-07-01",
+      "cumulative_stars": 17653
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-08-01",
+      "cumulative_stars": 19223
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-09-01",
+      "cumulative_stars": 20094
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-10-01",
+      "cumulative_stars": 21574
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-11-01",
+      "cumulative_stars": 22827
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2025-12-01",
+      "cumulative_stars": 25696
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2026-01-01",
+      "cumulative_stars": 30250
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2026-02-01",
+      "cumulative_stars": 32326
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2024-11-01",
+      "cumulative_stars": 2581
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2024-12-01",
+      "cumulative_stars": 7712
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-01-01",
+      "cumulative_stars": 21243
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-02-01",
+      "cumulative_stars": 33131
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-03-01",
+      "cumulative_stars": 49127
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-04-01",
+      "cumulative_stars": 56725
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-05-01",
+      "cumulative_stars": 60208
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-06-01",
+      "cumulative_stars": 62649
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-07-01",
+      "cumulative_stars": 65007
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-08-01",
+      "cumulative_stars": 67416
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-09-01",
+      "cumulative_stars": 69245
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-10-01",
+      "cumulative_stars": 70679
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-11-01",
+      "cumulative_stars": 71906
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2025-12-01",
+      "cumulative_stars": 73367
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2026-01-01",
+      "cumulative_stars": 76560
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2026-02-01",
+      "cumulative_stars": 78415
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-03-01",
+      "cumulative_stars": 4173
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-04-01",
+      "cumulative_stars": 4305
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-05-01",
       "cumulative_stars": 4449
     },
     {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-02-01",
-      "cumulative_stars": 8877
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-03-01",
-      "cumulative_stars": 10913
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-04-01",
-      "cumulative_stars": 12006
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-05-01",
-      "cumulative_stars": 13084
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-06-01",
-      "cumulative_stars": 15153
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-07-01",
-      "cumulative_stars": 17628
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-08-01",
-      "cumulative_stars": 19193
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-09-01",
-      "cumulative_stars": 20064
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-10-01",
-      "cumulative_stars": 21541
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-11-01",
-      "cumulative_stars": 22792
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2025-12-01",
-      "cumulative_stars": 25648
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2026-01-01",
-      "cumulative_stars": 30182
-    },
-    {
-      "repo": "https://github.com/block/goose",
-      "month": "2026-02-01",
-      "cumulative_stars": 32245
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2024-11-01",
-      "cumulative_stars": 2544
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2024-12-01",
-      "cumulative_stars": 7337
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-01-01",
-      "cumulative_stars": 20239
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-02-01",
-      "cumulative_stars": 31682
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-03-01",
-      "cumulative_stars": 47169
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-04-01",
-      "cumulative_stars": 54431
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-05-01",
-      "cumulative_stars": 57716
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-06-01",
-      "cumulative_stars": 60036
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-07-01",
-      "cumulative_stars": 62264
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-08-01",
-      "cumulative_stars": 64541
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-09-01",
-      "cumulative_stars": 66275
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-10-01",
-      "cumulative_stars": 67625
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-11-01",
-      "cumulative_stars": 68753
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2025-12-01",
-      "cumulative_stars": 70132
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2026-01-01",
-      "cumulative_stars": 73103
-    },
-    {
-      "repo": "https://github.com/browser-use/browser-use",
-      "month": "2026-02-01",
-      "cumulative_stars": 74819
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-03-01",
-      "cumulative_stars": 4110
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-04-01",
-      "cumulative_stars": 4236
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-05-01",
-      "cumulative_stars": 4377
-    },
-    {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-06-01",
-      "cumulative_stars": 4513
+      "cumulative_stars": 4589
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-07-01",
-      "cumulative_stars": 4831
+      "cumulative_stars": 4910
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-08-01",
-      "cumulative_stars": 5045
+      "cumulative_stars": 5124
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "cumulative_stars": 5159
+      "cumulative_stars": 5240
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "cumulative_stars": 5311
+      "cumulative_stars": 5397
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-11-01",
-      "cumulative_stars": 5499
+      "cumulative_stars": 5594
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-12-01",
-      "cumulative_stars": 5684
+      "cumulative_stars": 5786
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "cumulative_stars": 5882
+      "cumulative_stars": 5989
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-02-01",
-      "cumulative_stars": 6208
+      "cumulative_stars": 6330
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "cumulative_stars": 10754
+      "cumulative_stars": 11045
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-04-01",
-      "cumulative_stars": 11609
+      "cumulative_stars": 11931
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "cumulative_stars": 12138
+      "cumulative_stars": 12473
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-06-01",
-      "cumulative_stars": 12546
+      "cumulative_stars": 12900
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-07-01",
-      "cumulative_stars": 13025
+      "cumulative_stars": 13399
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "cumulative_stars": 13428
+      "cumulative_stars": 13839
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-09-01",
-      "cumulative_stars": 13786
+      "cumulative_stars": 14217
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "cumulative_stars": 14068
+      "cumulative_stars": 14512
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-11-01",
-      "cumulative_stars": 14327
+      "cumulative_stars": 14792
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-12-01",
-      "cumulative_stars": 14605
+      "cumulative_stars": 15078
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "cumulative_stars": 15279
+      "cumulative_stars": 15789
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "cumulative_stars": 15546
+      "cumulative_stars": 16071
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-03-01",
-      "cumulative_stars": 11481
+      "cumulative_stars": 11493
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-04-01",
-      "cumulative_stars": 12071
+      "cumulative_stars": 12084
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-05-01",
-      "cumulative_stars": 12563
+      "cumulative_stars": 12576
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-06-01",
-      "cumulative_stars": 13109
+      "cumulative_stars": 13122
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-07-01",
-      "cumulative_stars": 13621
+      "cumulative_stars": 13635
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-08-01",
-      "cumulative_stars": 14084
+      "cumulative_stars": 14098
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-09-01",
-      "cumulative_stars": 14506
+      "cumulative_stars": 14523
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-10-01",
-      "cumulative_stars": 14966
+      "cumulative_stars": 14984
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-11-01",
-      "cumulative_stars": 15426
+      "cumulative_stars": 15444
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-12-01",
-      "cumulative_stars": 15925
+      "cumulative_stars": 15946
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-01-01",
-      "cumulative_stars": 17137
+      "cumulative_stars": 17160
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-02-01",
-      "cumulative_stars": 17984
+      "cumulative_stars": 18008
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-03-01",
-      "cumulative_stars": 18868
+      "cumulative_stars": 18893
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-04-01",
-      "cumulative_stars": 19477
+      "cumulative_stars": 19503
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-05-01",
-      "cumulative_stars": 20100
+      "cumulative_stars": 20126
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-06-01",
-      "cumulative_stars": 20715
+      "cumulative_stars": 20741
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-07-01",
-      "cumulative_stars": 21390
+      "cumulative_stars": 21416
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-08-01",
-      "cumulative_stars": 22846
+      "cumulative_stars": 22875
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-09-01",
-      "cumulative_stars": 23696
+      "cumulative_stars": 23726
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-10-01",
-      "cumulative_stars": 24272
+      "cumulative_stars": 24303
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-11-01",
-      "cumulative_stars": 24784
+      "cumulative_stars": 24817
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-12-01",
-      "cumulative_stars": 25418
+      "cumulative_stars": 25453
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-01-01",
-      "cumulative_stars": 26122
+      "cumulative_stars": 26157
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-02-01",
-      "cumulative_stars": 26663
+      "cumulative_stars": 26707
     },
     {
       "repo": "https://github.com/cline/cline",
@@ -2015,817 +2015,817 @@
     {
       "repo": "https://github.com/cline/cline",
       "month": "2024-08-01",
-      "cumulative_stars": 2595
+      "cumulative_stars": 2596
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2024-09-01",
-      "cumulative_stars": 5341
+      "cumulative_stars": 5348
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2024-10-01",
-      "cumulative_stars": 9505
+      "cumulative_stars": 9516
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2024-11-01",
-      "cumulative_stars": 12497
+      "cumulative_stars": 12513
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2024-12-01",
-      "cumulative_stars": 17125
+      "cumulative_stars": 17161
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-01-01",
-      "cumulative_stars": 25254
+      "cumulative_stars": 25298
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-02-01",
-      "cumulative_stars": 31052
+      "cumulative_stars": 31111
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-03-01",
-      "cumulative_stars": 36700
+      "cumulative_stars": 36777
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-04-01",
-      "cumulative_stars": 41133
+      "cumulative_stars": 41220
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-05-01",
-      "cumulative_stars": 43851
+      "cumulative_stars": 43939
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-06-01",
-      "cumulative_stars": 45737
+      "cumulative_stars": 45828
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-07-01",
-      "cumulative_stars": 47625
+      "cumulative_stars": 47722
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-08-01",
-      "cumulative_stars": 49261
+      "cumulative_stars": 49360
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-09-01",
-      "cumulative_stars": 50380
+      "cumulative_stars": 50481
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-10-01",
-      "cumulative_stars": 51456
+      "cumulative_stars": 51559
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-11-01",
-      "cumulative_stars": 53396
+      "cumulative_stars": 53504
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2025-12-01",
-      "cumulative_stars": 56354
+      "cumulative_stars": 56474
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2026-01-01",
-      "cumulative_stars": 57469
+      "cumulative_stars": 57592
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2026-02-01",
-      "cumulative_stars": 58851
+      "cumulative_stars": 58982
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-03-01",
-      "cumulative_stars": 395
+      "cumulative_stars": 407
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-04-01",
-      "cumulative_stars": 411
+      "cumulative_stars": 423
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-05-01",
-      "cumulative_stars": 424
+      "cumulative_stars": 438
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-06-01",
-      "cumulative_stars": 437
+      "cumulative_stars": 451
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-07-01",
-      "cumulative_stars": 449
+      "cumulative_stars": 463
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-08-01",
-      "cumulative_stars": 469
+      "cumulative_stars": 483
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-09-01",
-      "cumulative_stars": 1358
+      "cumulative_stars": 1390
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-10-01",
-      "cumulative_stars": 1752
+      "cumulative_stars": 1796
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-11-01",
-      "cumulative_stars": 2232
+      "cumulative_stars": 2286
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-12-01",
-      "cumulative_stars": 3573
+      "cumulative_stars": 3713
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-01-01",
-      "cumulative_stars": 4409
+      "cumulative_stars": 4571
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "cumulative_stars": 4826
+      "cumulative_stars": 5001
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "cumulative_stars": 5605
+      "cumulative_stars": 5819
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-04-01",
-      "cumulative_stars": 6653
+      "cumulative_stars": 6975
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "cumulative_stars": 8416
+      "cumulative_stars": 8810
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-06-01",
-      "cumulative_stars": 9662
+      "cumulative_stars": 10138
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-07-01",
-      "cumulative_stars": 11014
+      "cumulative_stars": 11575
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "cumulative_stars": 12266
+      "cumulative_stars": 12910
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "cumulative_stars": 13209
+      "cumulative_stars": 13935
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-10-01",
-      "cumulative_stars": 14004
+      "cumulative_stars": 14898
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "cumulative_stars": 14858
+      "cumulative_stars": 15822
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "cumulative_stars": 15621
+      "cumulative_stars": 16686
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "cumulative_stars": 16104
+      "cumulative_stars": 17220
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "cumulative_stars": 16421
+      "cumulative_stars": 17585
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-03-01",
-      "cumulative_stars": 1451
+      "cumulative_stars": 1476
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-04-01",
-      "cumulative_stars": 1697
+      "cumulative_stars": 1728
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-05-01",
-      "cumulative_stars": 1921
+      "cumulative_stars": 1959
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-06-01",
-      "cumulative_stars": 2204
+      "cumulative_stars": 2245
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-07-01",
-      "cumulative_stars": 2444
+      "cumulative_stars": 2495
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-08-01",
-      "cumulative_stars": 2705
+      "cumulative_stars": 2767
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-09-01",
-      "cumulative_stars": 2941
+      "cumulative_stars": 3016
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-10-01",
-      "cumulative_stars": 3269
+      "cumulative_stars": 3365
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-11-01",
-      "cumulative_stars": 3645
+      "cumulative_stars": 3754
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2024-12-01",
-      "cumulative_stars": 3948
+      "cumulative_stars": 4061
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-01-01",
-      "cumulative_stars": 4401
+      "cumulative_stars": 4522
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-02-01",
-      "cumulative_stars": 5038
+      "cumulative_stars": 5173
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-03-01",
-      "cumulative_stars": 5540
+      "cumulative_stars": 5688
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-04-01",
-      "cumulative_stars": 5852
+      "cumulative_stars": 6014
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-05-01",
-      "cumulative_stars": 6636
+      "cumulative_stars": 6830
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-06-01",
-      "cumulative_stars": 8175
+      "cumulative_stars": 8457
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-07-01",
-      "cumulative_stars": 9193
+      "cumulative_stars": 9511
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-08-01",
-      "cumulative_stars": 9958
+      "cumulative_stars": 10311
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-09-01",
-      "cumulative_stars": 10767
+      "cumulative_stars": 11172
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-10-01",
-      "cumulative_stars": 11319
+      "cumulative_stars": 11758
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-11-01",
-      "cumulative_stars": 11770
+      "cumulative_stars": 12233
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "cumulative_stars": 12171
+      "cumulative_stars": 12656
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "cumulative_stars": 12631
+      "cumulative_stars": 13137
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "cumulative_stars": 13196
+      "cumulative_stars": 13749
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-03-01",
-      "cumulative_stars": 9409
+      "cumulative_stars": 9415
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-04-01",
-      "cumulative_stars": 10688
+      "cumulative_stars": 10694
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-05-01",
-      "cumulative_stars": 11757
+      "cumulative_stars": 11765
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-06-01",
-      "cumulative_stars": 12552
+      "cumulative_stars": 12561
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-07-01",
-      "cumulative_stars": 13503
+      "cumulative_stars": 13512
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-08-01",
-      "cumulative_stars": 14685
+      "cumulative_stars": 14694
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-09-01",
-      "cumulative_stars": 16336
+      "cumulative_stars": 16348
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-10-01",
-      "cumulative_stars": 18222
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2024-11-01",
-      "cumulative_stars": 19177
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2024-12-01",
-      "cumulative_stars": 20287
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-01-01",
-      "cumulative_stars": 21824
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-02-01",
-      "cumulative_stars": 23593
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-03-01",
-      "cumulative_stars": 24746
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-04-01",
-      "cumulative_stars": 25705
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-05-01",
-      "cumulative_stars": 26387
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-06-01",
-      "cumulative_stars": 27289
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-07-01",
-      "cumulative_stars": 28019
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-08-01",
-      "cumulative_stars": 28778
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-09-01",
-      "cumulative_stars": 29377
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-10-01",
-      "cumulative_stars": 29970
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-11-01",
-      "cumulative_stars": 30554
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-12-01",
-      "cumulative_stars": 31223
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2026-01-01",
-      "cumulative_stars": 31953
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2026-02-01",
-      "cumulative_stars": 32437
-    },
-    {
-      "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2024-03-01",
-      "cumulative_stars": 10483
-    },
-    {
-      "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2024-04-01",
-      "cumulative_stars": 12721
-    },
-    {
-      "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2024-05-01",
-      "cumulative_stars": 14748
-    },
-    {
-      "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2024-06-01",
-      "cumulative_stars": 16167
-    },
-    {
-      "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2024-07-01",
-      "cumulative_stars": 17317
-    },
-    {
-      "repo": "https://github.com/crewAIInc/crewAI",
-      "month": "2024-08-01",
       "cumulative_stars": 18239
     },
     {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2024-11-01",
+      "cumulative_stars": 19196
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2024-12-01",
+      "cumulative_stars": 20308
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-01-01",
+      "cumulative_stars": 21846
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-02-01",
+      "cumulative_stars": 23618
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-03-01",
+      "cumulative_stars": 24774
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-04-01",
+      "cumulative_stars": 25734
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-05-01",
+      "cumulative_stars": 26416
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-06-01",
+      "cumulative_stars": 27323
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-07-01",
+      "cumulative_stars": 28056
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-08-01",
+      "cumulative_stars": 28818
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-09-01",
+      "cumulative_stars": 29417
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-10-01",
+      "cumulative_stars": 30011
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-11-01",
+      "cumulative_stars": 30598
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2025-12-01",
+      "cumulative_stars": 31267
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2026-01-01",
+      "cumulative_stars": 31999
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2026-02-01",
+      "cumulative_stars": 32486
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2024-03-01",
+      "cumulative_stars": 10491
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2024-04-01",
+      "cumulative_stars": 12733
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2024-05-01",
+      "cumulative_stars": 14762
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2024-06-01",
+      "cumulative_stars": 16185
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2024-07-01",
+      "cumulative_stars": 17337
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2024-08-01",
+      "cumulative_stars": 18261
+    },
+    {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2024-09-01",
-      "cumulative_stars": 19141
+      "cumulative_stars": 19164
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2024-10-01",
-      "cumulative_stars": 20198
+      "cumulative_stars": 20223
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2024-11-01",
-      "cumulative_stars": 21350
+      "cumulative_stars": 21379
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2024-12-01",
-      "cumulative_stars": 22837
+      "cumulative_stars": 22868
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-01-01",
-      "cumulative_stars": 25176
+      "cumulative_stars": 25211
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-02-01",
-      "cumulative_stars": 26969
+      "cumulative_stars": 27007
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-03-01",
-      "cumulative_stars": 28844
+      "cumulative_stars": 28885
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-04-01",
-      "cumulative_stars": 30343
+      "cumulative_stars": 30387
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-05-01",
-      "cumulative_stars": 31869
+      "cumulative_stars": 31916
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-06-01",
-      "cumulative_stars": 33208
+      "cumulative_stars": 33258
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-07-01",
-      "cumulative_stars": 34789
+      "cumulative_stars": 34841
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-08-01",
-      "cumulative_stars": 36033
+      "cumulative_stars": 36090
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-09-01",
-      "cumulative_stars": 38494
+      "cumulative_stars": 38555
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-10-01",
-      "cumulative_stars": 39795
+      "cumulative_stars": 39862
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-11-01",
-      "cumulative_stars": 40876
+      "cumulative_stars": 40952
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2025-12-01",
-      "cumulative_stars": 42121
+      "cumulative_stars": 42199
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2026-01-01",
-      "cumulative_stars": 43602
+      "cumulative_stars": 43688
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2026-02-01",
-      "cumulative_stars": 45137
+      "cumulative_stars": 45232
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "cumulative_stars": 4482
+      "cumulative_stars": 4691
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "cumulative_stars": 4865
+      "cumulative_stars": 5078
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "cumulative_stars": 5020
+      "cumulative_stars": 5239
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "cumulative_stars": 5879
+      "cumulative_stars": 6250
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "cumulative_stars": 6149
+      "cumulative_stars": 6563
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-08-01",
-      "cumulative_stars": 6829
+      "cumulative_stars": 7311
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "cumulative_stars": 7310
+      "cumulative_stars": 7866
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-10-01",
-      "cumulative_stars": 7864
+      "cumulative_stars": 8786
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-11-01",
-      "cumulative_stars": 9341
+      "cumulative_stars": 11130
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "cumulative_stars": 10208
+      "cumulative_stars": 12479
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-01-01",
-      "cumulative_stars": 10490
+      "cumulative_stars": 12765
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-02-01",
-      "cumulative_stars": 10896
+      "cumulative_stars": 13280
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-03-01",
-      "cumulative_stars": 11069
+      "cumulative_stars": 13497
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "cumulative_stars": 12706
+      "cumulative_stars": 15548
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-05-01",
-      "cumulative_stars": 15025
+      "cumulative_stars": 18550
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "cumulative_stars": 15279
+      "cumulative_stars": 18807
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "cumulative_stars": 15717
+      "cumulative_stars": 19321
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "cumulative_stars": 16020
+      "cumulative_stars": 19740
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "cumulative_stars": 16198
+      "cumulative_stars": 19959
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "cumulative_stars": 19712
+      "cumulative_stars": 24597
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "cumulative_stars": 22395
+      "cumulative_stars": 31242
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "cumulative_stars": 24588
+      "cumulative_stars": 37085
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "cumulative_stars": 27555
+      "cumulative_stars": 46980
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "cumulative_stars": 30070
+      "cumulative_stars": 56259
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-03-01",
-      "cumulative_stars": 13033
+      "cumulative_stars": 13046
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-04-01",
-      "cumulative_stars": 13411
+      "cumulative_stars": 13425
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-05-01",
-      "cumulative_stars": 13849
+      "cumulative_stars": 13863
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-06-01",
-      "cumulative_stars": 14209
+      "cumulative_stars": 14224
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-07-01",
-      "cumulative_stars": 14697
+      "cumulative_stars": 14715
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-08-01",
-      "cumulative_stars": 15998
+      "cumulative_stars": 16018
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-09-01",
-      "cumulative_stars": 16660
+      "cumulative_stars": 16682
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-10-01",
-      "cumulative_stars": 17179
+      "cumulative_stars": 17201
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-11-01",
-      "cumulative_stars": 17651
+      "cumulative_stars": 17676
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2024-12-01",
-      "cumulative_stars": 18091
+      "cumulative_stars": 18116
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-01-01",
-      "cumulative_stars": 18680
+      "cumulative_stars": 18706
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-02-01",
-      "cumulative_stars": 19293
+      "cumulative_stars": 19319
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-03-01",
-      "cumulative_stars": 19902
+      "cumulative_stars": 19928
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-04-01",
-      "cumulative_stars": 20340
+      "cumulative_stars": 20368
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-05-01",
-      "cumulative_stars": 20831
+      "cumulative_stars": 20859
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-06-01",
-      "cumulative_stars": 21221
+      "cumulative_stars": 21249
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-07-01",
-      "cumulative_stars": 21618
+      "cumulative_stars": 21649
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-08-01",
-      "cumulative_stars": 22014
+      "cumulative_stars": 22047
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-09-01",
-      "cumulative_stars": 22779
+      "cumulative_stars": 22815
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-10-01",
-      "cumulative_stars": 23208
+      "cumulative_stars": 23247
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-11-01",
-      "cumulative_stars": 23514
+      "cumulative_stars": 23556
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2025-12-01",
-      "cumulative_stars": 23826
+      "cumulative_stars": 23870
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2026-01-01",
-      "cumulative_stars": 24150
+      "cumulative_stars": 24194
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
       "month": "2026-02-01",
-      "cumulative_stars": 24486
+      "cumulative_stars": 24532
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
@@ -2835,487 +2835,487 @@
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-04-01",
-      "cumulative_stars": 265
+      "cumulative_stars": 266
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-05-01",
-      "cumulative_stars": 646
+      "cumulative_stars": 650
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-06-01",
-      "cumulative_stars": 788
+      "cumulative_stars": 793
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-07-01",
-      "cumulative_stars": 905
+      "cumulative_stars": 910
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-08-01",
-      "cumulative_stars": 1024
+      "cumulative_stars": 1029
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-09-01",
-      "cumulative_stars": 1104
+      "cumulative_stars": 1110
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-10-01",
-      "cumulative_stars": 1199
+      "cumulative_stars": 1205
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-11-01",
-      "cumulative_stars": 1248
+      "cumulative_stars": 1255
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2024-12-01",
-      "cumulative_stars": 1323
+      "cumulative_stars": 1330
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-01-01",
-      "cumulative_stars": 1397
+      "cumulative_stars": 1404
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-02-01",
-      "cumulative_stars": 1471
+      "cumulative_stars": 1478
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-03-01",
-      "cumulative_stars": 1585
+      "cumulative_stars": 1592
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-04-01",
-      "cumulative_stars": 1671
+      "cumulative_stars": 1680
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-05-01",
-      "cumulative_stars": 1757
+      "cumulative_stars": 1766
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-06-01",
-      "cumulative_stars": 1817
+      "cumulative_stars": 1827
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-07-01",
-      "cumulative_stars": 1875
+      "cumulative_stars": 1885
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-08-01",
-      "cumulative_stars": 1943
+      "cumulative_stars": 1954
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-09-01",
-      "cumulative_stars": 1979
+      "cumulative_stars": 1990
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-10-01",
-      "cumulative_stars": 2026
+      "cumulative_stars": 2037
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-11-01",
-      "cumulative_stars": 2074
+      "cumulative_stars": 2086
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2025-12-01",
-      "cumulative_stars": 2130
+      "cumulative_stars": 2142
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-01-01",
-      "cumulative_stars": 2167
+      "cumulative_stars": 2180
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-02-01",
-      "cumulative_stars": 2198
+      "cumulative_stars": 2212
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
-      "cumulative_stars": 7418
+      "cumulative_stars": 7776
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-05-01",
-      "cumulative_stars": 8884
+      "cumulative_stars": 9298
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-06-01",
-      "cumulative_stars": 9842
+      "cumulative_stars": 10294
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-07-01",
-      "cumulative_stars": 10632
+      "cumulative_stars": 11133
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-08-01",
-      "cumulative_stars": 11800
+      "cumulative_stars": 12372
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-09-01",
-      "cumulative_stars": 12532
+      "cumulative_stars": 13135
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-10-01",
-      "cumulative_stars": 13322
+      "cumulative_stars": 13990
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-11-01",
-      "cumulative_stars": 14774
+      "cumulative_stars": 15645
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-12-01",
-      "cumulative_stars": 15711
+      "cumulative_stars": 16643
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-01-01",
-      "cumulative_stars": 16253
+      "cumulative_stars": 17228
     },
     {
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
-      "cumulative_stars": 16871
+      "cumulative_stars": 17906
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
-      "cumulative_stars": 3079
+      "cumulative_stars": 3105
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-04-01",
-      "cumulative_stars": 3224
+      "cumulative_stars": 3251
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-05-01",
-      "cumulative_stars": 3360
+      "cumulative_stars": 3389
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-06-01",
-      "cumulative_stars": 3490
+      "cumulative_stars": 3520
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-07-01",
-      "cumulative_stars": 3600
+      "cumulative_stars": 3630
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-08-01",
-      "cumulative_stars": 3704
+      "cumulative_stars": 3736
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-09-01",
-      "cumulative_stars": 3812
+      "cumulative_stars": 3845
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-10-01",
-      "cumulative_stars": 3924
+      "cumulative_stars": 3957
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-11-01",
-      "cumulative_stars": 4069
+      "cumulative_stars": 4107
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-12-01",
-      "cumulative_stars": 4201
+      "cumulative_stars": 4239
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-01-01",
-      "cumulative_stars": 4313
+      "cumulative_stars": 4353
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-02-01",
-      "cumulative_stars": 4444
+      "cumulative_stars": 4484
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-03-01",
-      "cumulative_stars": 4596
+      "cumulative_stars": 4641
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "cumulative_stars": 4756
+      "cumulative_stars": 4804
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-05-01",
-      "cumulative_stars": 4914
+      "cumulative_stars": 4965
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-06-01",
-      "cumulative_stars": 5059
+      "cumulative_stars": 5113
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-07-01",
-      "cumulative_stars": 5232
+      "cumulative_stars": 5289
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-08-01",
-      "cumulative_stars": 5428
+      "cumulative_stars": 5489
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-09-01",
-      "cumulative_stars": 5597
+      "cumulative_stars": 5661
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "cumulative_stars": 5758
+      "cumulative_stars": 5826
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-11-01",
-      "cumulative_stars": 5941
+      "cumulative_stars": 6011
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-12-01",
-      "cumulative_stars": 6081
+      "cumulative_stars": 6157
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-01-01",
-      "cumulative_stars": 6205
+      "cumulative_stars": 6288
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2026-02-01",
-      "cumulative_stars": 6345
+      "cumulative_stars": 6439
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2024-12-01",
-      "cumulative_stars": 747
+      "cumulative_stars": 748
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-01-01",
-      "cumulative_stars": 5984
+      "cumulative_stars": 5998
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-02-01",
-      "cumulative_stars": 12554
+      "cumulative_stars": 12577
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-03-01",
-      "cumulative_stars": 15811
+      "cumulative_stars": 15839
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-04-01",
-      "cumulative_stars": 17521
+      "cumulative_stars": 17554
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-05-01",
-      "cumulative_stars": 19234
+      "cumulative_stars": 19273
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-06-01",
-      "cumulative_stars": 20514
+      "cumulative_stars": 20553
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-07-01",
-      "cumulative_stars": 21503
+      "cumulative_stars": 21543
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-08-01",
-      "cumulative_stars": 22283
+      "cumulative_stars": 22324
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-09-01",
-      "cumulative_stars": 22976
+      "cumulative_stars": 23023
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-10-01",
-      "cumulative_stars": 23573
+      "cumulative_stars": 23622
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-11-01",
-      "cumulative_stars": 24097
+      "cumulative_stars": 24146
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-12-01",
-      "cumulative_stars": 24616
+      "cumulative_stars": 24668
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-01-01",
-      "cumulative_stars": 25201
+      "cumulative_stars": 25253
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "cumulative_stars": 25728
+      "cumulative_stars": 25783
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-03-01",
-      "cumulative_stars": 118413
+      "cumulative_stars": 118550
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-04-01",
-      "cumulative_stars": 120420
+      "cumulative_stars": 120563
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-05-01",
-      "cumulative_stars": 122231
+      "cumulative_stars": 122378
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-06-01",
-      "cumulative_stars": 123754
+      "cumulative_stars": 123905
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-07-01",
-      "cumulative_stars": 125584
+      "cumulative_stars": 125740
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-08-01",
-      "cumulative_stars": 127191
+      "cumulative_stars": 127353
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-09-01",
-      "cumulative_stars": 128707
+      "cumulative_stars": 128870
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-10-01",
-      "cumulative_stars": 130337
+      "cumulative_stars": 130502
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-11-01",
-      "cumulative_stars": 131955
+      "cumulative_stars": 132123
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-12-01",
-      "cumulative_stars": 133378
+      "cumulative_stars": 133552
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-01-01",
-      "cumulative_stars": 134946
+      "cumulative_stars": 135122
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-02-01",
-      "cumulative_stars": 137152
+      "cumulative_stars": 137330
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "cumulative_stars": 139235
+      "cumulative_stars": 139415
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-04-01",
-      "cumulative_stars": 140943
+      "cumulative_stars": 141126
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-05-01",
-      "cumulative_stars": 142470
+      "cumulative_stars": 142654
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-06-01",
-      "cumulative_stars": 143844
+      "cumulative_stars": 144030
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-07-01",
-      "cumulative_stars": 145578
+      "cumulative_stars": 145767
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-08-01",
-      "cumulative_stars": 147088
+      "cumulative_stars": 147280
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-09-01",
-      "cumulative_stars": 148831
+      "cumulative_stars": 149030
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-10-01",
-      "cumulative_stars": 150525
+      "cumulative_stars": 150732
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-11-01",
-      "cumulative_stars": 152002
+      "cumulative_stars": 152213
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-12-01",
-      "cumulative_stars": 153502
+      "cumulative_stars": 153720
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2026-01-01",
-      "cumulative_stars": 155267
+      "cumulative_stars": 155490
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2026-02-01",
-      "cumulative_stars": 156670
+      "cumulative_stars": 156917
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -3325,357 +3325,357 @@
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-04-01",
-      "cumulative_stars": 5959
+      "cumulative_stars": 5964
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-05-01",
-      "cumulative_stars": 8259
+      "cumulative_stars": 8268
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-06-01",
-      "cumulative_stars": 10203
+      "cumulative_stars": 10217
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-07-01",
-      "cumulative_stars": 12504
+      "cumulative_stars": 12524
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-08-01",
-      "cumulative_stars": 15545
+      "cumulative_stars": 15568
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-09-01",
-      "cumulative_stars": 17871
+      "cumulative_stars": 17896
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-10-01",
-      "cumulative_stars": 20979
+      "cumulative_stars": 21013
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-11-01",
-      "cumulative_stars": 23700
+      "cumulative_stars": 23737
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-12-01",
-      "cumulative_stars": 26214
+      "cumulative_stars": 26255
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-01-01",
-      "cumulative_stars": 30029
+      "cumulative_stars": 30079
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-02-01",
-      "cumulative_stars": 40849
+      "cumulative_stars": 40928
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-03-01",
-      "cumulative_stars": 46679
+      "cumulative_stars": 46774
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-04-01",
-      "cumulative_stars": 50415
+      "cumulative_stars": 50519
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-05-01",
-      "cumulative_stars": 53578
+      "cumulative_stars": 53684
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-06-01",
-      "cumulative_stars": 58266
+      "cumulative_stars": 58381
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-07-01",
-      "cumulative_stars": 61142
+      "cumulative_stars": 61259
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-08-01",
-      "cumulative_stars": 63288
+      "cumulative_stars": 63405
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-09-01",
-      "cumulative_stars": 65421
+      "cumulative_stars": 65545
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-10-01",
-      "cumulative_stars": 67045
+      "cumulative_stars": 67175
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-11-01",
-      "cumulative_stars": 68868
+      "cumulative_stars": 69004
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2025-12-01",
-      "cumulative_stars": 71246
+      "cumulative_stars": 71384
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-01-01",
-      "cumulative_stars": 73225
+      "cumulative_stars": 73373
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
       "month": "2026-02-01",
-      "cumulative_stars": 74764
+      "cumulative_stars": 74939
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-03-01",
-      "cumulative_stars": 13750
+      "cumulative_stars": 13776
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-04-01",
-      "cumulative_stars": 16895
+      "cumulative_stars": 16923
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-05-01",
-      "cumulative_stars": 18604
+      "cumulative_stars": 18635
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-06-01",
-      "cumulative_stars": 19822
+      "cumulative_stars": 19855
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-07-01",
-      "cumulative_stars": 20446
+      "cumulative_stars": 20479
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-08-01",
-      "cumulative_stars": 21017
+      "cumulative_stars": 21052
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-09-01",
-      "cumulative_stars": 21759
+      "cumulative_stars": 21795
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-10-01",
-      "cumulative_stars": 22420
+      "cumulative_stars": 22459
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-11-01",
-      "cumulative_stars": 23235
+      "cumulative_stars": 23276
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-12-01",
-      "cumulative_stars": 24124
+      "cumulative_stars": 24166
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-01-01",
-      "cumulative_stars": 26600
+      "cumulative_stars": 26649
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-02-01",
-      "cumulative_stars": 27395
+      "cumulative_stars": 27444
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-03-01",
-      "cumulative_stars": 27930
+      "cumulative_stars": 27979
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-04-01",
-      "cumulative_stars": 28445
+      "cumulative_stars": 28494
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-05-01",
-      "cumulative_stars": 29091
+      "cumulative_stars": 29144
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-06-01",
-      "cumulative_stars": 33592
+      "cumulative_stars": 33660
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-07-01",
-      "cumulative_stars": 35155
+      "cumulative_stars": 35225
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-08-01",
-      "cumulative_stars": 37613
+      "cumulative_stars": 37687
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-09-01",
-      "cumulative_stars": 38189
+      "cumulative_stars": 38265
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-10-01",
-      "cumulative_stars": 39076
+      "cumulative_stars": 39155
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-11-01",
-      "cumulative_stars": 39911
+      "cumulative_stars": 39992
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-12-01",
-      "cumulative_stars": 40395
+      "cumulative_stars": 40477
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2026-01-01",
-      "cumulative_stars": 40849
+      "cumulative_stars": 40932
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2026-02-01",
-      "cumulative_stars": 41410
+      "cumulative_stars": 41498
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-03-01",
-      "cumulative_stars": 13715
+      "cumulative_stars": 14335
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "cumulative_stars": 14034
+      "cumulative_stars": 14670
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "cumulative_stars": 14341
+      "cumulative_stars": 14992
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-06-01",
-      "cumulative_stars": 14566
+      "cumulative_stars": 15231
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-07-01",
-      "cumulative_stars": 14811
+      "cumulative_stars": 15488
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-08-01",
-      "cumulative_stars": 14982
+      "cumulative_stars": 15670
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-09-01",
-      "cumulative_stars": 15152
+      "cumulative_stars": 15852
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "cumulative_stars": 16033
+      "cumulative_stars": 16828
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "cumulative_stars": 16413
+      "cumulative_stars": 17253
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-12-01",
-      "cumulative_stars": 16662
+      "cumulative_stars": 17536
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-01-01",
-      "cumulative_stars": 16890
+      "cumulative_stars": 17789
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-02-01",
-      "cumulative_stars": 17128
+      "cumulative_stars": 18047
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-03-01",
-      "cumulative_stars": 17380
+      "cumulative_stars": 18320
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-04-01",
-      "cumulative_stars": 17571
+      "cumulative_stars": 18525
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-05-01",
-      "cumulative_stars": 17724
+      "cumulative_stars": 18706
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-06-01",
-      "cumulative_stars": 17857
+      "cumulative_stars": 18846
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-07-01",
-      "cumulative_stars": 18026
+      "cumulative_stars": 19028
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-08-01",
-      "cumulative_stars": 18162
+      "cumulative_stars": 19183
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-09-01",
-      "cumulative_stars": 18363
+      "cumulative_stars": 19408
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-10-01",
-      "cumulative_stars": 18535
+      "cumulative_stars": 19593
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-11-01",
-      "cumulative_stars": 18698
+      "cumulative_stars": 19786
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "cumulative_stars": 18853
+      "cumulative_stars": 19963
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-01-01",
-      "cumulative_stars": 19004
+      "cumulative_stars": 20139
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-02-01",
-      "cumulative_stars": 19315
+      "cumulative_stars": 20501
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -3800,602 +3800,602 @@
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-03-01",
-      "cumulative_stars": 78358
+      "cumulative_stars": 78463
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-04-01",
-      "cumulative_stars": 81303
+      "cumulative_stars": 81410
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-05-01",
-      "cumulative_stars": 83979
+      "cumulative_stars": 84090
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-06-01",
-      "cumulative_stars": 86158
+      "cumulative_stars": 86274
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-07-01",
-      "cumulative_stars": 88132
+      "cumulative_stars": 88249
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-08-01",
-      "cumulative_stars": 89969
+      "cumulative_stars": 90088
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-09-01",
-      "cumulative_stars": 91448
+      "cumulative_stars": 91567
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-10-01",
-      "cumulative_stars": 92875
+      "cumulative_stars": 93000
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-11-01",
-      "cumulative_stars": 94455
+      "cumulative_stars": 94584
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2024-12-01",
-      "cumulative_stars": 96386
+      "cumulative_stars": 96520
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-01-01",
-      "cumulative_stars": 98663
+      "cumulative_stars": 98800
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-02-01",
-      "cumulative_stars": 101480
+      "cumulative_stars": 101623
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-03-01",
-      "cumulative_stars": 104511
+      "cumulative_stars": 104656
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-04-01",
-      "cumulative_stars": 106690
+      "cumulative_stars": 106837
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-05-01",
-      "cumulative_stars": 108787
+      "cumulative_stars": 108940
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-06-01",
-      "cumulative_stars": 110917
+      "cumulative_stars": 111074
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-07-01",
-      "cumulative_stars": 113295
+      "cumulative_stars": 113458
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-08-01",
-      "cumulative_stars": 115436
+      "cumulative_stars": 115607
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-09-01",
-      "cumulative_stars": 117641
+      "cumulative_stars": 117815
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-10-01",
-      "cumulative_stars": 120003
+      "cumulative_stars": 120184
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-11-01",
-      "cumulative_stars": 122513
+      "cumulative_stars": 122700
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2025-12-01",
-      "cumulative_stars": 125099
+      "cumulative_stars": 125291
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2026-01-01",
-      "cumulative_stars": 127848
+      "cumulative_stars": 128050
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
       "month": "2026-02-01",
-      "cumulative_stars": 130350
+      "cumulative_stars": 130568
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-03-01",
-      "cumulative_stars": 2012
+      "cumulative_stars": 2013
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-04-01",
-      "cumulative_stars": 2701
+      "cumulative_stars": 2703
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-05-01",
-      "cumulative_stars": 3325
+      "cumulative_stars": 3327
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-06-01",
-      "cumulative_stars": 3972
+      "cumulative_stars": 3975
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-07-01",
-      "cumulative_stars": 4657
+      "cumulative_stars": 4662
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-08-01",
-      "cumulative_stars": 5260
+      "cumulative_stars": 5267
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-09-01",
-      "cumulative_stars": 5768
+      "cumulative_stars": 5775
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-10-01",
-      "cumulative_stars": 6294
+      "cumulative_stars": 6301
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-11-01",
-      "cumulative_stars": 6796
+      "cumulative_stars": 6804
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2024-12-01",
-      "cumulative_stars": 7487
+      "cumulative_stars": 7498
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-01-01",
-      "cumulative_stars": 8383
+      "cumulative_stars": 8395
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-02-01",
-      "cumulative_stars": 9388
+      "cumulative_stars": 9403
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-03-01",
-      "cumulative_stars": 10736
+      "cumulative_stars": 10755
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-04-01",
-      "cumulative_stars": 11974
+      "cumulative_stars": 11994
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-05-01",
-      "cumulative_stars": 13191
+      "cumulative_stars": 13213
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-06-01",
-      "cumulative_stars": 14846
+      "cumulative_stars": 14871
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-07-01",
-      "cumulative_stars": 16454
+      "cumulative_stars": 16484
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-08-01",
-      "cumulative_stars": 17869
+      "cumulative_stars": 17900
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-09-01",
-      "cumulative_stars": 19221
+      "cumulative_stars": 19255
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-10-01",
-      "cumulative_stars": 20438
+      "cumulative_stars": 20477
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-11-01",
-      "cumulative_stars": 21591
+      "cumulative_stars": 21637
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2025-12-01",
-      "cumulative_stars": 22828
+      "cumulative_stars": 22876
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2026-01-01",
-      "cumulative_stars": 24206
+      "cumulative_stars": 24260
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2026-02-01",
-      "cumulative_stars": 25502
+      "cumulative_stars": 25574
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-03-01",
-      "cumulative_stars": 2546
+      "cumulative_stars": 2549
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-04-01",
-      "cumulative_stars": 3396
+      "cumulative_stars": 3400
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-05-01",
-      "cumulative_stars": 3888
+      "cumulative_stars": 3892
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-06-01",
-      "cumulative_stars": 4421
+      "cumulative_stars": 4427
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-07-01",
-      "cumulative_stars": 4875
+      "cumulative_stars": 4881
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-08-01",
-      "cumulative_stars": 5297
+      "cumulative_stars": 5303
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2024-09-01",
+      "cumulative_stars": 5666
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2024-10-01",
+      "cumulative_stars": 6074
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2024-11-01",
+      "cumulative_stars": 6718
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2024-12-01",
+      "cumulative_stars": 7441
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-01-01",
+      "cumulative_stars": 8079
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-02-01",
+      "cumulative_stars": 8867
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-03-01",
+      "cumulative_stars": 9856
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-04-01",
+      "cumulative_stars": 10901
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-05-01",
+      "cumulative_stars": 11879
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-06-01",
+      "cumulative_stars": 13186
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-07-01",
+      "cumulative_stars": 14462
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-08-01",
+      "cumulative_stars": 15659
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-09-01",
+      "cumulative_stars": 16715
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-10-01",
+      "cumulative_stars": 17909
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-11-01",
+      "cumulative_stars": 18958
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2025-12-01",
+      "cumulative_stars": 20251
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2026-01-01",
+      "cumulative_stars": 21605
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2026-02-01",
+      "cumulative_stars": 22759
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-03-01",
+      "cumulative_stars": 7991
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-04-01",
+      "cumulative_stars": 8398
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-05-01",
+      "cumulative_stars": 10028
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-06-01",
+      "cumulative_stars": 10375
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-07-01",
+      "cumulative_stars": 10672
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-08-01",
+      "cumulative_stars": 10966
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-09-01",
+      "cumulative_stars": 11551
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-10-01",
+      "cumulative_stars": 11779
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-11-01",
+      "cumulative_stars": 12787
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2024-12-01",
+      "cumulative_stars": 13345
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-01-01",
+      "cumulative_stars": 14009
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-02-01",
+      "cumulative_stars": 14525
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-03-01",
+      "cumulative_stars": 15450
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-04-01",
+      "cumulative_stars": 16040
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-05-01",
+      "cumulative_stars": 16488
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-06-01",
+      "cumulative_stars": 16928
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-07-01",
+      "cumulative_stars": 17441
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-08-01",
+      "cumulative_stars": 18025
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-09-01",
+      "cumulative_stars": 18482
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-10-01",
+      "cumulative_stars": 18944
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-11-01",
+      "cumulative_stars": 19301
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-12-01",
+      "cumulative_stars": 20422
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2026-01-01",
+      "cumulative_stars": 20964
+    },
+    {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2026-02-01",
+      "cumulative_stars": 21426
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-03-01",
+      "cumulative_stars": 145
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-04-01",
+      "cumulative_stars": 174
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-05-01",
+      "cumulative_stars": 434
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-06-01",
+      "cumulative_stars": 599
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-07-01",
+      "cumulative_stars": 691
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-08-01",
+      "cumulative_stars": 849
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-09-01",
+      "cumulative_stars": 1114
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-10-01",
+      "cumulative_stars": 3686
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-11-01",
+      "cumulative_stars": 3980
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2024-12-01",
+      "cumulative_stars": 4330
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-01-01",
+      "cumulative_stars": 4808
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-02-01",
+      "cumulative_stars": 5064
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-03-01",
+      "cumulative_stars": 5289
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2025-04-01",
       "cumulative_stars": 5660
     },
     {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2024-10-01",
-      "cumulative_stars": 6068
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2024-11-01",
-      "cumulative_stars": 6706
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2024-12-01",
-      "cumulative_stars": 7428
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-01-01",
-      "cumulative_stars": 8062
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-02-01",
-      "cumulative_stars": 8848
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-03-01",
-      "cumulative_stars": 9836
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-04-01",
-      "cumulative_stars": 10878
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-05-01",
-      "cumulative_stars": 11854
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-06-01",
-      "cumulative_stars": 13160
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-07-01",
-      "cumulative_stars": 14434
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-08-01",
-      "cumulative_stars": 15628
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-09-01",
-      "cumulative_stars": 16682
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-10-01",
-      "cumulative_stars": 17871
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-11-01",
-      "cumulative_stars": 18918
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-12-01",
-      "cumulative_stars": 20208
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2026-01-01",
-      "cumulative_stars": 21560
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2026-02-01",
-      "cumulative_stars": 22706
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-03-01",
-      "cumulative_stars": 7981
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-04-01",
-      "cumulative_stars": 8388
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-05-01",
-      "cumulative_stars": 10010
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-06-01",
-      "cumulative_stars": 10356
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-07-01",
-      "cumulative_stars": 10652
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-08-01",
-      "cumulative_stars": 10946
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-09-01",
-      "cumulative_stars": 11529
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-10-01",
-      "cumulative_stars": 11757
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-11-01",
-      "cumulative_stars": 12763
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2024-12-01",
-      "cumulative_stars": 13321
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-01-01",
-      "cumulative_stars": 13982
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-02-01",
-      "cumulative_stars": 14497
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-03-01",
-      "cumulative_stars": 15421
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-04-01",
-      "cumulative_stars": 16010
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-05-01",
-      "cumulative_stars": 16455
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-06-01",
-      "cumulative_stars": 16894
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-07-01",
-      "cumulative_stars": 17406
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-08-01",
-      "cumulative_stars": 17988
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-09-01",
-      "cumulative_stars": 18444
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-10-01",
-      "cumulative_stars": 18905
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-11-01",
-      "cumulative_stars": 19262
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-12-01",
-      "cumulative_stars": 20381
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-01-01",
-      "cumulative_stars": 20922
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-02-01",
-      "cumulative_stars": 21378
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-03-01",
-      "cumulative_stars": 143
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-04-01",
-      "cumulative_stars": 172
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-05-01",
-      "cumulative_stars": 432
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-06-01",
-      "cumulative_stars": 597
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-07-01",
-      "cumulative_stars": 688
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-08-01",
-      "cumulative_stars": 844
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-09-01",
-      "cumulative_stars": 1100
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-10-01",
-      "cumulative_stars": 3638
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-11-01",
-      "cumulative_stars": 3925
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2024-12-01",
-      "cumulative_stars": 4270
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-01-01",
-      "cumulative_stars": 4736
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-02-01",
-      "cumulative_stars": 4985
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-03-01",
-      "cumulative_stars": 5204
-    },
-    {
-      "repo": "https://github.com/livekit/agents",
-      "month": "2025-04-01",
-      "cumulative_stars": 5567
-    },
-    {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-05-01",
-      "cumulative_stars": 5925
+      "cumulative_stars": 6033
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-06-01",
-      "cumulative_stars": 6377
+      "cumulative_stars": 6495
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-07-01",
-      "cumulative_stars": 6672
+      "cumulative_stars": 6802
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-08-01",
-      "cumulative_stars": 7103
+      "cumulative_stars": 7249
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-09-01",
-      "cumulative_stars": 7374
+      "cumulative_stars": 7534
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-10-01",
-      "cumulative_stars": 7764
+      "cumulative_stars": 7940
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-11-01",
-      "cumulative_stars": 8089
+      "cumulative_stars": 8279
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2025-12-01",
-      "cumulative_stars": 8384
+      "cumulative_stars": 8585
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-01-01",
-      "cumulative_stars": 8917
+      "cumulative_stars": 9155
     },
     {
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
-      "cumulative_stars": 9162
+      "cumulative_stars": 9416
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
@@ -4405,767 +4405,767 @@
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-10-01",
-      "cumulative_stars": 159
+      "cumulative_stars": 169
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-11-01",
-      "cumulative_stars": 842
+      "cumulative_stars": 910
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2024-12-01",
-      "cumulative_stars": 1020
+      "cumulative_stars": 1098
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-01-01",
-      "cumulative_stars": 1259
+      "cumulative_stars": 1340
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-02-01",
-      "cumulative_stars": 7033
+      "cumulative_stars": 7786
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-03-01",
-      "cumulative_stars": 10025
+      "cumulative_stars": 11018
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
-      "cumulative_stars": 11123
+      "cumulative_stars": 12137
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-05-01",
-      "cumulative_stars": 12061
+      "cumulative_stars": 13094
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-06-01",
-      "cumulative_stars": 13151
+      "cumulative_stars": 14218
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-07-01",
-      "cumulative_stars": 13941
+      "cumulative_stars": 15023
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
-      "cumulative_stars": 14737
+      "cumulative_stars": 15841
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "cumulative_stars": 15494
+      "cumulative_stars": 16627
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-10-01",
-      "cumulative_stars": 16433
+      "cumulative_stars": 17589
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-11-01",
-      "cumulative_stars": 17083
+      "cumulative_stars": 18260
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
-      "cumulative_stars": 17603
+      "cumulative_stars": 18790
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "cumulative_stars": 19145
+      "cumulative_stars": 20405
     },
     {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "cumulative_stars": 20063
+      "cumulative_stars": 21359
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-10-01",
-      "cumulative_stars": 3130
+      "cumulative_stars": 3463
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-11-01",
-      "cumulative_stars": 4416
+      "cumulative_stars": 4764
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2024-12-01",
-      "cumulative_stars": 4798
+      "cumulative_stars": 5153
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-01-01",
-      "cumulative_stars": 5032
+      "cumulative_stars": 5390
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
-      "cumulative_stars": 16561
+      "cumulative_stars": 17781
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-03-01",
-      "cumulative_stars": 19260
+      "cumulative_stars": 20568
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-04-01",
-      "cumulative_stars": 19924
+      "cumulative_stars": 21254
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-05-01",
-      "cumulative_stars": 20350
+      "cumulative_stars": 21698
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-06-01",
-      "cumulative_stars": 20647
+      "cumulative_stars": 22002
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-07-01",
-      "cumulative_stars": 21111
+      "cumulative_stars": 22482
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-08-01",
-      "cumulative_stars": 21556
+      "cumulative_stars": 22944
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-09-01",
-      "cumulative_stars": 21782
+      "cumulative_stars": 23179
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-10-01",
-      "cumulative_stars": 21978
+      "cumulative_stars": 23379
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-11-01",
-      "cumulative_stars": 22156
+      "cumulative_stars": 23567
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-12-01",
-      "cumulative_stars": 22356
+      "cumulative_stars": 23778
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-01-01",
-      "cumulative_stars": 22579
+      "cumulative_stars": 24012
     },
     {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2026-02-01",
-      "cumulative_stars": 22707
+      "cumulative_stars": 24152
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-03-01",
-      "cumulative_stars": 4194
+      "cumulative_stars": 4350
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-04-01",
-      "cumulative_stars": 4393
+      "cumulative_stars": 4554
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-05-01",
-      "cumulative_stars": 4514
+      "cumulative_stars": 4679
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-06-01",
-      "cumulative_stars": 4634
+      "cumulative_stars": 4801
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-07-01",
-      "cumulative_stars": 4757
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2024-08-01",
-      "cumulative_stars": 4844
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2024-09-01",
       "cumulative_stars": 4926
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2024-08-01",
+      "cumulative_stars": 5016
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2024-09-01",
+      "cumulative_stars": 5098
+    },
+    {
+      "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-10-01",
-      "cumulative_stars": 5003
+      "cumulative_stars": 5177
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-11-01",
-      "cumulative_stars": 5067
+      "cumulative_stars": 5242
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2024-12-01",
-      "cumulative_stars": 5125
+      "cumulative_stars": 5300
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-01-01",
-      "cumulative_stars": 5192
+      "cumulative_stars": 5367
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-02-01",
-      "cumulative_stars": 5252
+      "cumulative_stars": 5428
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-03-01",
-      "cumulative_stars": 5329
+      "cumulative_stars": 5507
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-04-01",
-      "cumulative_stars": 5396
+      "cumulative_stars": 5574
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-05-01",
-      "cumulative_stars": 5461
+      "cumulative_stars": 5640
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-06-01",
-      "cumulative_stars": 5502
+      "cumulative_stars": 5683
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-07-01",
-      "cumulative_stars": 5556
+      "cumulative_stars": 5738
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-08-01",
-      "cumulative_stars": 5611
+      "cumulative_stars": 5794
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-09-01",
-      "cumulative_stars": 5660
+      "cumulative_stars": 5844
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-10-01",
-      "cumulative_stars": 5702
+      "cumulative_stars": 5886
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-11-01",
-      "cumulative_stars": 5750
+      "cumulative_stars": 5936
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2025-12-01",
-      "cumulative_stars": 5821
+      "cumulative_stars": 6009
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-01-01",
-      "cumulative_stars": 5856
+      "cumulative_stars": 6047
     },
     {
       "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-02-01",
-      "cumulative_stars": 5873
+      "cumulative_stars": 6066
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-03-01",
-      "cumulative_stars": 23098
+      "cumulative_stars": 23106
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-04-01",
-      "cumulative_stars": 24584
+      "cumulative_stars": 24592
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-05-01",
-      "cumulative_stars": 25985
+      "cumulative_stars": 25993
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-06-01",
-      "cumulative_stars": 27279
+      "cumulative_stars": 27287
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-07-01",
-      "cumulative_stars": 28423
+      "cumulative_stars": 28432
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-08-01",
-      "cumulative_stars": 29542
+      "cumulative_stars": 29552
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-09-01",
-      "cumulative_stars": 30780
+      "cumulative_stars": 30790
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-10-01",
-      "cumulative_stars": 31901
+      "cumulative_stars": 31911
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-11-01",
-      "cumulative_stars": 34483
+      "cumulative_stars": 34495
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2024-12-01",
-      "cumulative_stars": 36009
+      "cumulative_stars": 36021
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-01-01",
-      "cumulative_stars": 38048
+      "cumulative_stars": 38062
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-02-01",
-      "cumulative_stars": 39967
+      "cumulative_stars": 39981
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-03-01",
-      "cumulative_stars": 42042
+      "cumulative_stars": 42056
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-04-01",
-      "cumulative_stars": 43546
+      "cumulative_stars": 43560
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-05-01",
-      "cumulative_stars": 45049
+      "cumulative_stars": 45063
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-06-01",
-      "cumulative_stars": 46432
+      "cumulative_stars": 46447
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-07-01",
-      "cumulative_stars": 47954
+      "cumulative_stars": 47969
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-08-01",
-      "cumulative_stars": 49171
+      "cumulative_stars": 49186
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-09-01",
-      "cumulative_stars": 50320
+      "cumulative_stars": 50336
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-10-01",
-      "cumulative_stars": 51366
+      "cumulative_stars": 51384
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-11-01",
-      "cumulative_stars": 52261
+      "cumulative_stars": 52279
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2025-12-01",
-      "cumulative_stars": 53356
+      "cumulative_stars": 53374
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2026-01-01",
-      "cumulative_stars": 54537
+      "cumulative_stars": 54555
     },
     {
       "repo": "https://github.com/microsoft/autogen",
       "month": "2026-02-01",
-      "cumulative_stars": 55507
+      "cumulative_stars": 55528
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-04-01",
-      "cumulative_stars": 8
+      "cumulative_stars": 10
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-05-01",
-      "cumulative_stars": 18
+      "cumulative_stars": 20
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-06-01",
-      "cumulative_stars": 24
+      "cumulative_stars": 26
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
-      "cumulative_stars": 12610
+      "cumulative_stars": 12957
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-08-01",
-      "cumulative_stars": 15381
+      "cumulative_stars": 15796
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-09-01",
-      "cumulative_stars": 16647
+      "cumulative_stars": 17099
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-10-01",
-      "cumulative_stars": 17520
+      "cumulative_stars": 18014
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-11-01",
-      "cumulative_stars": 18826
+      "cumulative_stars": 19355
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-12-01",
-      "cumulative_stars": 20049
+      "cumulative_stars": 20611
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-01-01",
-      "cumulative_stars": 20831
+      "cumulative_stars": 21420
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-02-01",
-      "cumulative_stars": 21781
+      "cumulative_stars": 22395
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-03-01",
-      "cumulative_stars": 22874
+      "cumulative_stars": 23514
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-04-01",
-      "cumulative_stars": 23693
+      "cumulative_stars": 24369
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-05-01",
-      "cumulative_stars": 24330
+      "cumulative_stars": 25033
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-06-01",
-      "cumulative_stars": 24944
+      "cumulative_stars": 25671
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-07-01",
-      "cumulative_stars": 25730
+      "cumulative_stars": 26487
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-08-01",
-      "cumulative_stars": 26465
+      "cumulative_stars": 27262
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-09-01",
-      "cumulative_stars": 27198
+      "cumulative_stars": 28031
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-10-01",
-      "cumulative_stars": 27730
+      "cumulative_stars": 28583
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-11-01",
-      "cumulative_stars": 28246
+      "cumulative_stars": 29121
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2025-12-01",
-      "cumulative_stars": 28853
+      "cumulative_stars": 29773
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-01-01",
-      "cumulative_stars": 29438
+      "cumulative_stars": 30396
     },
     {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2026-02-01",
-      "cumulative_stars": 29953
+      "cumulative_stars": 30940
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-03-01",
-      "cumulative_stars": 60294
+      "cumulative_stars": 60369
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-04-01",
-      "cumulative_stars": 61174
+      "cumulative_stars": 61252
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-05-01",
-      "cumulative_stars": 62108
+      "cumulative_stars": 62191
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-06-01",
-      "cumulative_stars": 63107
+      "cumulative_stars": 63194
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-07-01",
-      "cumulative_stars": 63900
+      "cumulative_stars": 63988
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-08-01",
-      "cumulative_stars": 64795
+      "cumulative_stars": 64884
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-09-01",
-      "cumulative_stars": 65636
+      "cumulative_stars": 65726
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-10-01",
-      "cumulative_stars": 66344
+      "cumulative_stars": 66437
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-11-01",
-      "cumulative_stars": 67067
+      "cumulative_stars": 67162
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-12-01",
-      "cumulative_stars": 67968
+      "cumulative_stars": 68063
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-01-01",
-      "cumulative_stars": 68821
+      "cumulative_stars": 68918
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-02-01",
-      "cumulative_stars": 69680
+      "cumulative_stars": 69778
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-03-01",
-      "cumulative_stars": 71139
+      "cumulative_stars": 71242
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-04-01",
-      "cumulative_stars": 72367
+      "cumulative_stars": 72475
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-05-01",
-      "cumulative_stars": 73237
+      "cumulative_stars": 73347
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-06-01",
-      "cumulative_stars": 74535
+      "cumulative_stars": 74649
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-07-01",
-      "cumulative_stars": 75861
+      "cumulative_stars": 75979
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-08-01",
-      "cumulative_stars": 77085
+      "cumulative_stars": 77207
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-09-01",
-      "cumulative_stars": 78317
+      "cumulative_stars": 78442
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-10-01",
-      "cumulative_stars": 79579
+      "cumulative_stars": 79704
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-11-01",
-      "cumulative_stars": 80593
+      "cumulative_stars": 80721
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2025-12-01",
-      "cumulative_stars": 81660
+      "cumulative_stars": 81793
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2026-01-01",
-      "cumulative_stars": 83042
+      "cumulative_stars": 83180
     },
     {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2026-02-01",
-      "cumulative_stars": 84429
+      "cumulative_stars": 84581
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
-      "cumulative_stars": 16117
+      "cumulative_stars": 16976
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-04-01",
-      "cumulative_stars": 16645
+      "cumulative_stars": 17538
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-05-01",
-      "cumulative_stars": 17154
+      "cumulative_stars": 18087
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-06-01",
-      "cumulative_stars": 18277
+      "cumulative_stars": 19332
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-07-01",
-      "cumulative_stars": 19001
+      "cumulative_stars": 20111
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-08-01",
-      "cumulative_stars": 19329
+      "cumulative_stars": 20445
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-09-01",
-      "cumulative_stars": 19641
+      "cumulative_stars": 20780
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-10-01",
-      "cumulative_stars": 19981
+      "cumulative_stars": 21132
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-11-01",
-      "cumulative_stars": 20281
+      "cumulative_stars": 21447
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-12-01",
-      "cumulative_stars": 20616
+      "cumulative_stars": 21798
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-01-01",
-      "cumulative_stars": 21039
+      "cumulative_stars": 22241
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-02-01",
-      "cumulative_stars": 21466
+      "cumulative_stars": 22683
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-03-01",
-      "cumulative_stars": 21930
+      "cumulative_stars": 23173
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-04-01",
-      "cumulative_stars": 22392
+      "cumulative_stars": 23659
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-05-01",
-      "cumulative_stars": 22993
+      "cumulative_stars": 24286
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-06-01",
-      "cumulative_stars": 23368
+      "cumulative_stars": 24679
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-07-01",
-      "cumulative_stars": 23742
+      "cumulative_stars": 25071
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-08-01",
-      "cumulative_stars": 24113
+      "cumulative_stars": 25458
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-09-01",
-      "cumulative_stars": 24453
+      "cumulative_stars": 25811
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-10-01",
-      "cumulative_stars": 24752
+      "cumulative_stars": 26122
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-11-01",
-      "cumulative_stars": 24960
+      "cumulative_stars": 26340
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2025-12-01",
-      "cumulative_stars": 25169
+      "cumulative_stars": 26557
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-01-01",
-      "cumulative_stars": 25403
+      "cumulative_stars": 26809
     },
     {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
-      "cumulative_stars": 25638
+      "cumulative_stars": 27057
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -5285,127 +5285,127 @@
     {
       "repo": "https://github.com/milvus-io/milvus",
       "month": "2026-02-01",
-      "cumulative_stars": 44209
+      "cumulative_stars": 44210
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-03-01",
-      "cumulative_stars": 7899
+      "cumulative_stars": 8078
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-04-01",
-      "cumulative_stars": 8172
+      "cumulative_stars": 8359
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-05-01",
-      "cumulative_stars": 8408
+      "cumulative_stars": 8599
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-06-01",
-      "cumulative_stars": 8616
+      "cumulative_stars": 8813
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-07-01",
-      "cumulative_stars": 8888
+      "cumulative_stars": 9087
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-08-01",
-      "cumulative_stars": 8982
+      "cumulative_stars": 9185
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-09-01",
-      "cumulative_stars": 9096
+      "cumulative_stars": 9304
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-10-01",
-      "cumulative_stars": 9228
+      "cumulative_stars": 9438
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-11-01",
-      "cumulative_stars": 9328
+      "cumulative_stars": 9538
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-12-01",
-      "cumulative_stars": 9401
+      "cumulative_stars": 9615
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-01-01",
-      "cumulative_stars": 9477
+      "cumulative_stars": 9693
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-02-01",
-      "cumulative_stars": 9614
+      "cumulative_stars": 9834
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-03-01",
-      "cumulative_stars": 9731
+      "cumulative_stars": 9956
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-04-01",
-      "cumulative_stars": 9800
+      "cumulative_stars": 10026
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-05-01",
-      "cumulative_stars": 9887
+      "cumulative_stars": 10115
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-06-01",
-      "cumulative_stars": 9947
+      "cumulative_stars": 10176
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-07-01",
-      "cumulative_stars": 10018
+      "cumulative_stars": 10251
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-08-01",
-      "cumulative_stars": 10080
+      "cumulative_stars": 10314
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-09-01",
-      "cumulative_stars": 10138
+      "cumulative_stars": 10372
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-10-01",
-      "cumulative_stars": 10186
+      "cumulative_stars": 10421
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-11-01",
-      "cumulative_stars": 10226
+      "cumulative_stars": 10462
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2025-12-01",
-      "cumulative_stars": 10289
+      "cumulative_stars": 10528
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-01-01",
-      "cumulative_stars": 10351
+      "cumulative_stars": 10591
     },
     {
       "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2026-02-01",
-      "cumulative_stars": 10398
+      "cumulative_stars": 10640
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
@@ -5435,257 +5435,257 @@
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-04-01",
-      "cumulative_stars": 2363
+      "cumulative_stars": 2364
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-05-01",
-      "cumulative_stars": 3389
+      "cumulative_stars": 3392
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-06-01",
-      "cumulative_stars": 4376
+      "cumulative_stars": 4383
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-07-01",
-      "cumulative_stars": 5264
+      "cumulative_stars": 5273
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-08-01",
-      "cumulative_stars": 5972
+      "cumulative_stars": 5983
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-09-01",
-      "cumulative_stars": 6655
+      "cumulative_stars": 6667
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-10-01",
-      "cumulative_stars": 7296
+      "cumulative_stars": 7309
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-11-01",
-      "cumulative_stars": 7745
+      "cumulative_stars": 7760
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2025-12-01",
-      "cumulative_stars": 8131
+      "cumulative_stars": 8147
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2026-01-01",
-      "cumulative_stars": 8530
+      "cumulative_stars": 8547
     },
     {
       "repo": "https://github.com/modelcontextprotocol/inspector",
       "month": "2026-02-01",
-      "cumulative_stars": 8906
+      "cumulative_stars": 8928
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2024-11-01",
-      "cumulative_stars": 150
+      "cumulative_stars": 151
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2024-12-01",
-      "cumulative_stars": 249
+      "cumulative_stars": 250
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-01-01",
-      "cumulative_stars": 319
+      "cumulative_stars": 323
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-02-01",
-      "cumulative_stars": 407
+      "cumulative_stars": 412
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-03-01",
-      "cumulative_stars": 958
+      "cumulative_stars": 963
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-04-01",
-      "cumulative_stars": 2320
+      "cumulative_stars": 2332
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-05-01",
-      "cumulative_stars": 3286
+      "cumulative_stars": 3299
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-06-01",
-      "cumulative_stars": 4081
+      "cumulative_stars": 4095
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-07-01",
-      "cumulative_stars": 4756
+      "cumulative_stars": 4771
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-08-01",
-      "cumulative_stars": 5267
+      "cumulative_stars": 5283
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-09-01",
-      "cumulative_stars": 5660
+      "cumulative_stars": 5676
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-10-01",
-      "cumulative_stars": 5962
+      "cumulative_stars": 5979
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-11-01",
-      "cumulative_stars": 6343
+      "cumulative_stars": 6364
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2025-12-01",
-      "cumulative_stars": 6709
+      "cumulative_stars": 6731
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2026-01-01",
-      "cumulative_stars": 7022
+      "cumulative_stars": 7046
     },
     {
       "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "month": "2026-02-01",
-      "cumulative_stars": 7304
+      "cumulative_stars": 7332
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-03-01",
-      "cumulative_stars": 50305
+      "cumulative_stars": 50378
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-04-01",
-      "cumulative_stars": 60979
+      "cumulative_stars": 61072
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-05-01",
-      "cumulative_stars": 68890
+      "cumulative_stars": 68994
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-06-01",
-      "cumulative_stars": 74625
+      "cumulative_stars": 74735
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-07-01",
-      "cumulative_stars": 81167
+      "cumulative_stars": 81288
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-08-01",
-      "cumulative_stars": 85967
+      "cumulative_stars": 86103
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-09-01",
-      "cumulative_stars": 90280
+      "cumulative_stars": 90422
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-10-01",
-      "cumulative_stars": 94550
+      "cumulative_stars": 94702
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-11-01",
-      "cumulative_stars": 99131
+      "cumulative_stars": 99295
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2024-12-01",
-      "cumulative_stars": 104157
+      "cumulative_stars": 104331
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-01-01",
-      "cumulative_stars": 115472
+      "cumulative_stars": 115666
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-02-01",
-      "cumulative_stars": 129556
+      "cumulative_stars": 129779
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-03-01",
-      "cumulative_stars": 135231
+      "cumulative_stars": 135471
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-04-01",
-      "cumulative_stars": 139116
+      "cumulative_stars": 139359
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-05-01",
-      "cumulative_stars": 142674
+      "cumulative_stars": 142922
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-06-01",
-      "cumulative_stars": 145820
+      "cumulative_stars": 146072
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-07-01",
-      "cumulative_stars": 149197
+      "cumulative_stars": 149460
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-08-01",
-      "cumulative_stars": 152745
+      "cumulative_stars": 153018
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-09-01",
-      "cumulative_stars": 155169
+      "cumulative_stars": 155450
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-10-01",
-      "cumulative_stars": 157370
+      "cumulative_stars": 157658
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-11-01",
-      "cumulative_stars": 159469
+      "cumulative_stars": 159763
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2025-12-01",
-      "cumulative_stars": 161636
+      "cumulative_stars": 161936
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-01-01",
-      "cumulative_stars": 164829
+      "cumulative_stars": 165140
     },
     {
       "repo": "https://github.com/ollama/ollama",
       "month": "2026-02-01",
-      "cumulative_stars": 167717
+      "cumulative_stars": 168062
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -5810,182 +5810,182 @@
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-03-01",
-      "cumulative_stars": 10984
+      "cumulative_stars": 11001
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-04-01",
-      "cumulative_stars": 16950
+      "cumulative_stars": 16979
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-05-01",
-      "cumulative_stars": 24164
+      "cumulative_stars": 24205
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-06-01",
-      "cumulative_stars": 28762
+      "cumulative_stars": 28813
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-07-01",
-      "cumulative_stars": 32948
+      "cumulative_stars": 33013
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-08-01",
-      "cumulative_stars": 36558
+      "cumulative_stars": 36629
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-09-01",
-      "cumulative_stars": 40140
+      "cumulative_stars": 40217
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-10-01",
-      "cumulative_stars": 44113
+      "cumulative_stars": 44197
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-11-01",
-      "cumulative_stars": 48410
+      "cumulative_stars": 48502
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2024-12-01",
-      "cumulative_stars": 53280
+      "cumulative_stars": 53380
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-01-01",
-      "cumulative_stars": 63642
+      "cumulative_stars": 63761
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-02-01",
-      "cumulative_stars": 79211
+      "cumulative_stars": 79354
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-03-01",
-      "cumulative_stars": 86080
+      "cumulative_stars": 86237
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-04-01",
-      "cumulative_stars": 91963
+      "cumulative_stars": 92136
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-05-01",
-      "cumulative_stars": 96989
+      "cumulative_stars": 97175
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-06-01",
-      "cumulative_stars": 100956
+      "cumulative_stars": 101145
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-07-01",
-      "cumulative_stars": 105182
+      "cumulative_stars": 105380
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-08-01",
-      "cumulative_stars": 109296
+      "cumulative_stars": 109504
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-09-01",
-      "cumulative_stars": 112472
+      "cumulative_stars": 112689
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-10-01",
-      "cumulative_stars": 115336
+      "cumulative_stars": 115563
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-11-01",
-      "cumulative_stars": 118421
+      "cumulative_stars": 118663
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2025-12-01",
-      "cumulative_stars": 121522
+      "cumulative_stars": 121779
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-01-01",
-      "cumulative_stars": 124997
+      "cumulative_stars": 125267
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
       "month": "2026-02-01",
-      "cumulative_stars": 128105
+      "cumulative_stars": 128403
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-03-01",
-      "cumulative_stars": 7071
+      "cumulative_stars": 7474
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-04-01",
-      "cumulative_stars": 8854
+      "cumulative_stars": 9328
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-05-01",
-      "cumulative_stars": 10059
+      "cumulative_stars": 10606
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-06-01",
-      "cumulative_stars": 11171
+      "cumulative_stars": 11790
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-07-01",
-      "cumulative_stars": 12111
+      "cumulative_stars": 12794
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-08-01",
-      "cumulative_stars": 13044
+      "cumulative_stars": 13790
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-09-01",
-      "cumulative_stars": 14016
+      "cumulative_stars": 14808
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-10-01",
-      "cumulative_stars": 15744
+      "cumulative_stars": 16635
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-11-01",
-      "cumulative_stars": 16341
+      "cumulative_stars": 17271
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2025-12-01",
-      "cumulative_stars": 16841
+      "cumulative_stars": 17799
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-01-01",
-      "cumulative_stars": 17411
+      "cumulative_stars": 18408
     },
     {
       "repo": "https://github.com/openai/openai-agents-python",
       "month": "2026-02-01",
-      "cumulative_stars": 17985
+      "cumulative_stars": 19028
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
@@ -5995,137 +5995,137 @@
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2025-12-01",
-      "cumulative_stars": 947
+      "cumulative_stars": 949
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-01-01",
-      "cumulative_stars": 132847
+      "cumulative_stars": 133245
     },
     {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
-      "cumulative_stars": 244872
+      "cumulative_stars": 245655
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
-      "cumulative_stars": 916
+      "cumulative_stars": 1357
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-04-01",
-      "cumulative_stars": 996
+      "cumulative_stars": 1460
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-05-01",
-      "cumulative_stars": 1207
+      "cumulative_stars": 1899
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-06-01",
-      "cumulative_stars": 1547
+      "cumulative_stars": 2388
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-07-01",
-      "cumulative_stars": 1598
+      "cumulative_stars": 2441
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-08-01",
-      "cumulative_stars": 1744
+      "cumulative_stars": 2738
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-09-01",
-      "cumulative_stars": 1963
+      "cumulative_stars": 3216
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-10-01",
-      "cumulative_stars": 2109
+      "cumulative_stars": 3448
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-11-01",
-      "cumulative_stars": 2218
+      "cumulative_stars": 3678
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-12-01",
-      "cumulative_stars": 4779
+      "cumulative_stars": 9067
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-01-01",
-      "cumulative_stars": 6135
+      "cumulative_stars": 10916
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-02-01",
-      "cumulative_stars": 6383
+      "cumulative_stars": 11298
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-03-01",
-      "cumulative_stars": 9701
+      "cumulative_stars": 19116
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-04-01",
-      "cumulative_stars": 9991
+      "cumulative_stars": 20141
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-05-01",
-      "cumulative_stars": 11125
+      "cumulative_stars": 21817
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-06-01",
-      "cumulative_stars": 11901
+      "cumulative_stars": 23802
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-07-01",
-      "cumulative_stars": 12728
+      "cumulative_stars": 24937
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-08-01",
-      "cumulative_stars": 15584
+      "cumulative_stars": 28526
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-09-01",
-      "cumulative_stars": 23674
+      "cumulative_stars": 38504
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-10-01",
-      "cumulative_stars": 25979
+      "cumulative_stars": 43533
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-11-01",
-      "cumulative_stars": 27041
+      "cumulative_stars": 45160
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2025-12-01",
-      "cumulative_stars": 27858
+      "cumulative_stars": 47945
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-01-01",
-      "cumulative_stars": 29879
+      "cumulative_stars": 53761
     },
     {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
-      "cumulative_stars": 30242
+      "cumulative_stars": 54667
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -6135,237 +6135,237 @@
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-04-01",
-      "cumulative_stars": 45
+      "cumulative_stars": 47
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-05-01",
-      "cumulative_stars": 1445
+      "cumulative_stars": 1453
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-06-01",
-      "cumulative_stars": 1917
+      "cumulative_stars": 1935
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-07-01",
-      "cumulative_stars": 2497
+      "cumulative_stars": 2523
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-08-01",
-      "cumulative_stars": 2810
+      "cumulative_stars": 2840
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-09-01",
-      "cumulative_stars": 3002
+      "cumulative_stars": 3036
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-10-01",
-      "cumulative_stars": 3184
+      "cumulative_stars": 3221
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-11-01",
-      "cumulative_stars": 3349
+      "cumulative_stars": 3387
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2024-12-01",
-      "cumulative_stars": 3920
+      "cumulative_stars": 3966
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-01-01",
-      "cumulative_stars": 4341
+      "cumulative_stars": 4397
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-02-01",
-      "cumulative_stars": 4760
+      "cumulative_stars": 4826
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-03-01",
-      "cumulative_stars": 5206
+      "cumulative_stars": 5283
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-04-01",
-      "cumulative_stars": 5626
+      "cumulative_stars": 5722
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-05-01",
-      "cumulative_stars": 6042
+      "cumulative_stars": 6149
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-06-01",
-      "cumulative_stars": 6391
+      "cumulative_stars": 6510
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-07-01",
-      "cumulative_stars": 7011
+      "cumulative_stars": 7144
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-08-01",
-      "cumulative_stars": 7569
+      "cumulative_stars": 7715
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-09-01",
-      "cumulative_stars": 7940
+      "cumulative_stars": 8104
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-10-01",
-      "cumulative_stars": 8346
+      "cumulative_stars": 8524
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-11-01",
-      "cumulative_stars": 8811
+      "cumulative_stars": 9010
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2025-12-01",
-      "cumulative_stars": 9282
+      "cumulative_stars": 9498
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-01-01",
-      "cumulative_stars": 9783
+      "cumulative_stars": 10019
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
       "month": "2026-02-01",
-      "cumulative_stars": 10152
+      "cumulative_stars": 10408
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-03-01",
-      "cumulative_stars": 2201
+      "cumulative_stars": 2205
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-04-01",
-      "cumulative_stars": 2676
+      "cumulative_stars": 2682
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-05-01",
-      "cumulative_stars": 3057
+      "cumulative_stars": 3063
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-06-01",
-      "cumulative_stars": 3388
+      "cumulative_stars": 3394
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-07-01",
-      "cumulative_stars": 3695
+      "cumulative_stars": 3702
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-08-01",
-      "cumulative_stars": 3942
+      "cumulative_stars": 3951
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-09-01",
-      "cumulative_stars": 4248
+      "cumulative_stars": 4258
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-10-01",
-      "cumulative_stars": 4517
+      "cumulative_stars": 4528
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-11-01",
-      "cumulative_stars": 4805
+      "cumulative_stars": 4817
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2024-12-01",
-      "cumulative_stars": 4992
+      "cumulative_stars": 5004
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-01-01",
-      "cumulative_stars": 5303
+      "cumulative_stars": 5315
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-02-01",
-      "cumulative_stars": 5601
+      "cumulative_stars": 5613
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-03-01",
-      "cumulative_stars": 5970
+      "cumulative_stars": 5982
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-04-01",
-      "cumulative_stars": 6315
+      "cumulative_stars": 6327
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-05-01",
-      "cumulative_stars": 6831
+      "cumulative_stars": 6844
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-06-01",
-      "cumulative_stars": 7355
+      "cumulative_stars": 7368
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-07-01",
-      "cumulative_stars": 7785
+      "cumulative_stars": 7798
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-08-01",
-      "cumulative_stars": 8209
+      "cumulative_stars": 8223
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-09-01",
-      "cumulative_stars": 8558
+      "cumulative_stars": 8573
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-10-01",
-      "cumulative_stars": 8940
+      "cumulative_stars": 8956
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-11-01",
-      "cumulative_stars": 9298
+      "cumulative_stars": 9315
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2025-12-01",
-      "cumulative_stars": 9731
+      "cumulative_stars": 9750
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2026-01-01",
-      "cumulative_stars": 10326
+      "cumulative_stars": 10351
     },
     {
       "repo": "https://github.com/promptfoo/promptfoo",
       "month": "2026-02-01",
-      "cumulative_stars": 10838
+      "cumulative_stars": 10869
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
@@ -6380,1032 +6380,1032 @@
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2024-11-01",
-      "cumulative_stars": 88
+      "cumulative_stars": 89
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2024-12-01",
-      "cumulative_stars": 4484
+      "cumulative_stars": 4491
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-01-01",
-      "cumulative_stars": 5803
+      "cumulative_stars": 5811
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-02-01",
-      "cumulative_stars": 6571
+      "cumulative_stars": 6580
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-03-01",
-      "cumulative_stars": 7733
+      "cumulative_stars": 7742
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-04-01",
-      "cumulative_stars": 8905
+      "cumulative_stars": 8916
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-05-01",
-      "cumulative_stars": 9770
+      "cumulative_stars": 9783
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-06-01",
-      "cumulative_stars": 10374
+      "cumulative_stars": 10390
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-07-01",
-      "cumulative_stars": 11226
+      "cumulative_stars": 11249
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-08-01",
-      "cumulative_stars": 11896
+      "cumulative_stars": 11919
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-09-01",
-      "cumulative_stars": 12633
+      "cumulative_stars": 12658
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-10-01",
-      "cumulative_stars": 13079
+      "cumulative_stars": 13105
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-11-01",
-      "cumulative_stars": 13543
+      "cumulative_stars": 13572
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2025-12-01",
-      "cumulative_stars": 14078
+      "cumulative_stars": 14108
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2026-01-01",
-      "cumulative_stars": 14573
+      "cumulative_stars": 14604
     },
     {
       "repo": "https://github.com/pydantic/pydantic-ai",
       "month": "2026-02-01",
-      "cumulative_stars": 15213
+      "cumulative_stars": 15250
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-03-01",
-      "cumulative_stars": 17080
+      "cumulative_stars": 17103
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-04-01",
-      "cumulative_stars": 17590
+      "cumulative_stars": 17614
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-05-01",
-      "cumulative_stars": 18056
+      "cumulative_stars": 18081
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-06-01",
-      "cumulative_stars": 18397
+      "cumulative_stars": 18423
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-07-01",
-      "cumulative_stars": 18986
+      "cumulative_stars": 19012
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-08-01",
-      "cumulative_stars": 19377
+      "cumulative_stars": 19403
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-09-01",
-      "cumulative_stars": 19722
+      "cumulative_stars": 19749
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-10-01",
-      "cumulative_stars": 20132
+      "cumulative_stars": 20161
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-11-01",
-      "cumulative_stars": 20550
+      "cumulative_stars": 20580
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-12-01",
-      "cumulative_stars": 20942
+      "cumulative_stars": 20972
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-01-01",
-      "cumulative_stars": 21380
+      "cumulative_stars": 21410
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-02-01",
-      "cumulative_stars": 22001
+      "cumulative_stars": 22032
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-03-01",
-      "cumulative_stars": 22659
+      "cumulative_stars": 22692
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-04-01",
-      "cumulative_stars": 23183
+      "cumulative_stars": 23218
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-05-01",
-      "cumulative_stars": 23796
+      "cumulative_stars": 23831
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-06-01",
-      "cumulative_stars": 24331
+      "cumulative_stars": 24368
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-07-01",
-      "cumulative_stars": 24997
+      "cumulative_stars": 25034
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-08-01",
-      "cumulative_stars": 25649
+      "cumulative_stars": 25688
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-09-01",
-      "cumulative_stars": 26425
+      "cumulative_stars": 26464
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-10-01",
-      "cumulative_stars": 26969
+      "cumulative_stars": 27008
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-11-01",
-      "cumulative_stars": 27544
+      "cumulative_stars": 27586
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2025-12-01",
-      "cumulative_stars": 28166
+      "cumulative_stars": 28211
     },
     {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2026-01-01",
-      "cumulative_stars": 28793
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2026-02-01",
-      "cumulative_stars": 29514
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-03-01",
-      "cumulative_stars": 29567
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-04-01",
-      "cumulative_stars": 30696
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-05-01",
-      "cumulative_stars": 31769
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-06-01",
-      "cumulative_stars": 32699
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-07-01",
-      "cumulative_stars": 33686
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-08-01",
-      "cumulative_stars": 34643
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-09-01",
-      "cumulative_stars": 35420
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-10-01",
-      "cumulative_stars": 36101
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-11-01",
-      "cumulative_stars": 36771
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-12-01",
-      "cumulative_stars": 37475
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-01-01",
-      "cumulative_stars": 38317
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-02-01",
-      "cumulative_stars": 39308
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-03-01",
-      "cumulative_stars": 40493
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-04-01",
-      "cumulative_stars": 41335
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-05-01",
-      "cumulative_stars": 42090
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-06-01",
-      "cumulative_stars": 42845
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-07-01",
-      "cumulative_stars": 43633
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-08-01",
-      "cumulative_stars": 44259
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-09-01",
-      "cumulative_stars": 44882
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-10-01",
-      "cumulative_stars": 45449
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-11-01",
-      "cumulative_stars": 46064
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-12-01",
-      "cumulative_stars": 46691
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2026-01-01",
-      "cumulative_stars": 47402
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2026-02-01",
-      "cumulative_stars": 48046
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-03-01",
-      "cumulative_stars": 5255
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-04-01",
-      "cumulative_stars": 5441
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-05-01",
-      "cumulative_stars": 5588
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-06-01",
-      "cumulative_stars": 5949
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-07-01",
-      "cumulative_stars": 6131
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-08-01",
-      "cumulative_stars": 6236
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-09-01",
-      "cumulative_stars": 6405
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-10-01",
-      "cumulative_stars": 6525
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-11-01",
-      "cumulative_stars": 6640
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-12-01",
-      "cumulative_stars": 6778
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-01-01",
-      "cumulative_stars": 6915
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-02-01",
-      "cumulative_stars": 7176
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-03-01",
-      "cumulative_stars": 7420
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-04-01",
-      "cumulative_stars": 7786
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-05-01",
-      "cumulative_stars": 7988
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-06-01",
-      "cumulative_stars": 8107
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-07-01",
-      "cumulative_stars": 8248
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-08-01",
-      "cumulative_stars": 8396
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-09-01",
-      "cumulative_stars": 8598
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-10-01",
-      "cumulative_stars": 8713
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-11-01",
-      "cumulative_stars": 8853
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-12-01",
-      "cumulative_stars": 8986
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2026-01-01",
-      "cumulative_stars": 9241
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2026-02-01",
-      "cumulative_stars": 9365
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-03-01",
-      "cumulative_stars": 8935
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-04-01",
-      "cumulative_stars": 10473
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-05-01",
-      "cumulative_stars": 11801
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-06-01",
-      "cumulative_stars": 13499
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-07-01",
-      "cumulative_stars": 14727
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-08-01",
-      "cumulative_stars": 15954
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-09-01",
-      "cumulative_stars": 17090
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-10-01",
-      "cumulative_stars": 18062
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-11-01",
-      "cumulative_stars": 19134
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-12-01",
-      "cumulative_stars": 20394
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-01-01",
-      "cumulative_stars": 21335
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-02-01",
-      "cumulative_stars": 21997
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-03-01",
-      "cumulative_stars": 22664
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-04-01",
-      "cumulative_stars": 23836
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-05-01",
-      "cumulative_stars": 24524
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-06-01",
-      "cumulative_stars": 25942
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-07-01",
-      "cumulative_stars": 26826
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-08-01",
-      "cumulative_stars": 27761
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-09-01",
       "cumulative_stars": 28839
     },
     {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2026-02-01",
+      "cumulative_stars": 29572
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-03-01",
+      "cumulative_stars": 29607
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-04-01",
+      "cumulative_stars": 30738
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-05-01",
+      "cumulative_stars": 31812
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-06-01",
+      "cumulative_stars": 32743
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-07-01",
+      "cumulative_stars": 33731
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-08-01",
+      "cumulative_stars": 34688
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-09-01",
+      "cumulative_stars": 35465
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-10-01",
+      "cumulative_stars": 36147
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-11-01",
+      "cumulative_stars": 36820
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-12-01",
+      "cumulative_stars": 37525
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-01-01",
+      "cumulative_stars": 38368
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-02-01",
+      "cumulative_stars": 39361
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-03-01",
+      "cumulative_stars": 40549
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-04-01",
+      "cumulative_stars": 41392
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-05-01",
+      "cumulative_stars": 42147
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-06-01",
+      "cumulative_stars": 42903
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-07-01",
+      "cumulative_stars": 43693
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-08-01",
+      "cumulative_stars": 44323
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-09-01",
+      "cumulative_stars": 44948
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-10-01",
+      "cumulative_stars": 45516
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-11-01",
+      "cumulative_stars": 46137
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-12-01",
+      "cumulative_stars": 46766
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2026-01-01",
+      "cumulative_stars": 47479
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2026-02-01",
+      "cumulative_stars": 48129
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-03-01",
+      "cumulative_stars": 5300
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-04-01",
+      "cumulative_stars": 5486
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-05-01",
+      "cumulative_stars": 5633
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-06-01",
+      "cumulative_stars": 5998
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-07-01",
+      "cumulative_stars": 6182
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-08-01",
+      "cumulative_stars": 6287
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-09-01",
+      "cumulative_stars": 6457
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-10-01",
+      "cumulative_stars": 6579
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-11-01",
+      "cumulative_stars": 6695
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-12-01",
+      "cumulative_stars": 6835
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-01-01",
+      "cumulative_stars": 6973
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-02-01",
+      "cumulative_stars": 7236
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-03-01",
+      "cumulative_stars": 7483
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-04-01",
+      "cumulative_stars": 7857
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-05-01",
+      "cumulative_stars": 8062
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-06-01",
+      "cumulative_stars": 8181
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-07-01",
+      "cumulative_stars": 8327
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-08-01",
+      "cumulative_stars": 8478
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-09-01",
+      "cumulative_stars": 8684
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-10-01",
+      "cumulative_stars": 8803
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-11-01",
+      "cumulative_stars": 8946
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-12-01",
+      "cumulative_stars": 9081
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2026-01-01",
+      "cumulative_stars": 9338
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2026-02-01",
+      "cumulative_stars": 9465
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-03-01",
+      "cumulative_stars": 8943
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-04-01",
+      "cumulative_stars": 10483
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-05-01",
+      "cumulative_stars": 11813
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-06-01",
+      "cumulative_stars": 13513
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-07-01",
+      "cumulative_stars": 14741
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-08-01",
+      "cumulative_stars": 15969
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-09-01",
+      "cumulative_stars": 17106
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-10-01",
+      "cumulative_stars": 18080
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-11-01",
+      "cumulative_stars": 19157
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-12-01",
+      "cumulative_stars": 20421
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-01-01",
+      "cumulative_stars": 21363
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-02-01",
+      "cumulative_stars": 22027
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-03-01",
+      "cumulative_stars": 22695
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-04-01",
+      "cumulative_stars": 23867
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-05-01",
+      "cumulative_stars": 24556
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-06-01",
+      "cumulative_stars": 25981
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-07-01",
+      "cumulative_stars": 26867
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-08-01",
+      "cumulative_stars": 27804
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-09-01",
+      "cumulative_stars": 28883
+    },
+    {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2025-10-01",
-      "cumulative_stars": 29793
+      "cumulative_stars": 29842
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2025-11-01",
-      "cumulative_stars": 30566
+      "cumulative_stars": 30620
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2025-12-01",
-      "cumulative_stars": 31396
+      "cumulative_stars": 31453
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2026-01-01",
-      "cumulative_stars": 32198
+      "cumulative_stars": 32256
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2026-02-01",
-      "cumulative_stars": 32812
+      "cumulative_stars": 32879
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-03-01",
-      "cumulative_stars": 6499
+      "cumulative_stars": 6685
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-04-01",
-      "cumulative_stars": 6648
+      "cumulative_stars": 6836
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-05-01",
-      "cumulative_stars": 6778
+      "cumulative_stars": 6968
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-06-01",
-      "cumulative_stars": 6860
+      "cumulative_stars": 7052
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-07-01",
-      "cumulative_stars": 6942
+      "cumulative_stars": 7134
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-08-01",
-      "cumulative_stars": 6986
+      "cumulative_stars": 7178
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-09-01",
-      "cumulative_stars": 7021
+      "cumulative_stars": 7213
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2024-10-01",
-      "cumulative_stars": 7061
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-11-01",
-      "cumulative_stars": 7095
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-12-01",
-      "cumulative_stars": 7112
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-01-01",
-      "cumulative_stars": 7133
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-02-01",
-      "cumulative_stars": 7170
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-03-01",
-      "cumulative_stars": 7195
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-04-01",
-      "cumulative_stars": 7231
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-05-01",
       "cumulative_stars": 7253
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-06-01",
-      "cumulative_stars": 7263
+      "month": "2024-11-01",
+      "cumulative_stars": 7287
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-07-01",
-      "cumulative_stars": 7282
+      "month": "2024-12-01",
+      "cumulative_stars": 7305
     },
     {
       "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-08-01",
-      "cumulative_stars": 7301
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-09-01",
-      "cumulative_stars": 7314
-    },
-    {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2025-10-01",
+      "month": "2025-01-01",
       "cumulative_stars": 7328
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-02-01",
+      "cumulative_stars": 7365
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-03-01",
+      "cumulative_stars": 7390
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-04-01",
+      "cumulative_stars": 7426
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-05-01",
+      "cumulative_stars": 7449
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-06-01",
+      "cumulative_stars": 7459
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-07-01",
+      "cumulative_stars": 7478
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-08-01",
+      "cumulative_stars": 7498
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-09-01",
+      "cumulative_stars": 7511
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2025-10-01",
+      "cumulative_stars": 7526
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-11-01",
-      "cumulative_stars": 7341
+      "cumulative_stars": 7540
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-12-01",
-      "cumulative_stars": 7360
+      "cumulative_stars": 7559
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-01-01",
-      "cumulative_stars": 7380
+      "cumulative_stars": 7579
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-02-01",
-      "cumulative_stars": 7397
+      "cumulative_stars": 7598
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-03-01",
-      "cumulative_stars": 9424
+      "cumulative_stars": 9440
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-04-01",
-      "cumulative_stars": 9715
+      "cumulative_stars": 9731
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-05-01",
-      "cumulative_stars": 10103
+      "cumulative_stars": 10119
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-06-01",
-      "cumulative_stars": 10371
+      "cumulative_stars": 10387
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-07-01",
-      "cumulative_stars": 10692
+      "cumulative_stars": 10708
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-08-01",
-      "cumulative_stars": 11011
+      "cumulative_stars": 11027
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-09-01",
-      "cumulative_stars": 11374
+      "cumulative_stars": 11391
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-10-01",
-      "cumulative_stars": 11718
+      "cumulative_stars": 11736
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-11-01",
-      "cumulative_stars": 12014
+      "cumulative_stars": 12033
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2024-12-01",
-      "cumulative_stars": 12322
+      "cumulative_stars": 12343
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-01-01",
-      "cumulative_stars": 12651
+      "cumulative_stars": 12673
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-02-01",
-      "cumulative_stars": 12999
+      "cumulative_stars": 13021
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-03-01",
-      "cumulative_stars": 13367
+      "cumulative_stars": 13391
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-04-01",
-      "cumulative_stars": 13684
+      "cumulative_stars": 13710
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-05-01",
-      "cumulative_stars": 14102
+      "cumulative_stars": 14128
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-06-01",
-      "cumulative_stars": 14594
+      "cumulative_stars": 14621
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-07-01",
-      "cumulative_stars": 15021
+      "cumulative_stars": 15050
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-08-01",
-      "cumulative_stars": 15418
+      "cumulative_stars": 15447
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-09-01",
-      "cumulative_stars": 15858
+      "cumulative_stars": 15890
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-10-01",
-      "cumulative_stars": 16350
+      "cumulative_stars": 16383
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-11-01",
-      "cumulative_stars": 16780
+      "cumulative_stars": 16813
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2025-12-01",
-      "cumulative_stars": 17319
+      "cumulative_stars": 17355
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2026-01-01",
-      "cumulative_stars": 18097
+      "cumulative_stars": 18139
     },
     {
       "repo": "https://github.com/temporalio/temporal",
       "month": "2026-02-01",
-      "cumulative_stars": 18625
+      "cumulative_stars": 18671
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-05-01",
-      "cumulative_stars": 681
+      "cumulative_stars": 691
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-06-01",
-      "cumulative_stars": 1069
+      "cumulative_stars": 1081
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "cumulative_stars": 1438
+      "cumulative_stars": 1457
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-08-01",
-      "cumulative_stars": 1841
+      "cumulative_stars": 1867
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-09-01",
-      "cumulative_stars": 7324
+      "cumulative_stars": 7655
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-10-01",
-      "cumulative_stars": 13930
+      "cumulative_stars": 14526
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-11-01",
-      "cumulative_stars": 15856
+      "cumulative_stars": 16499
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-12-01",
-      "cumulative_stars": 17609
+      "cumulative_stars": 18310
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-01-01",
-      "cumulative_stars": 26007
+      "cumulative_stars": 27176
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-02-01",
-      "cumulative_stars": 29545
+      "cumulative_stars": 30873
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
-      "cumulative_stars": 32563
+      "cumulative_stars": 34033
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-04-01",
-      "cumulative_stars": 38869
+      "cumulative_stars": 40589
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "cumulative_stars": 41705
+      "cumulative_stars": 43582
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-06-01",
-      "cumulative_stars": 43767
+      "cumulative_stars": 45746
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "cumulative_stars": 46876
+      "cumulative_stars": 49042
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "cumulative_stars": 48591
+      "cumulative_stars": 50869
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-09-01",
-      "cumulative_stars": 50735
+      "cumulative_stars": 53137
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "cumulative_stars": 51922
+      "cumulative_stars": 54436
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-11-01",
-      "cumulative_stars": 53181
+      "cumulative_stars": 55796
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "cumulative_stars": 54423
+      "cumulative_stars": 57134
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "cumulative_stars": 55834
+      "cumulative_stars": 58645
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "cumulative_stars": 57632
+      "cumulative_stars": 60604
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-03-01",
-      "cumulative_stars": 8934
+      "cumulative_stars": 8942
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-04-01",
-      "cumulative_stars": 9247
+      "cumulative_stars": 9255
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-05-01",
-      "cumulative_stars": 9574
+      "cumulative_stars": 9583
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-06-01",
-      "cumulative_stars": 9864
+      "cumulative_stars": 9874
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-07-01",
-      "cumulative_stars": 10144
+      "cumulative_stars": 10154
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-08-01",
-      "cumulative_stars": 10373
+      "cumulative_stars": 10383
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-09-01",
-      "cumulative_stars": 10706
+      "cumulative_stars": 10717
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-10-01",
-      "cumulative_stars": 11033
+      "cumulative_stars": 11045
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-11-01",
-      "cumulative_stars": 11412
+      "cumulative_stars": 11425
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-12-01",
-      "cumulative_stars": 11667
+      "cumulative_stars": 11682
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-01-01",
-      "cumulative_stars": 11918
+      "cumulative_stars": 11933
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-02-01",
-      "cumulative_stars": 12324
+      "cumulative_stars": 12341
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-03-01",
-      "cumulative_stars": 12727
+      "cumulative_stars": 12745
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-04-01",
-      "cumulative_stars": 13000
+      "cumulative_stars": 13019
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-05-01",
-      "cumulative_stars": 13295
+      "cumulative_stars": 13314
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-06-01",
-      "cumulative_stars": 13600
+      "cumulative_stars": 13619
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-07-01",
-      "cumulative_stars": 13902
+      "cumulative_stars": 13923
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-08-01",
-      "cumulative_stars": 14257
+      "cumulative_stars": 14279
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-09-01",
-      "cumulative_stars": 14581
+      "cumulative_stars": 14605
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-10-01",
-      "cumulative_stars": 14802
+      "cumulative_stars": 14826
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-11-01",
-      "cumulative_stars": 15051
+      "cumulative_stars": 15076
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2025-12-01",
-      "cumulative_stars": 15275
+      "cumulative_stars": 15300
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2026-01-01",
-      "cumulative_stars": 15492
+      "cumulative_stars": 15518
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2026-02-01",
-      "cumulative_stars": 15703
+      "cumulative_stars": 15734
     },
     {
       "repo": "https://github.com/wong2/litemcp",
@@ -7475,117 +7475,117 @@
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "cumulative_stars": 634
+      "cumulative_stars": 646
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "cumulative_stars": 925
+      "cumulative_stars": 943
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-06-01",
-      "cumulative_stars": 977
+      "cumulative_stars": 996
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-07-01",
-      "cumulative_stars": 1020
+      "cumulative_stars": 1041
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-08-01",
-      "cumulative_stars": 1053
-    },
-    {
-      "repo": "https://github.com/xlang-ai/OSWorld",
-      "month": "2024-09-01",
       "cumulative_stars": 1076
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
+      "month": "2024-09-01",
+      "cumulative_stars": 1099
+    },
+    {
+      "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-10-01",
-      "cumulative_stars": 1228
+      "cumulative_stars": 1253
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "cumulative_stars": 1351
+      "cumulative_stars": 1379
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-12-01",
-      "cumulative_stars": 1424
+      "cumulative_stars": 1453
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-01-01",
-      "cumulative_stars": 1510
+      "cumulative_stars": 1540
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-02-01",
-      "cumulative_stars": 1575
+      "cumulative_stars": 1607
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "cumulative_stars": 1656
+      "cumulative_stars": 1690
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "cumulative_stars": 1743
+      "cumulative_stars": 1778
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "cumulative_stars": 1804
+      "cumulative_stars": 1841
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "cumulative_stars": 1865
+      "cumulative_stars": 1903
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "cumulative_stars": 1917
+      "cumulative_stars": 1955
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "cumulative_stars": 2043
+      "cumulative_stars": 2086
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "cumulative_stars": 2106
+      "cumulative_stars": 2149
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "cumulative_stars": 2199
+      "cumulative_stars": 2247
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "cumulative_stars": 2265
+      "cumulative_stars": 2315
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "cumulative_stars": 2337
+      "cumulative_stars": 2393
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "cumulative_stars": 2435
+      "cumulative_stars": 2493
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "cumulative_stars": 2515
+      "cumulative_stars": 2578
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/test_metric.json
+++ b/frontend/public/data/agentic-ai-momentum/test_metric.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:27:46.361869",
+    "fetched_at": "2026-04-01T07:13:24.871395",
     "schema": {
       "name": "test_metric",
       "description": "Dummy test metric.",

--- a/frontend/public/data/agentic-ai-momentum/total_vulnerabilities_count.json
+++ b/frontend/public/data/agentic-ai-momentum/total_vulnerabilities_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:28:25.388315",
+    "fetched_at": "2026-04-01T07:14:02.958968",
     "schema": {
       "name": "total_vulnerabilities_count",
       "description": "Cumulative monthly count of known vulnerabilities for tracked repositories.",
@@ -28,99 +28,64 @@
   },
   "data": [
     {
-      "repo": "https://github.com/Aider-AI/aider",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/BerriAI/litellm",
-      "month": "2024-03-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/BerriAI/litellm",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 6
-    },
-    {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-02-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/BerriAI/litellm",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 8
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-10-01",
-      "vulnerabilities_count": 18
+      "vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2025-12-01",
-      "vulnerabilities_count": 28
+      "vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-01-01",
-      "vulnerabilities_count": 51
+      "vulnerabilities_count": 25
     },
     {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2026-02-01",
-      "vulnerabilities_count": 73
+      "vulnerabilities_count": 36
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-07-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/ComposioHQ/composio",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 4
+      "vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-09-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-10-01",
-      "vulnerabilities_count": 10
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-11-01",
-      "vulnerabilities_count": 12
+      "vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2025-12-01",
-      "vulnerabilities_count": 19
+      "vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-01-01",
-      "vulnerabilities_count": 49
+      "vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
       "month": "2026-02-01",
-      "vulnerabilities_count": 76
+      "vulnerabilities_count": 31
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
@@ -130,27 +95,27 @@
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-10-01",
-      "vulnerabilities_count": 4
+      "vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-11-01",
-      "vulnerabilities_count": 7
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2025-12-01",
-      "vulnerabilities_count": 12
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-01-01",
-      "vulnerabilities_count": 35
+      "vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-02-01",
-      "vulnerabilities_count": 59
+      "vulnerabilities_count": 26
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
@@ -165,32 +130,27 @@
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-09-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-10-01",
-      "vulnerabilities_count": 7
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2025-11-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/OpenHands/OpenHands",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-01-01",
-      "vulnerabilities_count": 13
+      "vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
       "month": "2026-02-01",
-      "vulnerabilities_count": 21
+      "vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -210,322 +170,307 @@
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-01-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
       "month": "2026-02-01",
-      "vulnerabilities_count": 16
+      "vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-04-01",
-      "vulnerabilities_count": 17
+      "vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-05-01",
-      "vulnerabilities_count": 20
+      "vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-08-01",
-      "vulnerabilities_count": 21
+      "vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-09-01",
-      "vulnerabilities_count": 27
+      "vulnerabilities_count": 17
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-10-01",
-      "vulnerabilities_count": 34
+      "vulnerabilities_count": 21
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-11-01",
-      "vulnerabilities_count": 47
+      "vulnerabilities_count": 26
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-12-01",
-      "vulnerabilities_count": 49
+      "vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-02-01",
+      "vulnerabilities_count": 28
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-03-01",
+      "vulnerabilities_count": 33
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 36
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 39
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 41
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 45
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-08-01",
+      "vulnerabilities_count": 46
+    },
+    {
+      "repo": "https://github.com/ShishirPatil/gorilla",
+      "month": "2025-09-01",
       "vulnerabilities_count": 50
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 56
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 63
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 67
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 72
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 82
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 84
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 91
-    },
-    {
-      "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-11-01",
-      "vulnerabilities_count": 96
+      "vulnerabilities_count": 52
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2025-12-01",
-      "vulnerabilities_count": 98
+      "vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-01-01",
-      "vulnerabilities_count": 104
+      "vulnerabilities_count": 57
     },
     {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2026-02-01",
-      "vulnerabilities_count": 115
+      "vulnerabilities_count": 64
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-03-01",
-      "vulnerabilities_count": 6
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-04-01",
-      "vulnerabilities_count": 17
+      "vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-05-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 20
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2024-07-01",
+      "vulnerabilities_count": 29
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 31
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2024-10-01",
       "vulnerabilities_count": 32
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 45
+      "month": "2024-11-01",
+      "vulnerabilities_count": 37
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2024-07-01",
-      "vulnerabilities_count": 60
+      "month": "2024-12-01",
+      "vulnerabilities_count": 41
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2024-09-01",
+      "month": "2025-03-01",
+      "vulnerabilities_count": 47
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 50
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 53
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 58
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 59
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2025-08-01",
       "vulnerabilities_count": 62
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2024-10-01",
+      "month": "2025-10-01",
       "vulnerabilities_count": 65
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 74
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2024-12-01",
-      "vulnerabilities_count": 83
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 96
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 99
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 105
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 113
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 120
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 124
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 129
-    },
-    {
-      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-11-01",
-      "vulnerabilities_count": 132
+      "vulnerabilities_count": 66
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2025-12-01",
-      "vulnerabilities_count": 147
+      "vulnerabilities_count": 71
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-01-01",
-      "vulnerabilities_count": 206
+      "vulnerabilities_count": 103
     },
     {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
-      "vulnerabilities_count": 231
+      "vulnerabilities_count": 119
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-08-01",
-      "vulnerabilities_count": 3
+      "vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-09-01",
-      "vulnerabilities_count": 6
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-10-01",
-      "vulnerabilities_count": 36
+      "vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-12-01",
-      "vulnerabilities_count": 42
+      "vulnerabilities_count": 19
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2026-01-01",
-      "vulnerabilities_count": 51
+      "vulnerabilities_count": 23
     },
     {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2026-02-01",
-      "vulnerabilities_count": 60
+      "vulnerabilities_count": 28
     },
     {
       "repo": "https://github.com/agntcy/slim",
-      "month": "2024-09-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/agntcy/slim",
-      "month": "2024-10-01",
+      "month": "2025-06-01",
       "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/agntcy/slim",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/agntcy/slim",
       "month": "2025-08-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2025-09-01",
-      "vulnerabilities_count": 6
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2025-10-01",
-      "vulnerabilities_count": 26
+      "vulnerabilities_count": 24
     },
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2025-12-01",
-      "vulnerabilities_count": 31
+      "vulnerabilities_count": 29
     },
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2026-01-01",
-      "vulnerabilities_count": 40
+      "vulnerabilities_count": 38
     },
     {
       "repo": "https://github.com/agntcy/slim",
       "month": "2026-02-01",
-      "vulnerabilities_count": 48
+      "vulnerabilities_count": 45
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-05-01",
-      "vulnerabilities_count": 6
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2024-12-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/assafelovic/gpt-researcher",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 10
+      "vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-07-01",
-      "vulnerabilities_count": 12
+      "vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-11-01",
-      "vulnerabilities_count": 14
+      "vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2025-12-01",
-      "vulnerabilities_count": 17
+      "vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2026-01-01",
-      "vulnerabilities_count": 19
+      "vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/assafelovic/gpt-researcher",
       "month": "2026-02-01",
-      "vulnerabilities_count": 24
+      "vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/block/goose",
@@ -555,212 +500,187 @@
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-01-01",
-      "vulnerabilities_count": 15
+      "vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/block/goose",
       "month": "2026-02-01",
-      "vulnerabilities_count": 28
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-03-01",
-      "vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 15
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-05-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 23
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-08-01",
       "vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-03-01",
+      "vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-04-01",
+      "vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-05-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2024-08-01",
+      "vulnerabilities_count": 16
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
       "month": "2024-09-01",
-      "vulnerabilities_count": 28
+      "vulnerabilities_count": 17
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2024-10-01",
-      "vulnerabilities_count": 53
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 54
+      "vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-01-01",
-      "vulnerabilities_count": 55
+      "vulnerabilities_count": 28
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-03-01",
-      "vulnerabilities_count": 58
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 59
+      "vulnerabilities_count": 29
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-05-01",
-      "vulnerabilities_count": 60
-    },
-    {
-      "repo": "https://github.com/camel-ai/camel",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 61
+      "vulnerabilities_count": 30
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-08-01",
-      "vulnerabilities_count": 62
+      "vulnerabilities_count": 31
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2025-10-01",
-      "vulnerabilities_count": 64
+      "vulnerabilities_count": 33
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-01-01",
-      "vulnerabilities_count": 74
+      "vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/camel-ai/camel",
       "month": "2026-02-01",
-      "vulnerabilities_count": 82
+      "vulnerabilities_count": 42
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-03-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-05-01",
+      "vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2024-06-01",
       "vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-09-01",
-      "vulnerabilities_count": 14
+      "vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-10-01",
-      "vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 17
+      "vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-12-01",
-      "vulnerabilities_count": 21
+      "vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-02-01",
-      "vulnerabilities_count": 26
+      "vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-03-01",
+      "vulnerabilities_count": 29
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 33
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 36
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-07-01",
       "vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 46
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 53
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 58
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
       "month": "2025-08-01",
+      "vulnerabilities_count": 43
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 51
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 56
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 61
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2025-12-01",
       "vulnerabilities_count": 64
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 74
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 84
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 100
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 109
-    },
-    {
-      "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-01-01",
-      "vulnerabilities_count": 149
+      "vulnerabilities_count": 85
     },
     {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-02-01",
-      "vulnerabilities_count": 198
+      "vulnerabilities_count": 117
     },
     {
       "repo": "https://github.com/cline/cline",
-      "month": "2025-02-01",
+      "month": "2025-12-01",
       "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/cline/cline",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/cline/cline",
       "month": "2026-01-01",
-      "vulnerabilities_count": 13
+      "vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/cline/cline",
       "month": "2026-02-01",
-      "vulnerabilities_count": 43
+      "vulnerabilities_count": 23
     },
     {
       "repo": "https://github.com/comet-ml/opik",
@@ -770,347 +690,282 @@
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-08-01",
-      "vulnerabilities_count": 3
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-02-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-03-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 10
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-05-01",
-      "vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 15
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-08-01",
-      "vulnerabilities_count": 19
+      "vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-09-01",
-      "vulnerabilities_count": 24
-    },
-    {
-      "repo": "https://github.com/comet-ml/opik",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 25
+      "vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-11-01",
-      "vulnerabilities_count": 27
+      "vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2025-12-01",
-      "vulnerabilities_count": 30
+      "vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-01-01",
-      "vulnerabilities_count": 35
+      "vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
-      "vulnerabilities_count": 90
+      "vulnerabilities_count": 48
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-02-01",
+      "month": "2025-07-01",
       "vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-07-01",
+      "month": "2025-11-01",
       "vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/confident-ai/deepeval",
       "month": "2025-12-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-01-01",
-      "vulnerabilities_count": 14
+      "vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
       "month": "2026-02-01",
-      "vulnerabilities_count": 34
+      "vulnerabilities_count": 18
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-04-01",
-      "vulnerabilities_count": 313
+      "vulnerabilities_count": 143
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-05-01",
-      "vulnerabilities_count": 316
+      "vulnerabilities_count": 145
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-06-01",
-      "vulnerabilities_count": 320
+      "vulnerabilities_count": 148
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-07-01",
-      "vulnerabilities_count": 321
+      "vulnerabilities_count": 149
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-08-01",
-      "vulnerabilities_count": 322
+      "vulnerabilities_count": 150
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-10-01",
-      "vulnerabilities_count": 324
+      "vulnerabilities_count": 151
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-11-01",
-      "vulnerabilities_count": 329
-    },
-    {
-      "repo": "https://github.com/continuedev/continue",
-      "month": "2025-01-01",
-      "vulnerabilities_count": 330
+      "vulnerabilities_count": 154
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-02-01",
-      "vulnerabilities_count": 334
+      "vulnerabilities_count": 156
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-03-01",
-      "vulnerabilities_count": 345
+      "vulnerabilities_count": 160
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-04-01",
-      "vulnerabilities_count": 346
+      "vulnerabilities_count": 161
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-06-01",
-      "vulnerabilities_count": 354
+      "vulnerabilities_count": 163
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-07-01",
-      "vulnerabilities_count": 358
+      "vulnerabilities_count": 166
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-09-01",
-      "vulnerabilities_count": 369
+      "vulnerabilities_count": 175
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-10-01",
-      "vulnerabilities_count": 377
+      "vulnerabilities_count": 179
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-11-01",
-      "vulnerabilities_count": 398
+      "vulnerabilities_count": 192
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2025-12-01",
-      "vulnerabilities_count": 409
+      "vulnerabilities_count": 197
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-01-01",
-      "vulnerabilities_count": 468
+      "vulnerabilities_count": 229
     },
     {
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
-      "vulnerabilities_count": 562
+      "vulnerabilities_count": 275
     },
     {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2026-02-01",
-      "vulnerabilities_count": 3
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-03-01",
-      "vulnerabilities_count": 70
+      "vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-04-01",
-      "vulnerabilities_count": 77
+      "vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-05-01",
-      "vulnerabilities_count": 79
+      "vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-06-01",
-      "vulnerabilities_count": 82
+      "vulnerabilities_count": 43
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-07-01",
-      "vulnerabilities_count": 83
+      "vulnerabilities_count": 44
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-09-01",
-      "vulnerabilities_count": 91
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 92
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 94
+      "vulnerabilities_count": 45
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2024-12-01",
-      "vulnerabilities_count": 96
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-01-01",
-      "vulnerabilities_count": 98
-    },
-    {
-      "repo": "https://github.com/daytonaio/daytona",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 101
+      "vulnerabilities_count": 46
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-03-01",
-      "vulnerabilities_count": 102
+      "vulnerabilities_count": 47
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-04-01",
-      "vulnerabilities_count": 105
+      "vulnerabilities_count": 48
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-06-01",
-      "vulnerabilities_count": 113
+      "vulnerabilities_count": 51
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-07-01",
-      "vulnerabilities_count": 117
+      "vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-08-01",
-      "vulnerabilities_count": 120
+      "vulnerabilities_count": 55
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-09-01",
-      "vulnerabilities_count": 128
+      "vulnerabilities_count": 61
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-10-01",
-      "vulnerabilities_count": 180
+      "vulnerabilities_count": 87
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-11-01",
-      "vulnerabilities_count": 185
+      "vulnerabilities_count": 88
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2025-12-01",
-      "vulnerabilities_count": 212
+      "vulnerabilities_count": 103
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-01-01",
-      "vulnerabilities_count": 286
+      "vulnerabilities_count": 140
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
-      "vulnerabilities_count": 331
+      "vulnerabilities_count": 164
     },
     {
       "repo": "https://github.com/e2b-dev/code-interpreter",
       "month": "2026-02-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-03-01",
-      "vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2024-09-01",
       "vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-04-01",
-      "vulnerabilities_count": 4
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2025-10-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/guardrails-ai/guardrails",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 6
+      "vulnerabilities_count": 3
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -1120,332 +975,267 @@
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2024-11-01",
-      "vulnerabilities_count": 7
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-03-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-04-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/huggingface/smolagents",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/huggingface/smolagents",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/huggingface/smolagents",
+      "month": "2025-10-01",
       "vulnerabilities_count": 14
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 23
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 29
-    },
-    {
-      "repo": "https://github.com/huggingface/smolagents",
       "month": "2025-11-01",
-      "vulnerabilities_count": 30
+      "vulnerabilities_count": 15
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-01-01",
-      "vulnerabilities_count": 33
+      "vulnerabilities_count": 16
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
       "month": "2026-02-01",
-      "vulnerabilities_count": 40
+      "vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-04-01",
-      "vulnerabilities_count": 16
+      "vulnerabilities_count": 9
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-05-01",
-      "vulnerabilities_count": 17
+      "vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-10-01",
-      "vulnerabilities_count": 19
+      "vulnerabilities_count": 11
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-03-01",
-      "vulnerabilities_count": 21
+      "vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2025-04-01",
-      "vulnerabilities_count": 27
+      "vulnerabilities_count": 17
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-08-01",
+      "vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2025-09-01",
       "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-10-01",
-      "vulnerabilities_count": 66
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 67
+      "vulnerabilities_count": 38
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-12-01",
-      "vulnerabilities_count": 75
+      "vulnerabilities_count": 43
     },
     {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-01-01",
-      "vulnerabilities_count": 87
-    },
-    {
-      "repo": "https://github.com/ibm/mcp-context-forge",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 91
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2024-03-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2024-05-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 36
-    },
-    {
-      "repo": "https://github.com/infiniflow/ragflow",
-      "month": "2026-02-01",
       "vulnerabilities_count": 48
     },
     {
-      "repo": "https://github.com/janhq/jan",
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 50
+    },
+    {
+      "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-03-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 3
     },
     {
-      "repo": "https://github.com/janhq/jan",
+      "repo": "https://github.com/infiniflow/ragflow",
       "month": "2024-05-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 4
     },
     {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 15
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 10
     },
     {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2024-11-01",
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 11
+    },
+    {
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2026-01-01",
       "vulnerabilities_count": 16
     },
     {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-04-01",
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2026-02-01",
       "vulnerabilities_count": 23
     },
     {
       "repo": "https://github.com/janhq/jan",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 24
+      "month": "2024-03-01",
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/janhq/jan",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 26
+      "month": "2024-05-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 11
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 12
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-07-01",
-      "vulnerabilities_count": 29
+      "vulnerabilities_count": 13
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-08-01",
-      "vulnerabilities_count": 39
+      "vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-09-01",
-      "vulnerabilities_count": 44
+      "vulnerabilities_count": 25
     },
     {
       "repo": "https://github.com/janhq/jan",
       "month": "2025-10-01",
+      "vulnerabilities_count": 29
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 35
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 38
+    },
+    {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2026-01-01",
       "vulnerabilities_count": 49
     },
     {
       "repo": "https://github.com/janhq/jan",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 61
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 68
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 93
-    },
-    {
-      "repo": "https://github.com/janhq/jan",
       "month": "2026-02-01",
-      "vulnerabilities_count": 124
+      "vulnerabilities_count": 65
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-04-01",
-      "vulnerabilities_count": 225
+      "vulnerabilities_count": 110
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-05-01",
-      "vulnerabilities_count": 231
+      "vulnerabilities_count": 113
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-06-01",
-      "vulnerabilities_count": 241
+      "vulnerabilities_count": 120
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-07-01",
-      "vulnerabilities_count": 249
+      "vulnerabilities_count": 125
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-10-01",
-      "vulnerabilities_count": 251
+      "vulnerabilities_count": 127
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2024-11-01",
-      "vulnerabilities_count": 253
-    },
-    {
-      "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 255
-    },
-    {
-      "repo": "https://github.com/joonspk-research/generative_agents",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 257
+      "vulnerabilities_count": 128
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-06-01",
-      "vulnerabilities_count": 263
+      "vulnerabilities_count": 129
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-07-01",
-      "vulnerabilities_count": 265
+      "vulnerabilities_count": 130
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-09-01",
-      "vulnerabilities_count": 267
+      "vulnerabilities_count": 131
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-11-01",
-      "vulnerabilities_count": 271
+      "vulnerabilities_count": 132
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2025-12-01",
-      "vulnerabilities_count": 275
+      "vulnerabilities_count": 135
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-01-01",
-      "vulnerabilities_count": 293
+      "vulnerabilities_count": 145
     },
     {
       "repo": "https://github.com/joonspk-research/generative_agents",
       "month": "2026-02-01",
-      "vulnerabilities_count": 297
+      "vulnerabilities_count": 147
     },
     {
       "repo": "https://github.com/kserve/kserve",
@@ -1558,11 +1348,6 @@
       "vulnerabilities_count": 2
     },
     {
-      "repo": "https://github.com/langchain-ai/langgraph",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 3
-    },
-    {
       "repo": "https://github.com/langfuse/langfuse",
       "month": "2025-02-01",
       "vulnerabilities_count": 1
@@ -1574,1163 +1359,983 @@
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
       "month": "2026-01-01",
-      "vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/langfuse/langfuse",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 28
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 49
-    },
-    {
-      "repo": "https://github.com/letta-ai/letta",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 63
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 27
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 29
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 54
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 82
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 92
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 173
-    },
-    {
-      "repo": "https://github.com/mastra-ai/mastra",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 295
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/microsoft/TaskWeaver",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 42
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 46
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 55
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 64
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 71
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 84
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 120
-    },
-    {
-      "repo": "https://github.com/microsoft/autogen",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 149
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2025-12-01",
       "vulnerabilities_count": 4
     },
     {
-      "repo": "https://github.com/microsoft/graphrag",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/microsoft/graphrag",
+      "repo": "https://github.com/langfuse/langfuse",
       "month": "2026-02-01",
       "vulnerabilities_count": 12
     },
     {
-      "repo": "https://github.com/microsoft/playwright",
-      "month": "2026-01-01",
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2025-03-01",
       "vulnerabilities_count": 1
     },
     {
-      "repo": "https://github.com/microsoft/playwright",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 7
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-07-01",
-      "vulnerabilities_count": 27
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 29
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 33
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 40
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 66
-    },
-    {
-      "repo": "https://github.com/microsoft/semantic-kernel",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 100
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2024-09-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 15
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 26
-    },
-    {
-      "repo": "https://github.com/milvus-io/milvus",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 38
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2024-12-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 15
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/mistralai/mistral-inference",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/inspector",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2025-09-01",
       "vulnerabilities_count": 2
     },
     {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-10-01",
-      "vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 27
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 31
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 45
-    },
-    {
-      "repo": "https://github.com/ollama/ollama",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 54
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-02-01",
       "vulnerabilities_count": 7
     },
     {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 9
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 22
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 30
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 36
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 41
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 51
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-11-01",
-      "vulnerabilities_count": 55
+      "vulnerabilities_count": 8
     },
     {
-      "repo": "https://github.com/open-webui/open-webui",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2025-12-01",
-      "vulnerabilities_count": 64
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 110
-    },
-    {
-      "repo": "https://github.com/open-webui/open-webui",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 145
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2026-01-01",
       "vulnerabilities_count": 16
     },
     {
-      "repo": "https://github.com/openai/openai-agents-python",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 1
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 16
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
+      "repo": "https://github.com/letta-ai/letta",
       "month": "2026-01-01",
-      "vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/openclaw/openclaw",
-      "month": "2026-02-01",
       "vulnerabilities_count": 24
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-05-01",
-      "vulnerabilities_count": 4
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 32
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 7
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 9
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-08-01",
-      "vulnerabilities_count": 8
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-03-01",
+      "vulnerabilities_count": 11
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-09-01",
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-07-01",
       "vulnerabilities_count": 14
     },
     {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 17
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 18
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2024-12-01",
-      "vulnerabilities_count": 20
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 21
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 23
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 25
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 34
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 35
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 36
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 40
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 52
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 70
-    },
-    {
-      "repo": "https://github.com/pathwaycom/pathway",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 86
-    },
-    {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2024-09-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-01-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 6
-    },
-    {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 8
-    },
-    {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-08-01",
       "vulnerabilities_count": 15
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-09-01",
-      "vulnerabilities_count": 17
+      "vulnerabilities_count": 32
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 37
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 39
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-12-01",
       "vulnerabilities_count": 43
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-01-01",
-      "vulnerabilities_count": 50
+      "vulnerabilities_count": 83
     },
     {
-      "repo": "https://github.com/promptfoo/promptfoo",
+      "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
-      "vulnerabilities_count": 57
+      "vulnerabilities_count": 141
     },
     {
-      "repo": "https://github.com/pydantic/pydantic-ai",
-      "month": "2026-01-01",
+      "repo": "https://github.com/microsoft/TaskWeaver",
+      "month": "2025-12-01",
       "vulnerabilities_count": 1
     },
     {
-      "repo": "https://github.com/pydantic/pydantic-ai",
+      "repo": "https://github.com/microsoft/TaskWeaver",
       "month": "2026-02-01",
-      "vulnerabilities_count": 2
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2024-09-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2024-12-01",
       "vulnerabilities_count": 6
     },
     {
-      "repo": "https://github.com/qdrant/qdrant",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-03-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-05-01",
       "vulnerabilities_count": 7
     },
     {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2025-09-01",
+      "repo": "https://github.com/microsoft/autogen",
+      "month": "2025-06-01",
       "vulnerabilities_count": 9
     },
     {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/qdrant/qdrant",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 14
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-03-01",
-      "vulnerabilities_count": 1379
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 1383
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-05-01",
-      "vulnerabilities_count": 1396
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 1429
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-07-01",
-      "vulnerabilities_count": 1436
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-08-01",
-      "vulnerabilities_count": 1454
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-09-01",
-      "vulnerabilities_count": 1467
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 1524
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 1559
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2024-12-01",
-      "vulnerabilities_count": 1560
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-01-01",
-      "vulnerabilities_count": 1564
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 1575
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 1658
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 1718
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 2301
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 4771
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-07-01",
-      "vulnerabilities_count": 6697
+      "vulnerabilities_count": 18
     },
     {
-      "repo": "https://github.com/run-llama/llama_index",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-08-01",
-      "vulnerabilities_count": 6785
+      "vulnerabilities_count": 20
     },
     {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 7609
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 7658
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 7687
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 10902
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 18102
-    },
-    {
-      "repo": "https://github.com/run-llama/llama_index",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 20014
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-03-01",
-      "vulnerabilities_count": 261
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-04-01",
-      "vulnerabilities_count": 262
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-07-01",
-      "vulnerabilities_count": 263
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-09-01",
-      "vulnerabilities_count": 264
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 266
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-11-01",
-      "vulnerabilities_count": 272
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2024-12-01",
-      "vulnerabilities_count": 273
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-01-01",
-      "vulnerabilities_count": 276
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 277
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-03-01",
-      "vulnerabilities_count": 284
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 290
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 294
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 297
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 302
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-08-01",
-      "vulnerabilities_count": 307
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-09-01",
-      "vulnerabilities_count": 311
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-10-01",
-      "vulnerabilities_count": 321
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-11-01",
-      "vulnerabilities_count": 323
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 328
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 337
-    },
-    {
-      "repo": "https://github.com/skypilot-org/skypilot",
-      "month": "2026-02-01",
-      "vulnerabilities_count": 345
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2024-06-01",
-      "vulnerabilities_count": 10
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-02-01",
-      "vulnerabilities_count": 11
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 12
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-05-01",
-      "vulnerabilities_count": 13
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-06-01",
-      "vulnerabilities_count": 19
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
-      "month": "2025-07-01",
-      "vulnerabilities_count": 23
-    },
-    {
-      "repo": "https://github.com/stanfordnlp/dspy",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-09-01",
       "vulnerabilities_count": 24
     },
     {
-      "repo": "https://github.com/stanfordnlp/dspy",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-10-01",
-      "vulnerabilities_count": 27
+      "vulnerabilities_count": 29
     },
     {
-      "repo": "https://github.com/stanfordnlp/dspy",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-11-01",
-      "vulnerabilities_count": 28
+      "vulnerabilities_count": 34
     },
     {
-      "repo": "https://github.com/stanfordnlp/dspy",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2025-12-01",
-      "vulnerabilities_count": 42
+      "vulnerabilities_count": 38
     },
     {
-      "repo": "https://github.com/stanfordnlp/dspy",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2026-01-01",
-      "vulnerabilities_count": 68
+      "vulnerabilities_count": 63
     },
     {
-      "repo": "https://github.com/stanfordnlp/dspy",
+      "repo": "https://github.com/microsoft/autogen",
       "month": "2026-02-01",
       "vulnerabilities_count": 75
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-05-01",
-      "vulnerabilities_count": 5
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 2
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-06-01",
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-02-01",
       "vulnerabilities_count": 6
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-08-01",
+      "repo": "https://github.com/microsoft/playwright",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/microsoft/playwright",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-04-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-10-01",
+      "vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2024-11-01",
+      "vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-03-01",
       "vulnerabilities_count": 8
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-09-01",
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 11
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-10-01",
       "vulnerabilities_count": 18
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
-      "month": "2024-10-01",
-      "vulnerabilities_count": 27
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 20
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 23
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 38
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 56
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
       "month": "2024-11-01",
-      "vulnerabilities_count": 30
+      "vulnerabilities_count": 12
     },
     {
-      "repo": "https://github.com/sweepai/sweep",
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 19
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 34
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
       "month": "2024-12-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/mistralai/mistral-inference",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/inspector",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-08-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 19
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 21
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 26
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2024-04-01",
+      "vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 16
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-08-01",
+      "vulnerabilities_count": 17
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 18
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 23
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 50
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 70
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 2
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-05-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-10-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2024-12-01",
+      "vulnerabilities_count": 10
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 11
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-03-01",
+      "vulnerabilities_count": 12
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 14
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 18
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 19
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 21
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 29
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 41
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 51
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-01-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 22
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 31
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 33
+    },
+    {
+      "repo": "https://github.com/pydantic/pydantic-ai",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 1
+    },
+    {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2024-10-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 6
+    },
+    {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 8
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-03-01",
+      "vulnerabilities_count": 726
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-04-01",
+      "vulnerabilities_count": 728
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-05-01",
+      "vulnerabilities_count": 736
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 754
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-07-01",
+      "vulnerabilities_count": 756
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-08-01",
+      "vulnerabilities_count": 765
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 770
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-10-01",
+      "vulnerabilities_count": 801
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2024-11-01",
+      "vulnerabilities_count": 820
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-01-01",
+      "vulnerabilities_count": 822
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 829
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-03-01",
+      "vulnerabilities_count": 868
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 903
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 1216
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 2506
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 3501
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-08-01",
+      "vulnerabilities_count": 3551
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 3984
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 4013
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 4031
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 5669
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 9444
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 10414
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-04-01",
+      "vulnerabilities_count": 135
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-07-01",
+      "vulnerabilities_count": 136
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-11-01",
+      "vulnerabilities_count": 141
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2024-12-01",
+      "vulnerabilities_count": 142
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-01-01",
+      "vulnerabilities_count": 144
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-02-01",
+      "vulnerabilities_count": 145
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-03-01",
+      "vulnerabilities_count": 150
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-04-01",
+      "vulnerabilities_count": 152
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 155
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 158
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 160
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-08-01",
+      "vulnerabilities_count": 161
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-09-01",
+      "vulnerabilities_count": 162
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 168
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-11-01",
+      "vulnerabilities_count": 169
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 172
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 176
+    },
+    {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2026-02-01",
+      "vulnerabilities_count": 181
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 3
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-05-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-06-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-07-01",
+      "vulnerabilities_count": 9
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-10-01",
+      "vulnerabilities_count": 11
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2025-12-01",
+      "vulnerabilities_count": 20
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2026-01-01",
+      "vulnerabilities_count": 35
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2026-02-01",
       "vulnerabilities_count": 37
     },
     {
       "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-05-01",
+      "vulnerabilities_count": 4
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-06-01",
+      "vulnerabilities_count": 5
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-08-01",
+      "vulnerabilities_count": 7
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-09-01",
+      "vulnerabilities_count": 13
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-10-01",
+      "vulnerabilities_count": 19
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-11-01",
+      "vulnerabilities_count": 21
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
+      "month": "2024-12-01",
+      "vulnerabilities_count": 25
+    },
+    {
+      "repo": "https://github.com/sweepai/sweep",
       "month": "2025-01-01",
-      "vulnerabilities_count": 41
+      "vulnerabilities_count": 28
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-02-01",
-      "vulnerabilities_count": 46
+      "vulnerabilities_count": 30
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-03-01",
-      "vulnerabilities_count": 55
+      "vulnerabilities_count": 34
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-04-01",
-      "vulnerabilities_count": 56
+      "vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-05-01",
-      "vulnerabilities_count": 62
+      "vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-06-01",
-      "vulnerabilities_count": 64
+      "vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-07-01",
-      "vulnerabilities_count": 66
+      "vulnerabilities_count": 41
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-08-01",
-      "vulnerabilities_count": 76
+      "vulnerabilities_count": 50
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-09-01",
-      "vulnerabilities_count": 77
+      "vulnerabilities_count": 51
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-10-01",
-      "vulnerabilities_count": 79
+      "vulnerabilities_count": 52
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-11-01",
-      "vulnerabilities_count": 83
+      "vulnerabilities_count": 54
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2025-12-01",
-      "vulnerabilities_count": 94
+      "vulnerabilities_count": 61
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-01-01",
-      "vulnerabilities_count": 105
+      "vulnerabilities_count": 66
     },
     {
       "repo": "https://github.com/sweepai/sweep",
       "month": "2026-02-01",
-      "vulnerabilities_count": 122
+      "vulnerabilities_count": 72
     },
     {
       "repo": "https://github.com/temporalio/temporal",
@@ -2740,52 +2345,47 @@
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2024-07-01",
-      "vulnerabilities_count": 3
-    },
-    {
-      "repo": "https://github.com/unclecode/crawl4ai",
-      "month": "2025-04-01",
-      "vulnerabilities_count": 5
+      "vulnerabilities_count": 2
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-05-01",
-      "vulnerabilities_count": 7
+      "vulnerabilities_count": 4
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-07-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-08-01",
-      "vulnerabilities_count": 11
+      "vulnerabilities_count": 6
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-10-01",
-      "vulnerabilities_count": 13
+      "vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-12-01",
-      "vulnerabilities_count": 19
+      "vulnerabilities_count": 10
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
-      "vulnerabilities_count": 47
+      "vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-02-01",
-      "vulnerabilities_count": 66
+      "vulnerabilities_count": 39
     },
     {
       "repo": "https://github.com/weaviate/weaviate",
       "month": "2024-12-01",
-      "vulnerabilities_count": 4
+      "vulnerabilities_count": 1
     },
     {
       "repo": "https://github.com/wong2/litemcp",
@@ -2804,93 +2404,83 @@
     },
     {
       "repo": "https://github.com/wong2/litemcp",
-      "month": "2025-12-01",
-      "vulnerabilities_count": 4
-    },
-    {
-      "repo": "https://github.com/wong2/litemcp",
-      "month": "2026-01-01",
-      "vulnerabilities_count": 5
-    },
-    {
-      "repo": "https://github.com/wong2/litemcp",
       "month": "2026-02-01",
-      "vulnerabilities_count": 9
+      "vulnerabilities_count": 5
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-04-01",
-      "vulnerabilities_count": 13
+      "vulnerabilities_count": 7
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-05-01",
-      "vulnerabilities_count": 16
+      "vulnerabilities_count": 8
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2024-11-01",
-      "vulnerabilities_count": 28
+      "vulnerabilities_count": 17
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-03-01",
-      "vulnerabilities_count": 32
+      "vulnerabilities_count": 20
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-04-01",
-      "vulnerabilities_count": 40
+      "vulnerabilities_count": 24
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-05-01",
-      "vulnerabilities_count": 44
+      "vulnerabilities_count": 26
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-06-01",
-      "vulnerabilities_count": 45
+      "vulnerabilities_count": 27
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-07-01",
-      "vulnerabilities_count": 53
+      "vulnerabilities_count": 33
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-08-01",
-      "vulnerabilities_count": 55
+      "vulnerabilities_count": 35
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-09-01",
-      "vulnerabilities_count": 61
+      "vulnerabilities_count": 38
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-10-01",
-      "vulnerabilities_count": 64
+      "vulnerabilities_count": 40
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-11-01",
-      "vulnerabilities_count": 67
+      "vulnerabilities_count": 41
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2025-12-01",
-      "vulnerabilities_count": 73
+      "vulnerabilities_count": 44
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-01-01",
-      "vulnerabilities_count": 90
+      "vulnerabilities_count": 57
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
       "month": "2026-02-01",
-      "vulnerabilities_count": 103
+      "vulnerabilities_count": 65
     }
   ]
 }


### PR DESCRIPTION
- Refresh all 26 static JSON data files for the Agentic AI Momentum report with data pulled on 2026-04-01.
- Add an 'Updated: Month Year' badge to the report header.