### PR TITLE
refactor: auth flow and plugin

### DIFF
--- a/frontend/app/pages/collection/my-collections/index.vue
+++ b/frontend/app/pages/collection/my-collections/index.vue
@@ -12,7 +12,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { nextTick, onMounted } from 'vue';
+import { watch } from 'vue';
 import { useRoute } from 'nuxt/app';
 import LfxCollectionListView from '~/components/modules/collection/views/collection-list.vue';
 import { useAuth } from '~~/composables/useAuth';
@@ -27,18 +27,19 @@ useSeoMeta({
   twitterDescription: description,
 });
 
-const { isAuthenticated, login, refreshAuth } = useAuth();
+const { isAuthenticated, isReady, login } = useAuth();
+const route = useRoute();
 
-onMounted(async () => {
-  const route = useRoute();
-  const isAuthCallback = route.query.auth === 'success' || route.query.auth === 'logout';
-  if (isAuthCallback) return;
-
-  await refreshAuth();
-  await nextTick();
-
-  if (!isAuthenticated.value) {
-    await login(window.location.pathname + window.location.search + window.location.hash);
-  }
-});
+watch(
+  [isReady, isAuthenticated],
+  ([ready, authed]) => {
+    if (!ready || !process.client) return;
+    const isAuthCallback = route.query.auth === 'success' || route.query.auth === 'logout';
+    if (isAuthCallback) return;
+    if (!authed) {
+      login(window.location.pathname + window.location.search + window.location.hash);
+    }
+  },
+  { immediate: true },
+);
 </script>

--- a/frontend/app/plugins/auth.client.ts
+++ b/frontend/app/plugins/auth.client.ts
@@ -65,6 +65,7 @@ export default defineNuxtPlugin(() => {
       getWasUserLoggedIn() // Only attempt silent login if the user has logged in previously
     ) {
       const currentPath = window.location.pathname + window.location.search + window.location.hash;
+      setSilentLoginAttempted(true);
       login(currentPath, true);
     }
 
@@ -91,12 +92,18 @@ export default defineNuxtPlugin(() => {
     }
   };
 
+  const runAuthQuery = (authParam: string | undefined) => {
+    handleAuthQuery(authParam).catch((error) => {
+      console.error('Auth query handling error:', error);
+    });
+  };
+
   if (route.query.auth === 'logout') {
-    nextTick(() => handleAuthQuery(route.query.auth as string | undefined));
+    nextTick(() => runAuthQuery(route.query.auth as string | undefined));
   }
 
   watch(
     () => route.query.auth,
-    (authParam) => handleAuthQuery(authParam as string | undefined),
+    (authParam) => runAuthQuery(authParam as string | undefined),
   );
 });

