### PR TITLE
fix: not found for category groups (IN-1091)

### DIFF
--- a/frontend/app/pages/open-source-index/group/[slug].vue
+++ b/frontend/app/pages/open-source-index/group/[slug].vue
@@ -9,6 +9,7 @@ SPDX-License-Identifier: MIT
 <script setup lang="ts">
 import { computed, onServerPrefetch, ref } from 'vue';
 import { useRoute } from 'vue-router';
+import { createError, showError } from 'nuxt/app';
 import LfxOpenSourceIndexGroup from '~/components/modules/open-source-index/views/open-source-index-group.vue';
 import { OSS_INDEX_API_SERVICE, type SortType } from '~/components/modules/open-source-index/services/osi.api.service';
 
@@ -16,10 +17,17 @@ const route = useRoute();
 const slug = ref<string>((route.params.slug as string) || '');
 const sort = ref<SortType>((route.query.sort as SortType) || 'totalContributors');
 
-const { data, suspense } = OSS_INDEX_API_SERVICE.fetchOSSCategory(slug.value, sort);
+const { data, isError, suspense } = OSS_INDEX_API_SERVICE.fetchOSSCategory(slug.value, sort);
 
 onServerPrefetch(async () => {
   await suspense();
+  if (isError.value) {
+    if (import.meta.server) {
+      throw createError({ statusCode: 404, statusMessage: 'Category not found' });
+    } else {
+      showError({ statusCode: 404, statusMessage: 'Category not found' });
+    }
+  }
 });
 
 const title = computed(() => `${data.value?.name || 'Category'} | Open Source Index`);

--- a/frontend/server/api/ossindex/categories.ts
+++ b/frontend/server/api/ossindex/categories.ts
@@ -72,6 +72,9 @@ export default defineEventHandler(async (event): Promise<OSSIndexCategoryGroupDe
       categories,
     };
   } catch (error) {
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
     console.error('Error fetching oss index category list from TinyBird:', error);
     throw createError({ statusCode: 500, statusMessage: 'Internal Server Error' });
   }


### PR DESCRIPTION
This pull request improves error handling for the Open Source Index category group page, ensuring users receive appropriate feedback when a category is not found and that server errors are handled more robustly.

**Error handling improvements:**

* In `group/[slug].vue`, added logic to check for errors after fetching a category. If the category is not found, the code now throws or shows a 404 error, depending on whether the code is running on the server or client. ([frontend/app/pages/open-source-index/group/[slug].vueR12-R30](diffhunk://#diff-47edddcb266aa13aff2b3b81753d70435ff572225635c89ea984c6bb971c14b5R12-R30))
* In `categories.ts` API handler, updated the error handling to rethrow errors that already have a `statusCode` property, preventing them from being masked as generic 500 errors.