### PR TITLE
feat: directly show security breakdown data for single repo projects

### DIFF
--- a/frontend/app/components/modules/project/components/shared/header/project-menu.vue
+++ b/frontend/app/components/modules/project/components/shared/header/project-menu.vue
@@ -68,7 +68,7 @@ SPDX-License-Identifier: MIT
 
 <script setup lang="ts">
 import { useRoute } from 'nuxt/app';
-import { computed, watch } from 'vue';
+import { computed } from 'vue';
 import { storeToRefs } from 'pinia';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
 import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
@@ -85,7 +85,6 @@ import { useProjectStore } from '~~/app/components/modules/project/store/project
 import LfxSkeletonState from '~/components/modules/project/components/shared/skeleton-state.vue';
 import { PROJECT_COMMUNITY_API_SERVICE } from '~/components/modules/project/services/community.api.service';
 import { useAuthStore } from '~/components/modules/auth/store/auth.store';
-import { VULNERABILITY_API_SERVICE } from '~/components/modules/project/services/vulnerability.api.service';
 
 const props = defineProps<{
   project?: Project;
@@ -94,16 +93,10 @@ const props = defineProps<{
 const route = useRoute();
 const repoName = computed(() => route.params.name as string);
 
-const { selectedRepositoryGroup, selectedReposValues } = storeToRefs(useProjectStore());
+const { selectedRepositoryGroup } = storeToRefs(useProjectStore());
 const { user } = storeToRefs(useAuthStore());
 
-const queryParams = computed(() => ({
-  projectSlug: props.project?.slug as string,
-  repos: selectedReposValues.value || undefined,
-}));
-const { data, refetch } = VULNERABILITY_API_SERVICE.checkVulnerabilitySummary(queryParams, user.value);
-
-const hasVulnerabilitiesData = computed(() => (data.value ? data.value.lastScanStatus === 'success' : false));
+const hasVulnerabilitiesData = computed(() => props.project?.lastVulnerabilityScanStatus === 'success' || false);
 
 const activeLink = computed(() =>
   lfProjectLinks.find((link) => {
@@ -157,10 +150,6 @@ const linkUrl = (link: (typeof lfProjectLinks)[number]) => {
     query,
   };
 };
-
-watch(user, () => {
-  refetch();
-});
 </script>
 
 <script lang="ts">

--- a/frontend/app/components/modules/project/components/vulnerabilities/vulnerabilities-section.vue
+++ b/frontend/app/components/modules/project/components/vulnerabilities/vulnerabilities-section.vue
@@ -78,7 +78,7 @@ const route = useRoute();
 
 const { selectedReposValues, project } = storeToRefs(useProjectStore());
 
-const isRepository = computed(() => !!route.params.name);
+const isRepository = computed(() => !!route.params.name || project.value?.repositoryGroups?.length === 0);
 const hasSelectedRepos = computed(() => selectedReposValues.value && selectedReposValues.value.length > 0);
 const showAggregatedDisclaimer = computed(() => !isRepository.value && !hasSelectedRepos.value);
 

--- a/frontend/app/components/modules/project/services/vulnerability.api.service.ts
+++ b/frontend/app/components/modules/project/services/vulnerability.api.service.ts
@@ -12,7 +12,6 @@ import type {
   VulnerabilityEcosystemCount,
 } from '~~/types/vulnerabilities/responses.types';
 import type { Pagination } from '~~/types/shared/pagination';
-import type { User } from '~~/types/auth/auth-user.types';
 
 export interface VulnerabilitiesQueryParams {
   projectSlug: string;
@@ -38,27 +37,6 @@ export interface AllVulnerabilitiesResponse {
 }
 
 class VulnerabilityApiService {
-  checkVulnerabilitySummary(params: ComputedRef<VulnerabilitiesQueryParams>, user: User | null) {
-    const queryKey = computed(() => [
-      TanstackKey.VULNERABILITIES,
-      'summary',
-      params.value.projectSlug,
-      params.value.repos,
-    ]);
-    const queryFn = computed<QueryFunction<VulnerabilitySummary>>(() =>
-      this.vulnerabilitySummaryQueryFn(() => ({
-        projectSlug: params.value.projectSlug,
-        repos: params.value.repos,
-      })),
-    );
-
-    return useQuery<VulnerabilitySummary>({
-      queryKey,
-      queryFn,
-      enabled: !!user && !!params.value.projectSlug,
-    });
-  }
-
   fetchVulnerabilitySummary(params: ComputedRef<VulnerabilitiesQueryParams>) {
     const queryKey = computed(() => [
       TanstackKey.VULNERABILITIES,

--- a/frontend/app/components/modules/project/views/security.vue
+++ b/frontend/app/components/modules/project/views/security.vue
@@ -186,7 +186,7 @@ const { selectedReposValues, project, isArchived, emptyStateTitle, emptyStateDes
   storeToRefs(useProjectStore());
 const { isAuthenticated } = storeToRefs(useAuthStore());
 
-const isRepository = computed(() => !!name);
+const isRepository = computed(() => !!name || project.value?.repositoryGroups?.length === 0);
 const isReposEvalModalOpen = ref(false);
 const currentTab = ref('');
 const accordion = ref('');

--- a/frontend/server/api/project/[slug]/index.ts
+++ b/frontend/server/api/project/[slug]/index.ts
@@ -51,7 +51,8 @@ export default defineEventHandler(async (event): Promise<Project | Error> => {
     if (!res.data || res.data.length === 0) {
       return createError({ statusCode: 404, statusMessage: 'Project not found' });
     }
-    const project: ProjectTinybird = res.data[0];
+    const project: ProjectTinybird = res.data[0]!;
+
     const repoData: Record<string, Partial<ProjectRepository>> = project.repoData.reduce(
       (acc, repo) => {
         const [url, score, rank] = repo;

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -43,6 +43,7 @@ export interface Project {
   communityKeywords: string[];
   communityLanguages: string[];
   status: string;
+  lastVulnerabilityScanStatus: string;
 }
 
 export interface ProjectLanguage {
@@ -93,6 +94,8 @@ export interface ProjectTinybird {
   firstCommitUrl?: string;
   connectedPlatforms: string[];
   repoData: ProjectRepoData[];
+  status: string;
+  lastVulnerabilityScanStatus: string;
 }
 
 export interface ProjectInsightsAchievement {


### PR DESCRIPTION
## In this PR

- Show the security assessment breakdown for projects that have single repo only
- Remove the message that and popup shortcut in the security tab that says the user is viewing aggregate repo data if the project only has 1 repository. The same is done on the vulnerability section
- Changed the vulnerability data check in the project menu to use the "lastVulnerabilityScanStatus" property instead of calling the vulnerability summary endpoint

## Ticket
[N-989](https://linuxfoundation.atlassian.net/browse/IN-989)