--- a/frontend/app/plugins/auth.client.ts
+++ b/frontend/app/plugins/auth.client.ts
@@ -1,0 +1,95 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+import { defineNuxtPlugin, useAsyncData, useRoute, navigateTo } from 'nuxt/app';
+import { watch, watchEffect, nextTick } from 'vue';
+import { useCollectionsStore } from '~/components/modules/collection/store/collections.store';
+import {
+  authState,
+  isAuthLoading,
+  setRefreshAuth,
+  getSilentLoginAttempted,
+  setSilentLoginAttempted,
+  getWasUserLoggedIn,
+  setWasUserLoggedIn,
+  login,
+} from '~~/composables/useAuth';
+import type { AuthData } from '~~/types/auth/auth-user.types';
+
+declare const window: Window & typeof globalThis;
+
+export default defineNuxtPlugin(() => {
+  const { data: userData, refresh: refreshAuth } = useAsyncData<AuthData>(
+    'auth-user',
+    () => $fetch('/api/auth/user', { credentials: 'include' }),
+    {
+      default: () => ({
+        isAuthenticated: false,
+        user: null,
+        token: null,
+      }),
+      server: false,
+      lazy: true,
+    },
+  );
+
+  setRefreshAuth(refreshAuth);
+
+  watchEffect(() => {
+    if (!userData.value) return;
+
+    isAuthLoading.value = false;
+    authState.value = userData.value;
+
+    // Attempt silent login if suggested by the server and not already attempted
+    if (
+      userData.value.shouldAttemptSilentLogin &&
+      process.client &&
+      !getSilentLoginAttempted() &&
+      getWasUserLoggedIn() // Only attempt silent login if the user has logged in previously
+    ) {
+      const currentPath = window.location.pathname + window.location.search + window.location.hash;
+      login(currentPath, true);
+    }
+
+    if (userData.value.isAuthenticated) {
+      setSilentLoginAttempted(false);
+      setWasUserLoggedIn(true);
+
+      // Fetch liked collections when user is authenticated
+      const collectionsStore = useCollectionsStore();
+      if (!collectionsStore.isLikedCollectionsLoaded) {
+        collectionsStore.fetchAndSetLikedCollections();
+      }
+    }
+  });
+
+  const route = useRoute();
+
+  const handleAuthQuery = async (authParam: string | undefined) => {
+    if (authParam === 'success') {
+      await refreshAuth();
+      setSilentLoginAttempted(false);
+    } else if (authParam === 'logout') {
+      await refreshAuth();
+      authState.value = {
+        isAuthenticated: false,
+        user: null,
+        token: null,
+      };
+      // Clean up the URL by removing the auth parameter
+      await navigateTo('/', { replace: true });
+    }
+  };
+
+  // Initial check for auth/logout success on first load
+  if (route.query.auth === 'success' || route.query.auth === 'logout') {
+    nextTick(() => handleAuthQuery(route.query.auth as string | undefined));
+  }
+
+  // Watch for subsequent route changes
+  watch(
+    () => route.query.auth,
+    (authParam) => handleAuthQuery(authParam as string | undefined),
+  );
+});

