### PR TITLE
fix: auto-refresh expired auth token

### DIFF
--- a/.github/workflows/production-cache-flush-partial.yaml
+++ b/.github/workflows/production-cache-flush-partial.yaml
@@ -74,12 +74,14 @@ jobs:
           REDIS_URL=$(kubectl get configmap insights-config-map -n insights -o jsonpath="{.data.NUXT_REDIS_URL}")
           REDIS_PASS=$(echo "$REDIS_URL" | sed -n 's|.*://:\([^@]*\)@.*|\1|p')
 
+          REDIS_POD=$(kubectl get pod -n insights -l app=redis -o jsonpath='{.items[0].metadata.name}')
+
           flush_project() {
             local PROJECT=$1
             local STRIPPED="${PROJECT//[-_.]/}"
             local PROJECT_KEY="${STRIPPED:0:6}"
             echo "Flushing cache for project: $PROJECT (key prefix: $PROJECT_KEY)"
-            kubectl exec -i redis-client -n insights -- \
+            kubectl exec -i "$REDIS_POD" -n insights -- \
               sh -c "redis-cli -h redis-svc -a \"$REDIS_PASS\" --scan --pattern \"*project${PROJECT_KEY}*\" 2>/dev/null | xargs -r redis-cli -h redis-svc -a \"$REDIS_PASS\" DEL 2>/dev/null"
           }
 
@@ -138,7 +140,7 @@ jobs:
 
           elif [ "$TYPE" = "leaderboards" ]; then
             echo "Flushing all leaderboard cache keys"
-            kubectl exec -i redis-client -n insights -- \
+            kubectl exec -i "$REDIS_POD" -n insights -- \
               sh -c "redis-cli -h redis-svc -a \"$REDIS_PASS\" --scan --pattern \"*leaderboard*\" 2>/dev/null | xargs -r redis-cli -h redis-svc -a \"$REDIS_PASS\" DEL 2>/dev/null"
             echo "Done."
           fi

--- a/.github/workflows/production-cache-flush.yaml
+++ b/.github/workflows/production-cache-flush.yaml
@@ -58,5 +58,6 @@ jobs:
         run: |
           REDIS_URL=$(kubectl get configmap insights-config-map -n insights -o jsonpath="{.data.NUXT_REDIS_URL}")
           PASSWORD=$(echo "$REDIS_URL" | sed -n 's|.*://:\([^@]*\)@.*|\1|p')
-          kubectl exec -i redis-client -n insights -- \
+          REDIS_POD=$(kubectl get pod -n insights -l app=redis -o jsonpath='{.items[0].metadata.name}')
+          kubectl exec -i "$REDIS_POD" -n insights -- \
             redis-cli -h redis-svc -a "$PASSWORD" FLUSHALL

--- a/.github/workflows/production-deploy.yaml
+++ b/.github/workflows/production-deploy.yaml
@@ -128,5 +128,6 @@ jobs:
         run: |
           REDIS_URL=$(kubectl get configmap insights-config-map -n insights -o jsonpath="{.data.NUXT_REDIS_URL}")
           PASSWORD=$(echo "$REDIS_URL" | sed -n 's|.*://:\([^@]*\)@.*|\1|p')
-          kubectl exec -i redis-client -n insights -- \
+          REDIS_POD=$(kubectl get pod -n insights -l app=redis -o jsonpath='{.items[0].metadata.name}')
+          kubectl exec -i "$REDIS_POD" -n insights -- \
             redis-cli -h redis-svc -a "$PASSWORD" FLUSHALL

--- a/frontend/app/components/modules/auth/components/login.vue
+++ b/frontend/app/components/modules/auth/components/login.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
     <lfx-button
       v-if="!isAuthenticated"
       type="transparent"
-      class="!rounded-full text-nowrap !text-brand-500"
+      class="!rounded-full text-nowrap !text-brand-500 min-w-24"
       :disabled="isLoading"
       @click="loginHandler()"
     >

--- a/frontend/app/components/shared/layout/menu.vue
+++ b/frontend/app/components/shared/layout/menu.vue
@@ -11,7 +11,7 @@ SPDX-License-Identifier: MIT
     <div class="border-r border-neutral-200 h-6" />
   </div>
   <!-- Fixed-width wrapper keeps the search bar layout stable between SSR (empty) and hydrated (button/avatar). -->
