### PR TITLE
fix(security): 2 improvements across 2 files

### DIFF
--- a/frontend/.storybook/preview-head.html
+++ b/frontend/.storybook/preview-head.html
@@ -11,4 +11,4 @@
   rel="stylesheet"
   href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600&family=Roboto+Slab:wght@300;400;600&display=swap"
 />
-<script src="https://kit.fontawesome.com/d65f54d9ea.js"></script>
+

--- a/frontend/app/components/modules/project/components/community/card-displays/default-card.vue
+++ b/frontend/app/components/modules/project/components/community/card-displays/default-card.vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
 <!-- SPDX-License-Identifier: MIT -->
 <template>
   <nuxt-link
-    :to="mention.url"
+    :to="safeMentionUrl"
     target="_blank"
     rel="noopener noreferrer"
   >
@@ -16,13 +16,13 @@ SPDX-License-Identifier: MIT
       <div class="flex flex-col md:gap-5 gap-3">
         <slot>
           <!-- Header Section -->
-          <lfx-community-card-header :mention="mention" />
+          <lfx-community-card-header :mention="props.mention" />
 
           <!-- Content Section -->
-          <lfx-community-card-content :mention="mention" />
+          <lfx-community-card-content :mention="props.mention" />
 
           <!-- Relevance Comment Section -->
-          <lfx-community-card-footer :mention="mention" />
+          <lfx-community-card-footer :mention="props.mention" />
         </slot>
       </div>
     </lfx-card>
@@ -31,15 +31,26 @@ SPDX-License-Identifier: MIT
 
 <script setup lang="ts">
 // Default card display component for community mentions
+import { computed } from 'vue';
 import LfxCommunityCardHeader from '../fragments/card-header.vue';
 import LfxCommunityCardContent from '../fragments/card-content.vue';
 import LfxCommunityCardFooter from '../fragments/card-footer.vue';
 import type { CommunityMentions } from '~~/types/community/community';
 import LfxCard from '~/components/uikit/card/card.vue';
 
-defineProps<{
+const props = defineProps<{
   mention: CommunityMentions;
 }>();
+
+const safeMentionUrl = computed(() => {
+  try {
+    const parsedUrl = new URL(props.mention?.url);
+
+    return ['http:', 'https:'].includes(parsedUrl.protocol) ? parsedUrl.toString() : '#';
+  } catch {
+    return '#';
+  }
+});
 </script>
 
 <script lang="ts">


### PR DESCRIPTION
## Summary

fix(security): 2 improvements across 2 files

## Problem

**Severity**: `Medium` | **File**: `frontend/app/components/modules/project/components/community/card-displays/default-card.vue:L8`

The component binds `mention.url` directly into a link target (`:to="mention.url"`) for a clickable card. If `mention.url` is sourced from external/untrusted data, an attacker could supply a malicious URL (e.g., `javascript:...` or a deceptive phishing URL), leading to script execution on click in some contexts or user redirection to attacker-controlled sites.

## Solution

Validate and normalize URLs before binding. Allow only `http:` and `https:` protocols via a helper (e.g., `new URL(url)` + protocol allowlist), and fallback to `#`/disabled state for invalid values. Consider centralizing this in a `safeExternalUrl()` utility used by all community-card link renderers.

## Changes

- `frontend/app/components/modules/project/components/community/card-displays/default-card.vue` (modified)
- `frontend/.storybook/preview-head.html` (modified)