### PR TITLE
fix: blank logos in exported snapshots IN-1092

### DIFF
--- a/frontend/app/components/modules/widget/components/shared/snapshot/snapshot-modal.vue
+++ b/frontend/app/components/modules/widget/components/shared/snapshot/snapshot-modal.vue
@@ -93,11 +93,53 @@ const repoName = computed(
 
 const widgetConfig = computed(() => lfxWidgets[props.widgetName]);
 
+const shouldProxy = (src: string): boolean => {
+  if (!src) return false;
+  if (src.startsWith('data:') || src.startsWith('blob:')) return false;
+  try {
+    const parsed = new URL(src, window.location.href);
+    if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') return false;
+    return parsed.origin !== window.location.origin;
+  } catch {
+    return false;
+  }
+};
+
+const rewriteImagesThroughProxy = async (root: HTMLElement): Promise<() => void> => {
+  const imgs = Array.from(root.querySelectorAll('img')).filter((img) => shouldProxy(img.src));
+  const originals = imgs.map((img) => img.src);
+  imgs.forEach((img) => {
+    img.src = `/api/image-proxy?url=${encodeURIComponent(img.src)}`;
+  });
+  await Promise.all(
+    imgs.map(
+      (img) =>
+        new Promise<void>((resolve) => {
+          if (img.complete && img.naturalWidth > 0) return resolve();
+          const done = () => {
+            img.removeEventListener('load', done);
+            img.removeEventListener('error', done);
+            resolve();
+          };
+          img.addEventListener('load', done);
+          img.addEventListener('error', done);
+        }),
+    ),
+  );
+  return () => {
+    imgs.forEach((img, i) => {
+      img.src = originals[i]!;
+    });
+  };
+};
+
 const download = async () => {
   if (!snapshot.value) return;
+  let restoreImages: (() => void) | undefined;
   try {
     await document?.fonts.ready;
     await nextTick();
+    restoreImages = await rewriteImagesThroughProxy(snapshot.value);
     const canvas = await html2canvas(snapshot.value, {
       useCORS: true,
       allowTaint: false,
@@ -116,6 +158,8 @@ const download = async () => {
     document.body.removeChild(link);
   } catch (e) {
     showToast('Failed to download snapshot', ToastTypesEnum.negative);
+  } finally {
+    restoreImages?.();
   }
   isModalOpen.value = false;
 };

--- a/frontend/server/api/image-proxy.get.ts
+++ b/frontend/server/api/image-proxy.get.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2026 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+const MAX_BYTES = 5 * 1024 * 1024;
+const FETCH_TIMEOUT_MS = 8000;
+
+const PRIVATE_HOST_PATTERNS = [
+  /^localhost$/i,
+  /\.local$/i,
+  /\.internal$/i,
+  /^127\./,
+  /^10\./,
+  /^192\.168\./,
+  /^169\.254\./,
+  /^0\.0\.0\.0$/,
+  /^::1$/,
+];
+const PRIVATE_172 = /^172\.(1[6-9]|2\d|3[0-1])\./;
+
+function isPublicHost(hostname: string): boolean {
+  if (!hostname) return false;
+  if (PRIVATE_172.test(hostname)) return false;
+  return !PRIVATE_HOST_PATTERNS.some((re) => re.test(hostname));
+}
+
+export default defineEventHandler(async (event) => {
+  const { url } = getQuery(event) as { url?: string };
+  if (!url || typeof url !== 'string') {
+    throw createError({ statusCode: 400, statusMessage: 'Missing url parameter' });
+  }
+
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    throw createError({ statusCode: 400, statusMessage: 'Invalid url' });
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    throw createError({ statusCode: 400, statusMessage: 'Unsupported protocol' });
+  }
+  if (!isPublicHost(parsed.hostname)) {
+    throw createError({ statusCode: 400, statusMessage: 'Host not allowed' });
+  }
+
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), FETCH_TIMEOUT_MS);
+
+  try {
+    const upstream = await fetch(parsed.toString(), {
+      signal: controller.signal,
+      redirect: 'follow',
+      headers: { Accept: 'image/*' },
+    });
+
+    if (!upstream.ok || !upstream.body) {
+      throw createError({ statusCode: 502, statusMessage: 'Upstream fetch failed' });
+    }
+
+    const contentType = upstream.headers.get('content-type') || '';
+    if (!contentType.startsWith('image/')) {
+      throw createError({ statusCode: 415, statusMessage: 'Not an image' });
+    }
+
+    const buffer = Buffer.from(await upstream.arrayBuffer());
+    if (buffer.byteLength > MAX_BYTES) {
+      throw createError({ statusCode: 413, statusMessage: 'Image too large' });
+    }
+
+    setHeader(event, 'Content-Type', contentType);
+    setHeader(event, 'Cache-Control', 'public, max-age=86400, immutable');
+    setHeader(event, 'X-Content-Type-Options', 'nosniff');
+    return buffer;
+  } catch (err: unknown) {
+    if (err && typeof err === 'object' && 'statusCode' in err) throw err;
+    throw createError({ statusCode: 502, statusMessage: 'Upstream fetch failed' });
+  } finally {
+    clearTimeout(timeout);
+  }
+});


### PR DESCRIPTION
## Summary
- Organization logos rendered blank/white in exported leaderboard snapshots (`html2canvas`) because image sources from mixed origins (e.g. `t1.gstatic.com/faviconV2`) do not send CORS headers, so `html2canvas` configured with `useCORS: true, allowTaint: false` skipped them.
- Added a same-origin image proxy endpoint and rewrote all cross-origin `<img>` sources inside the snapshot container through it before capture, then restored the originals afterward.

## Changes
- `frontend/server/api/image-proxy.get.ts` — new `/api/image-proxy?url=...` endpoint. Validates protocol, blocks private/loopback hosts (SSRF guard), enforces `image/*` content-type, 5 MB cap, 8 s timeout, returns bytes with a 1-day `Cache-Control`.
- `frontend/app/components/modules/widget/components/shared/snapshot/snapshot-modal.vue` — before `html2canvas`, swap every cross-origin `<img>` src (skipping `data:`/`blob:`/same-origin) to the proxy URL, await load, capture, then restore originals in `finally`.