-  <div class="h-9 min-w-24 flex items-center justify-end shrink-0">
+  <div class="h-9 flex items-center justify-end shrink-0">
     <client-only>
       <lfx-login />
     </client-only>

--- a/frontend/server/api/auth/callback.ts
+++ b/frontend/server/api/auth/callback.ts
@@ -71,18 +71,17 @@ export default defineEventHandler(async (event) => {
     }
 
     if (!query.code || !codeVerifier) {
-      throw createError({
-        statusCode: 400,
-        statusMessage: 'Missing authorization code or code verifier',
-      });
+      // Stale or missing PKCE cookie (direct navigation to callback, bot crawl, etc.)
+      // Restart the login flow rather than showing an error page.
+      deleteCookie(event, 'auth_pkce');
+      return sendRedirect(event, '/api/auth/login');
     }
 
     // Validate state from cookie against URL to prevent CSRF and detect concurrent login races
     if (!storedState || storedState !== query.state) {
-      throw createError({
-        statusCode: 400,
-        statusMessage: 'Invalid state parameter — please try logging in again',
-      });
+      // State mismatch: multi-tab login or cookie race — restart cleanly.
+      deleteCookie(event, 'auth_pkce');
+      return sendRedirect(event, '/api/auth/login');
     }
 
     // Discover Auth0 configuration
@@ -182,9 +181,17 @@ export default defineEventHandler(async (event) => {
 
     await sendRedirect(event, finalRedirect);
   } catch (error) {
+    // OAuth recoverable errors (invalid_grant = code reused/replayed, back button, page refresh).
+    // Restart the login flow rather than surfacing a 500.
+    const oauthError = error as { code?: string; error?: string };
+    if (oauthError?.code === 'OAUTH_RESPONSE_BODY_ERROR' && oauthError?.error === 'invalid_grant') {
+      deleteCookie(event, 'auth_pkce');
+      return sendRedirect(event, '/api/auth/login');
+    }
+
     console.error('Auth callback error:', error);
 
-    // Clean up cookies on error
+    // Clean up all auth cookies on unrecoverable error
     deleteCookie(event, 'auth_pkce');
     deleteCookie(event, 'auth_redirect_to');
     deleteCookie(event, 'auth_oidc_token');

--- a/frontend/server/api/auth/login.get.ts
+++ b/frontend/server/api/auth/login.get.ts
@@ -69,7 +69,7 @@ export default defineEventHandler(async (event) => {
     const redirectUri = config.public.auth0RedirectUri;
 
     const authorizationUrl = buildAuthorizationUrl(authConfig, {
-      scope: 'openid profile email',
+      scope: 'openid profile email offline_access',
       audience: config.public.auth0Audience,
       state,
       code_challenge: codeChallenge,

--- a/frontend/server/api/auth/user.get.ts
+++ b/frontend/server/api/auth/user.get.ts
@@ -2,26 +2,22 @@
 // SPDX-License-Identifier: MIT
 
 import { getCookie } from 'h3';
-import jwt from 'jsonwebtoken';
 import { jwtDecode } from 'jwt-decode';
-import type { DecodedOidcToken } from '~~/types/auth/auth-jwt.types';
+import { verifyOrRefreshOidcToken } from '~~/server/utils/auth-refresh';
 
 export default defineEventHandler(async (event) => {
   try {
-    const config = useRuntimeConfig();
-    const oidcToken = getCookie(event, 'auth_oidc_token');
+    const decodedToken = await verifyOrRefreshOidcToken(event);
 
-    if (!oidcToken) {
-      // Check if this is a request that should attempt silent login
+    if (!decodedToken) {
+      // No valid session and refresh either wasn't possible or failed.
+      // Suggest silent login only for browser requests that haven't already tried it.
       const userAgent = getHeader(event, 'user-agent') || '';
       const referer = getHeader(event, 'referer') || '';
 
-      // Only attempt silent login for browser requests (not API calls from other sources)
-      // and avoid infinite loops by checking if we're already in a callback
       const isBrowserRequest = userAgent.includes('Mozilla');
       const isNotCallback = !referer.includes('/api/auth/callback');
 
-      // Check if silent login was already attempted by looking for the PKCE cookie
       const silentLoginPkce = getCookie(event, 'auth_pkce');
       const hasAttemptedSilentLogin = !!silentLoginPkce;
 
@@ -35,21 +31,6 @@ export default defineEventHandler(async (event) => {
         shouldAttemptSilentLogin,
       };
     }
-
-    // Validate client secret
-    if (!config.auth0ClientSecret) {
-      console.error('Auth0 client secret not configured');
-      return {
-        isAuthenticated: false,
-        user: null,
-        token: null,
-      };
-    }
-
-    // Verify and decode the OIDC token using the client secret
-    const decodedToken = jwt.verify(oidcToken, config.auth0ClientSecret, {
-      algorithms: ['HS256'],
-    }) as DecodedOidcToken;
 
     // Extract Intercom claims from the original Auth0 ID token
     let intercomJwt: string | undefined;

--- a/frontend/server/middleware/jwt-auth.ts
+++ b/frontend/server/middleware/jwt-auth.ts
@@ -1,9 +1,7 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { getCookie } from 'h3';
-import jwt from 'jsonwebtoken';
 import { isLocal } from '../utils/common';
-import { DecodedOidcToken } from '~~/types/auth/auth-jwt.types';
+import { verifyOrRefreshOidcToken } from '../utils/auth-refresh';
 
 const isJWT = (token: string) => {
   const parts = token.split('.');
@@ -48,41 +46,30 @@ export default defineEventHandler(async (event) => {
   }
 
   const config = useRuntimeConfig();
-  const oidcToken = getCookie(event, 'auth_oidc_token');
 
-  if (!oidcToken) {
+  // Verifies the OIDC cookie or transparently refreshes via auth_refresh_token if expired.
+  const decodedToken = await verifyOrRefreshOidcToken(event);
+
+  if (!decodedToken) {
     throw createError({
       statusCode: 401,
       statusMessage: 'Authorization header required',
     });
   }
 
-  try {
-    // Verify and decode the OIDC token using the client secret
-    const decodedToken = jwt.verify(oidcToken, config.auth0ClientSecret, {
-      algorithms: ['HS256'],
-    }) as DecodedOidcToken;
-
-    if (decodedToken.original_id_token && isJWT(decodedToken.original_id_token)) {
-      event.context.user = decodedToken;
-
-      if (!isLocal && isPermissionRequired && !decodedToken.hasLfxInsightsPermission) {
-        throw createError({
-          statusCode: 401,
-          statusMessage: `User does not belong to ${config.lfxAuth0TokenClaimGroupName}`,
-        });
-      }
-    } else {
-      throw createError({
-        statusCode: 401,
-        statusMessage: 'Invalid token format',
-      });
-    }
-  } catch (jwtError) {
-    console.error('JWT verification failed:', jwtError);
+  if (!decodedToken.original_id_token || !isJWT(decodedToken.original_id_token)) {
     throw createError({
       statusCode: 401,
-      statusMessage: jwtError instanceof Error ? jwtError.message : 'Invalid JWT token',
+      statusMessage: 'Invalid token format',
+    });
+  }
+
+  event.context.user = decodedToken;
+
+  if (!isLocal && isPermissionRequired && !decodedToken.hasLfxInsightsPermission) {
+    throw createError({
+      statusCode: 401,
+      statusMessage: `User does not belong to ${config.lfxAuth0TokenClaimGroupName}`,
     });
   }
 });

--- a/frontend/server/utils/auth-refresh.ts
+++ b/frontend/server/utils/auth-refresh.ts
@@ -1,0 +1,174 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+import type { H3Event } from 'h3';
+import { getCookie, setCookie, deleteCookie } from 'h3';
+import jwt from 'jsonwebtoken';
+import { jwtDecode } from 'jwt-decode';
+import { discovery, refreshTokenGrant } from 'openid-client';
+import { hasLfxInsightsPermission, isLfInsightsTeamMember } from './jwt';
+import type { DecodedIdToken, DecodedOidcToken } from '~~/types/auth/auth-jwt.types';
+
+const isProduction = process.env.NUXT_APP_ENV === 'production';
+
+export interface RefreshResult {
+  oidcToken: string;
+  decoded: DecodedOidcToken;
+}
+
+interface RawRefresh {
+  oidcToken: string;
+  decoded: DecodedOidcToken;
+  newRefreshToken?: string;
+  expiresIn: number;
+}
+
+// Dedup concurrent refreshes for the same refresh token to avoid races against
+// Auth0 refresh-token rotation (the second concurrent call would otherwise be rejected).
+const inFlightRefreshes = new Map<string, Promise<RawRefresh | null>>();
+
+const callAuth0Refresh = async (refreshToken: string): Promise<RawRefresh | null> => {
+  const config = useRuntimeConfig();
+
+  if (!config.auth0ClientSecret) {
+    console.error('Auth0 client secret not configured for refresh');
+    return null;
+  }
+
+  try {
+    const authConfig = await discovery(
+      new URL(`https://${config.public.auth0Domain}`),
+      config.public.auth0ClientId,
+    );
+
+    const tokenResponse = await refreshTokenGrant(authConfig, refreshToken);
+
+    if (!tokenResponse.id_token) {
+      console.error('Refresh token grant returned no id_token');
+      return null;
+    }
+
+    const decodedIdToken = jwtDecode(tokenResponse.id_token) as DecodedIdToken;
+    const claims = decodedIdToken[config.lfxAuth0TokenClaimGroupKey];
+    const expiresIn = tokenResponse.expires_in || 86400;
+
+    const oidcTokenPayload = {
+      sub: decodedIdToken.sub,
+      name: decodedIdToken.name,
+      email: decodedIdToken.email,
+      picture: decodedIdToken.picture,
+      email_verified: decodedIdToken.email_verified,
+      updated_at: decodedIdToken.updated_at,
+      iss: config.public.auth0Domain,
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + expiresIn,
+      claims,
+      hasLfxInsightsPermission: hasLfxInsightsPermission(claims as string[]),
+      isLfInsightsTeamMember: isLfInsightsTeamMember(decodedIdToken.email || ''),
+      original_id_token: tokenResponse.id_token,
+    };
+
+    const oidcToken = jwt.sign(oidcTokenPayload, config.auth0ClientSecret, {
+      algorithm: 'HS256',
+    });
+
+    return {
+      oidcToken,
+      decoded: oidcTokenPayload as DecodedOidcToken,
+      newRefreshToken: tokenResponse.refresh_token,
+      expiresIn,
+    };
+  } catch (error) {
+    console.error('Token refresh failed:', error);
+    return null;
+  }
+};
+
+const setRefreshedCookies = (event: H3Event, result: RawRefresh) => {
+  const config = useRuntimeConfig();
+
+  const tokenCookieOptions = {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax' as const,
+    path: '/',
+    ...(isProduction ? { domain: config.auth0CookieDomain } : { domain: 'localhost' }),
+    maxAge: result.expiresIn,
+  };
+
+  setCookie(event, 'auth_oidc_token', result.oidcToken, tokenCookieOptions);
+
+  if (result.newRefreshToken) {
+    setCookie(event, 'auth_refresh_token', result.newRefreshToken, {
+      ...tokenCookieOptions,
+      maxAge: 60 * 60 * 24 * 30,
+    });
+  }
+};
+
+const clearAuthCookies = (event: H3Event) => {
+  deleteCookie(event, 'auth_oidc_token');
+  deleteCookie(event, 'auth_refresh_token');
+};
+
+/**
+ * Attempts to refresh the OIDC token using the auth_refresh_token cookie.
+ * On success: re-issues auth_oidc_token (and rotated refresh token) cookies on the event response.
+ * On failure: clears auth cookies and returns null.
+ */
+export const refreshOidcToken = async (event: H3Event): Promise<RefreshResult | null> => {
+  const refreshToken = getCookie(event, 'auth_refresh_token');
+  if (!refreshToken) {
+    return null;
+  }
+
+  let promise = inFlightRefreshes.get(refreshToken);
+  if (!promise) {
+    promise = callAuth0Refresh(refreshToken).finally(() => {
+      inFlightRefreshes.delete(refreshToken);
+    });
+    inFlightRefreshes.set(refreshToken, promise);
+  }
+
+  const result = await promise;
+
+  if (!result) {
+    clearAuthCookies(event);
+    return null;
+  }
+
+  setRefreshedCookies(event, result);
+
+  return {
+    oidcToken: result.oidcToken,
+    decoded: result.decoded,
+  };
+};
+
+/**
+ * Verifies the OIDC cookie. If missing, expired, or invalid, transparently attempts a refresh
+ * using the refresh token cookie. Returns the decoded payload, or null when no valid session
+ * can be re-established.
+ */
+export const verifyOrRefreshOidcToken = async (
+  event: H3Event,
+): Promise<DecodedOidcToken | null> => {
+  const config = useRuntimeConfig();
+  const oidcToken = getCookie(event, 'auth_oidc_token');
+
+  if (oidcToken && config.auth0ClientSecret) {
+    try {
+      return jwt.verify(oidcToken, config.auth0ClientSecret, {
+        algorithms: ['HS256'],
+      }) as DecodedOidcToken;
+    } catch (error) {
+      // Token expired or otherwise invalid — fall through to refresh.
+      if (!(error instanceof jwt.TokenExpiredError)) {
+        console.error('OIDC token verify failed, attempting refresh:', error);
+      }
+    }
+  }
+
+  const refreshed = await refreshOidcToken(event);
+  return refreshed?.decoded ?? null;
+};

--- a/frontend/server/utils/auth-refresh.ts
+++ b/frontend/server/utils/auth-refresh.ts
@@ -110,8 +110,16 @@ const setRefreshedCookies = (event: H3Event, result: RawRefresh) => {
 };
 
 const clearAuthCookies = (event: H3Event) => {
-  deleteCookie(event, 'auth_oidc_token');
-  deleteCookie(event, 'auth_refresh_token');
+  const config = useRuntimeConfig();
+  const cookieOptions = {
+    httpOnly: true,
+    secure: isProduction,
+    sameSite: 'lax' as const,
+    path: '/',
+    ...(isProduction ? { domain: config.auth0CookieDomain } : { domain: 'localhost' }),
+  };
+  deleteCookie(event, 'auth_oidc_token', cookieOptions);
+  deleteCookie(event, 'auth_refresh_token', cookieOptions);
 };
 
 /**

--- a/frontend/server/utils/auth-refresh.ts
+++ b/frontend/server/utils/auth-refresh.ts
@@ -79,7 +79,10 @@ const callAuth0Refresh = async (refreshToken: string): Promise<RawRefresh | null
       expiresIn,
     };
   } catch (error) {
-    console.error('Token refresh failed:', error);
+    // Scrub: openid-client errors can carry the response body in the message,
+    // which on some Auth0 failure paths includes a refresh_token field.
+    const message = error instanceof Error ? error.name : 'unknown';
+    console.error('Token refresh failed:', message);
     return null;
   }
 };


### PR DESCRIPTION
## Summary
- Auth UI was staying "logged in" in memory after the OIDC cookie expired, then any protected call (e.g. `/api/collection/like`) 401'd because nothing revalidated the session.
- Refresh tokens were being stored in `auth_refresh_token` at callback time but never used anywhere — and `offline_access` scope was missing, so Auth0 wasn't even returning one.
- This PR wires up server-side refresh via `openid-client`'s `refreshTokenGrant` so expired sessions transparently recover on the next request.

## Changes
- `server/api/auth/login.get.ts` — added `offline_access` to the requested scope so Auth0 actually issues a refresh token.
- `server/utils/auth-refresh.ts` *(new)* — shared `verifyOrRefreshOidcToken` / `refreshOidcToken` helpers. Re-issues the OIDC JWT and resets the `auth_oidc_token` (+ rotated refresh token) cookies on the response. Includes an in-flight dedup keyed on the refresh-token string so concurrent requests don't race against Auth0's refresh-token rotation.
- `server/api/auth/user.get.ts` — calls `verifyOrRefreshOidcToken` instead of `jwt.verify` directly. Silent-login fallback only fires when refresh genuinely can't recover.
- `server/middleware/jwt-auth.ts` — same path, so any protected API call auto-refreshes server-side without needing changes on the frontend.

## Notes
- Existing logged-in users won't have an `auth_refresh_token` cookie until they next log in (since `offline_access` wasn't requested originally). They'll get one automatically on next login and the refresh path will start working from then on.
- Dedup is best-effort per Nitro instance — multi-instance prod is fine because each browser session only talks to one instance at a time via sticky session / single tab.