--- a/frontend/app/plugins/auth.client.ts
+++ b/frontend/app/plugins/auth.client.ts
@@ -7,6 +7,7 @@ import { useCollectionsStore } from '~/components/modules/collection/store/colle
 import {
   authState,
   isAuthLoading,
+  isAuthReady,
   setRefreshAuth,
   getSilentLoginAttempted,
   setSilentLoginAttempted,
@@ -19,7 +20,11 @@ import type { AuthData } from '~~/types/auth/auth-user.types';
 declare const window: Window & typeof globalThis;
 
 export default defineNuxtPlugin(() => {
-  const { data: userData, refresh: refreshAuth } = useAsyncData<AuthData>(
+  const {
+    data: userData,
+    refresh: refreshAuth,
+    status,
+  } = useAsyncData<AuthData>(
     'auth-user',
     () => $fetch('/api/auth/user', { credentials: 'include' }),
     {
@@ -34,6 +39,17 @@ export default defineNuxtPlugin(() => {
   );
 
   setRefreshAuth(refreshAuth);
+
+  watch(
+    status,
+    (s) => {
+      if (s === 'success' || s === 'error') {
+        isAuthReady.value = true;
+        isAuthLoading.value = false;
+      }
+    },
+    { immediate: true },
+  );
 
   watchEffect(() => {
     if (!userData.value) return;
@@ -66,28 +82,19 @@ export default defineNuxtPlugin(() => {
 
   const route = useRoute();
 
+  // The initial /api/auth/user fetch above already reflects the post-callback state
+  // (the callback sets/clears cookies before redirecting back), so we don't refetch here.
+  // We only clean up the ?auth=logout query param — ?auth=success is left as-is to match prior behavior.
   const handleAuthQuery = async (authParam: string | undefined) => {
-    if (authParam === 'success') {
-      await refreshAuth();
-      setSilentLoginAttempted(false);
-    } else if (authParam === 'logout') {
-      await refreshAuth();
-      authState.value = {
-        isAuthenticated: false,
-        user: null,
-        token: null,
-      };
-      // Clean up the URL by removing the auth parameter
+    if (authParam === 'logout') {
       await navigateTo('/', { replace: true });
     }
   };
 
-  // Initial check for auth/logout success on first load
-  if (route.query.auth === 'success' || route.query.auth === 'logout') {
+  if (route.query.auth === 'logout') {
     nextTick(() => handleAuthQuery(route.query.auth as string | undefined));
   }
 
-  // Watch for subsequent route changes
   watch(
     () => route.query.auth,
     (authParam) => handleAuthQuery(authParam as string | undefined),

--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -82,6 +82,8 @@ export const login = async (redirectTo?: string, silent?: boolean) => {
       } else {
         await navigateTo(response.authorizationUrl, { external: true });
       }
+    } else {
+      isAuthLoading.value = false;
     }
   } catch (error) {
     console.error('Login error:', error);

--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -1,27 +1,35 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 
-import { ref, computed, watchEffect, watch, nextTick } from 'vue';
-import { useAsyncData, navigateTo, useRoute } from 'nuxt/app';
+import { ref, computed } from 'vue';
+import { navigateTo, useRoute } from 'nuxt/app';
 import { useCollectionsStore } from '~/components/modules/collection/store/collections.store';
 import type { AuthData } from '~~/types/auth/auth-user.types';
 
 // Fix for window access in Nuxt
 declare const window: Window & typeof globalThis;
 
-const authState = ref<AuthData>({
+export const authState = ref<AuthData>({
   isAuthenticated: false,
   user: null,
   token: null,
 });
 
+export const isAuthLoading = ref(false);
+
+let refreshAuthFn: () => Promise<unknown> = async () => {};
+
+export const setRefreshAuth = (fn: () => Promise<unknown>) => {
+  refreshAuthFn = fn;
+};
+
 // Helper functions for localStorage access with client-side checks
-const getSilentLoginAttempted = (): boolean => {
+export const getSilentLoginAttempted = (): boolean => {
   if (!process.client) return false;
   return localStorage.getItem('lfx-silent-login-attempted') === 'true';
 };
 
-const setSilentLoginAttempted = (value: boolean): void => {
+export const setSilentLoginAttempted = (value: boolean): void => {
   if (!process.client) return;
   localStorage.setItem('lfx-silent-login-attempted', value.toString());
 };
@@ -32,204 +40,100 @@ export const getWasUserLoggedIn = (): boolean => {
   return localStorage.getItem('lfx-user-logged-in') === 'true';
 };
 
-const setWasUserLoggedIn = (value: boolean): void => {
+export const setWasUserLoggedIn = (value: boolean): void => {
   if (!process.client) return;
   localStorage.setItem('lfx-user-logged-in', value.toString());
+};
+
+export const login = async (redirectTo?: string, silent?: boolean) => {
+  isAuthLoading.value = true;
+  // Reset silent login flag for next time
+  setSilentLoginAttempted(false);
+  try {
+    let currentPath = redirectTo || '/';
+
+    if (!redirectTo && process.client) {
+      try {
+        const route = useRoute();
+        currentPath = route.fullPath || '/';
+      } catch {
+        currentPath = '/';
+      }
+    }
+
+    // Call the login API endpoint to get the Auth0 authorization URL
+    const response = await $fetch<{ success: boolean; authorizationUrl: string }>(
+      '/api/auth/login',
+      {
+        method: 'GET',
+        query: currentPath !== '/' ? { redirectTo: currentPath, silent } : { silent },
+        credentials: 'include',
+      },
+    );
+
+    if (response.success && response.authorizationUrl) {
+      // Redirect to Auth0 using the returned URL
+      if (process.client) {
+        window.location.href = response.authorizationUrl;
+      } else {
+        await navigateTo(response.authorizationUrl, { external: true });
+      }
+    }
+  } catch (error) {
+    console.error('Login error:', error);
+    isAuthLoading.value = false;
+  }
+};
+
+export const logout = async () => {
+  isAuthLoading.value = true;
+  // Reset silent login flag for next time
+  setSilentLoginAttempted(false);
+  try {
+    const response = await $fetch<{ success: boolean; logoutUrl: string }>('/api/auth/logout', {
+      method: 'POST',
+    });
+
+    if (response.success) {
+      // Clear local state
+      authState.value = {
+        isAuthenticated: false,
+        user: null,
+        token: null,
+      };
+
+      // Clear liked collections
+      const collectionsStore = useCollectionsStore();
+      collectionsStore.clearLikedCollections();
+
+      // Redirect to Auth0 logout or home
+      if (process.client) {
+        window.location.href = response.logoutUrl;
+      } else {
+        await navigateTo(response.logoutUrl, { external: true });
+      }
+
+      setWasUserLoggedIn(false);
+    }
+  } catch (error) {
+    console.error('Logout error:', error);
+  } finally {
+    isAuthLoading.value = false;
+  }
 };
 
 export const useAuth = () => {
   const isAuthenticated = computed(() => authState.value.isAuthenticated);
   const user = computed(() => authState.value.user);
   const token = computed(() => authState.value.token);
-  const isLoading = ref(false);
-
-  // Fetch user data from server
-  const { data: userData, refresh: refreshAuth } = useAsyncData<AuthData>(
-    'auth-user',
-    () => $fetch('/api/auth/user', { credentials: 'include' }),
-    {
-      default: () => ({
-        isAuthenticated: false,
-        user: null,
-        token: null,
-      }),
-      server: false, // Allow client-side fetching
-      lazy: true, // Don't block on initial load
-    },
-  );
-
-  // Update local state when data changes
-  watchEffect(() => {
-    if (userData.value) {
-      isLoading.value = false;
-      authState.value = userData.value;
-
-      // Attempt silent login if suggested by the server and not already attempted
-      if (
-        userData.value.shouldAttemptSilentLogin &&
-        process.client &&
-        !getSilentLoginAttempted() &&
-        getWasUserLoggedIn() // Only attempt silent login if the user has logged in previously
-      ) {
-        const currentPath =
-          window.location.pathname + window.location.search + window.location.hash;
-        login(currentPath, true);
-      }
-
-      if (userData.value.isAuthenticated) {
-        setSilentLoginAttempted(false);
-        setWasUserLoggedIn(true);
-
-        // Fetch liked collections when user is authenticated
-        const collectionsStore = useCollectionsStore();
-        if (!collectionsStore.isLikedCollectionsLoaded) {
-          collectionsStore.fetchAndSetLikedCollections();
-        }
-      }
-    }
-  });
-
-  // Watch for auth success parameter and refresh state
-  if (process.client) {
-    const route = useRoute();
-
-    // Initial check for auth success
-    if (route.query.auth === 'success') {
-      nextTick(async () => {
-        await refreshAuth();
-        // Reset silent login flag when authentication is successful
-        setSilentLoginAttempted(false);
-      });
-    }
-
-    // Watch for route changes
-    watch(
-      () => route.query.auth,
-      async (authParam) => {
-        if (authParam === 'success') {
-          await refreshAuth();
-          // Reset silent login flag when authentication is successful
-          setSilentLoginAttempted(false);
-        }
-      },
-    );
-
-    // Check for logout success parameter and refresh state
-    if (route.query.auth === 'logout') {
-      nextTick(async () => {
-        await refreshAuth();
-        authState.value = {
-          isAuthenticated: false,
-          user: null,
-          token: null,
-        };
-        // Clean up the URL by removing the auth parameter
-        await navigateTo('/', { replace: true });
-      });
-    }
-
-    // Watch for logout success parameter
-    watch(
-      () => route.query.auth,
-      async (authParam) => {
-        if (authParam === 'logout') {
-          await refreshAuth();
-          authState.value = {
-            isAuthenticated: false,
-            user: null,
-            token: null,
-          };
-          // Clean up the URL by removing the auth parameter
-          await navigateTo('/', { replace: true });
-        }
-      },
-    );
-  }
-
-  const login = async (redirectTo?: string, silent?: boolean) => {
-    isLoading.value = true;
-    // Reset silent login flag for next time
-    setSilentLoginAttempted(false);
-    try {
-      let currentPath = redirectTo || '/';
-
-      if (!redirectTo && process.client) {
-        try {
-          const route = useRoute();
-          currentPath = route.fullPath || '/';
-        } catch {
-          currentPath = '/';
-        }
-      }
-
-      // Call the login API endpoint to get the Auth0 authorization URL
-      const response = await $fetch<{ success: boolean; authorizationUrl: string }>(
-        '/api/auth/login',
-        {
-          method: 'GET',
-          query: currentPath !== '/' ? { redirectTo: currentPath, silent } : { silent },
-          credentials: 'include',
-        },
-      );
-
-      if (response.success && response.authorizationUrl) {
-        // Redirect to Auth0 using the returned URL
-        if (process.client) {
-          window.location.href = response.authorizationUrl;
-        } else {
-          await navigateTo(response.authorizationUrl, { external: true });
-        }
-      }
-    } catch (error) {
-      console.error('Login error:', error);
-      isLoading.value = false;
-    }
-  };
-
-  const logout = async () => {
-    isLoading.value = true;
-    // Reset silent login flag for next time
-    setSilentLoginAttempted(false);
-    try {
-      const response = await $fetch<{ success: boolean; logoutUrl: string }>('/api/auth/logout', {
-        method: 'POST',
-      });
-
-      if (response.success) {
-        // Clear local state
-        authState.value = {
-          isAuthenticated: false,
-          user: null,
-          token: null,
-        };
-
-        // Clear liked collections
-        const collectionsStore = useCollectionsStore();
-        collectionsStore.clearLikedCollections();
-
-        // Redirect to Auth0 logout or home
-        if (process.client) {
-          window.location.href = response.logoutUrl;
-        } else {
-          await navigateTo(response.logoutUrl, { external: true });
-        }
-
-        setWasUserLoggedIn(false);
-      }
-    } catch (error) {
-      console.error('Logout error:', error);
-    } finally {
-      isLoading.value = false;
-    }
-  };
 
   return {
     isAuthenticated,
     user,
     token,
-    isLoading,
+    isLoading: isAuthLoading,
     login,
     logout,
-    refreshAuth,
+    refreshAuth: () => refreshAuthFn(),
   };
 };

--- a/frontend/composables/useAuth.ts
+++ b/frontend/composables/useAuth.ts
@@ -17,6 +17,10 @@ export const authState = ref<AuthData>({
 
 export const isAuthLoading = ref(false);
 
+// Flips to true once the initial /api/auth/user fetch resolves (success or error).
+// Consumers can await this before making auth-gated decisions instead of calling refreshAuth().
+export const isAuthReady = ref(false);
+
 let refreshAuthFn: () => Promise<unknown> = async () => {};
 
 export const setRefreshAuth = (fn: () => Promise<unknown>) => {
@@ -132,6 +136,7 @@ export const useAuth = () => {
     user,
     token,
     isLoading: isAuthLoading,
+    isReady: isAuthReady,
     login,
     logout,
     refreshAuth: () => refreshAuthFn(),

--- a/frontend/nuxt.config.ts
+++ b/frontend/nuxt.config.ts
@@ -38,6 +38,7 @@ export default defineNuxtConfig({
     '~/plugins/vue-query.ts',
     '~/plugins/analytics.ts',
     '~/plugins/canonical.ts',
+    '~/plugins/auth.client.ts',
     '~/plugins/intercom.ts',
   ],
   css: ['~/assets/styles/main.scss'],


### PR DESCRIPTION
## Summary
- Refactor Auth0 authentication flow by moving initialization logic into a dedicated client plugin (`auth.client.ts`).
- Simplify `useAuth` composable by consuming plugin-provided state instead of duplicating the Auth0 client setup.

## Changes
- `frontend/app/plugins/auth.client.ts` (new): centralizes Auth0 client creation and session handling.
- `frontend/composables/useAuth.ts`: slimmed down to expose auth state/actions via the plugin.