### PR TITLE
fix: single repo detection for security view IN-1090

### DIFF
--- a/frontend/app/components/modules/project/components/vulnerabilities/vulnerabilities-section.vue
+++ b/frontend/app/components/modules/project/components/vulnerabilities/vulnerabilities-section.vue
@@ -78,7 +78,7 @@ const route = useRoute();
 
 const { selectedReposValues, project } = storeToRefs(useProjectStore());
 
-const isRepository = computed(() => !!route.params.name || project.value?.repositoryGroups?.length === 0);
+const isRepository = computed(() => !!route.params.name || (project.value?.repositories?.length ?? 0) <= 1);
 const hasSelectedRepos = computed(() => selectedReposValues.value && selectedReposValues.value.length > 0);
 const showAggregatedDisclaimer = computed(() => !isRepository.value && !hasSelectedRepos.value);
 

--- a/frontend/app/components/modules/project/views/security.vue
+++ b/frontend/app/components/modules/project/views/security.vue
@@ -186,7 +186,7 @@ const { selectedReposValues, project, isArchived, emptyStateTitle, emptyStateDes
   storeToRefs(useProjectStore());
 const { isAuthenticated } = storeToRefs(useAuthStore());
 
-const isRepository = computed(() => !!name || project.value?.repositoryGroups?.length === 0);
+const isRepository = computed(() => !!name || (project.value?.repositories?.length ?? 0) <= 1);
 const isReposEvalModalOpen = ref(false);
 const currentTab = ref('');
 const accordion = ref('');


### PR DESCRIPTION
## Summary
- On the project security view, `isRepository` previously relied on `repositoryGroups.length === 0` to decide whether the project is effectively a single-repo view.
- Projects with one repository can still have repository groups, so the aggregated-view disclaimer and related logic misbehaved for single-repo projects.
- Switched the check to `repositories.length <= 1`, which matches the actual "is this a single repo" intent.

## Changes
- `frontend/app/components/modules/project/components/vulnerabilities/vulnerabilities-section.vue` — update `isRepository` computed.
- `frontend/app/components/modules/project/views/security.vue` — update `isRepository` computed.