### PR TITLE
feat: update agentic ai momentum

### DIFF
--- a/frontend/app/components/modules/report/agentic-ai-momentum/components/project-leaderboard.vue
+++ b/frontend/app/components/modules/report/agentic-ai-momentum/components/project-leaderboard.vue
@@ -100,19 +100,6 @@ SPDX-License-Identifier: MIT
         <thead>
           <tr class="border-b border-neutral-200">
             <th
-              class="text-left py-3 px-2 font-semibold text-neutral-700 w-12 cursor-pointer hover:bg-neutral-50"
-              @click="sortBy('rank')"
-            >
-              <div class="flex items-center gap-1">
-                #
-                <lfx-icon
-                  v-if="sortColumn === 'rank'"
-                  :name="sortDirection === 'asc' ? 'arrow-up' : 'arrow-down'"
-                  :size="14"
-                />
-              </div>
-            </th>
-            <th
               class="text-left py-3 px-2 font-semibold text-neutral-700 min-w-[180px] cursor-pointer hover:bg-neutral-50"
               @click="sortBy('name')"
             >
@@ -385,13 +372,10 @@ SPDX-License-Identifier: MIT
         </thead>
         <tbody>
           <tr
-            v-for="(row, i) in sortedData"
+            v-for="row in sortedData"
             :key="row.slug"
             class="border-b border-neutral-100 hover:bg-neutral-50"
           >
-            <td class="py-3 px-2 text-neutral-500">
-              {{ i + 1 }}
-            </td>
             <td class="py-3 px-2">
               <div class="flex items-center gap-2">
                 <span class="font-medium text-neutral-900">{{ row.name }}</span>
@@ -767,7 +751,6 @@ const VulnDeltaIndicator: FunctionalComponent<{ value: number }> = (componentPro
 VulnDeltaIndicator.props = ['value'];
 
 type SortColumn =
-  | 'rank'
   | 'name'
   | 'stars'
   | 'forks'
@@ -795,14 +778,13 @@ function sortBy(column: SortColumn) {
     sortDirection.value = sortDirection.value === 'asc' ? 'desc' : 'asc';
   } else {
     sortColumn.value = column;
-    sortDirection.value = column === 'rank' || column === 'name' ? 'asc' : 'desc';
+    sortDirection.value = column === 'name' ? 'asc' : 'desc';
   }
 }
 
 // Build leaderboard rows directly from flat TB data
 const leaderboardData = computed<ProjectLeaderboardRow[]>(() => {
   return props.tbProjects.map((p) => ({
-    rank: p.rank,
     slug: p.slug,
     name: p.name,
     layer: p.layer,
@@ -893,8 +875,6 @@ const sortedData = computed(() => {
     }
 
     switch (col) {
-      case 'rank':
-        return dir === 'asc' ? a.rank - b.rank : b.rank - a.rank;
       case 'name':
         return dir === 'asc' ? a.name.localeCompare(b.name) : b.name.localeCompare(a.name);
       case 'stars':

--- a/frontend/app/components/modules/report/agentic-ai-momentum/components/project-leaderboard.vue
+++ b/frontend/app/components/modules/report/agentic-ai-momentum/components/project-leaderboard.vue
@@ -806,7 +806,6 @@ const leaderboardData = computed<ProjectLeaderboardRow[]>(() => {
     slug: p.slug,
     name: p.name,
     layer: p.layer,
-    license: p.license,
     githubUrl: p.githubRepoLink,
     stars: p.stars,
     starsDelta: p.stars30d,

--- a/frontend/public/data/agentic-ai-momentum/github_ecosystem_breadth.json
+++ b/frontend/public/data/agentic-ai-momentum/github_ecosystem_breadth.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:30:23.267270",
+    "fetched_at": "2026-04-30T16:01:01.916658",
     "schema": {
       "name": "github_ecosystem_breadth",
       "description": "Monthly snapshot of GitHub repository, issue, and discussion counts per search term.",
@@ -36,50 +36,100 @@
           "optional": false
         }
       ]
-    }
+    },
+    "covered_items": [
+      "agent_memory_planning",
+      "agent_safety_alignment",
+      "agentic_rag",
+      "autonomous_agents",
+      "llm_tool_use",
+      "multi_agent_systems"
+    ]
   },
   "data": [
     {
-      "search_term": "autonomous_agents",
+      "search_term": "agent_memory_planning",
       "month": "2026-03-01",
-      "repo_count": 23159,
-      "issue_count": 81918,
-      "discussion_count": 2424
-    },
-    {
-      "search_term": "multi_agent_systems",
-      "month": "2026-03-01",
-      "repo_count": 21399,
-      "issue_count": 43539,
-      "discussion_count": 1999
-    },
-    {
-      "search_term": "llm_tool_use",
-      "month": "2026-03-01",
-      "repo_count": 6448,
-      "issue_count": 100426,
-      "discussion_count": 8652
+      "repo_count": 398,
+      "issue_count": 19624,
+      "discussion_count": 902
     },
     {
       "search_term": "agent_memory_planning",
-      "month": "2026-03-01",
-      "repo_count": 407,
-      "issue_count": 19940,
-      "discussion_count": 909
+      "month": "2026-04-01",
+      "repo_count": 534,
+      "issue_count": 26402,
+      "discussion_count": 1170
     },
     {
       "search_term": "agent_safety_alignment",
       "month": "2026-03-01",
-      "repo_count": 42,
-      "issue_count": 8028,
-      "discussion_count": 287
+      "repo_count": 40,
+      "issue_count": 7942,
+      "discussion_count": 283
+    },
+    {
+      "search_term": "agent_safety_alignment",
+      "month": "2026-04-01",
+      "repo_count": 49,
+      "issue_count": 9948,
+      "discussion_count": 379
     },
     {
       "search_term": "agentic_rag",
       "month": "2026-03-01",
-      "repo_count": 20359,
-      "issue_count": 5679,
-      "discussion_count": 433
+      "repo_count": 20141,
+      "issue_count": 5596,
+      "discussion_count": 429
+    },
+    {
+      "search_term": "agentic_rag",
+      "month": "2026-04-01",
+      "repo_count": 25435,
+      "issue_count": 7343,
+      "discussion_count": 490
+    },
+    {
+      "search_term": "autonomous_agents",
+      "month": "2026-03-01",
+      "repo_count": 22754,
+      "issue_count": 80558,
+      "discussion_count": 2360
+    },
+    {
+      "search_term": "autonomous_agents",
+      "month": "2026-04-01",
+      "repo_count": 29549,
+      "issue_count": 103874,
+      "discussion_count": 3246
+    },
+    {
+      "search_term": "llm_tool_use",
+      "month": "2026-03-01",
+      "repo_count": 6406,
+      "issue_count": 95212,
+      "discussion_count": 8587
+    },
+    {
+      "search_term": "llm_tool_use",
+      "month": "2026-04-01",
+      "repo_count": 7303,
+      "issue_count": 128327,
+      "discussion_count": 9780
+    },
+    {
+      "search_term": "multi_agent_systems",
+      "month": "2026-03-01",
+      "repo_count": 21147,
+      "issue_count": 43002,
+      "discussion_count": 1948
+    },
+    {
+      "search_term": "multi_agent_systems",
+      "month": "2026-04-01",
+      "repo_count": 26580,
+      "issue_count": 54336,
+      "discussion_count": 2745
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/github_releases_count.json
+++ b/frontend/public/data/agentic-ai-momentum/github_releases_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:30:18.373850",
+    "fetched_at": "2026-04-30T16:00:55.422103",
     "schema": {
       "name": "github_releases_count",
       "description": "Cumulative monthly release counts for tracked repositories.",
@@ -24,7 +24,116 @@
           "optional": false
         }
       ]
-    }
+    },
+    "covered_items": [
+      "https://github.com/567-labs/instructor",
+      "https://github.com/Aider-AI/aider",
+      "https://github.com/AmoyLab/Unla",
+      "https://github.com/Arize-ai/phoenix",
+      "https://github.com/Azure/PyRIT",
+      "https://github.com/BerriAI/litellm",
+      "https://github.com/ComposioHQ/composio",
+      "https://github.com/FoundationAgents/MetaGPT",
+      "https://github.com/HKUDS/LightRAG",
+      "https://github.com/Kilo-Org/kilocode",
+      "https://github.com/NVIDIA-NeMo/Guardrails",
+      "https://github.com/NVIDIA/garak",
+      "https://github.com/NousResearch/hermes-agent",
+      "https://github.com/OAI/OpenAPI-Specification",
+      "https://github.com/OpenAutoCoder/Agentless",
+      "https://github.com/OpenHands/OpenHands",
+      "https://github.com/OpenInterpreter/open-interpreter",
+      "https://github.com/PrefectHQ/fastmcp",
+      "https://github.com/PrefectHQ/prefect",
+      "https://github.com/SWE-agent/SWE-agent",
+      "https://github.com/SWE-bench/SWE-bench",
+      "https://github.com/ShishirPatil/gorilla",
+      "https://github.com/Significant-Gravitas/AutoGPT",
+      "https://github.com/Universal-Commerce-Protocol/ucp",
+      "https://github.com/a2aproject/A2A",
+      "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol",
+      "https://github.com/agentscope-ai/agentscope",
+      "https://github.com/agentskills/agentskills",
+      "https://github.com/agentsmd/agents.md",
+      "https://github.com/agno-agi/agno",
+      "https://github.com/agntcy/acp-spec",
+      "https://github.com/agntcy/oasf",
+      "https://github.com/agntcy/slim",
+      "https://github.com/anomalyco/opencode",
+      "https://github.com/assafelovic/gpt-researcher",
+      "https://github.com/aurelio-labs/semantic-router",
+      "https://github.com/badlogic/pi-mono",
+      "https://github.com/block/goose",
+      "https://github.com/browser-use/browser-use",
+      "https://github.com/bytedance/deer-flow",
+      "https://github.com/camel-ai/camel",
+      "https://github.com/camel-ai/owl",
+      "https://github.com/chroma-core/chroma",
+      "https://github.com/cline/cline",
+      "https://github.com/comet-ml/opik",
+      "https://github.com/confident-ai/deepeval",
+      "https://github.com/continuedev/continue",
+      "https://github.com/crewAIInc/crewAI",
+      "https://github.com/daytonaio/daytona",
+      "https://github.com/deepset-ai/haystack",
+      "https://github.com/e2b-dev/code-interpreter",
+      "https://github.com/firecrawl/firecrawl",
+      "https://github.com/google-agentic-commerce/AP2",
+      "https://github.com/google/a2ui",
+      "https://github.com/google/adk-python",
+      "https://github.com/guardrails-ai/guardrails",
+      "https://github.com/huggingface/smolagents",
+      "https://github.com/huggingface/transformers",
+      "https://github.com/ibm/mcp-context-forge",
+      "https://github.com/infiniflow/ragflow",
+      "https://github.com/janhq/jan",
+      "https://github.com/joonspk-research/generative_agents",
+      "https://github.com/kserve/kserve",
+      "https://github.com/langchain-ai/langchain",
+      "https://github.com/langchain-ai/langgraph",
+      "https://github.com/langfuse/langfuse",
+      "https://github.com/letta-ai/letta",
+      "https://github.com/livekit/agents",
+      "https://github.com/mastra-ai/mastra",
+      "https://github.com/microsoft/OmniParser",
+      "https://github.com/microsoft/TaskWeaver",
+      "https://github.com/microsoft/autogen",
+      "https://github.com/microsoft/graphrag",
+      "https://github.com/microsoft/playwright",
+      "https://github.com/microsoft/semantic-kernel",
+      "https://github.com/milvus-io/milvus",
+      "https://github.com/mistralai/mistral-inference",
+      "https://github.com/modelcontextprotocol/inspector",
+      "https://github.com/modelcontextprotocol/modelcontextprotocol",
+      "https://github.com/ollama/ollama",
+      "https://github.com/open-telemetry/semantic-conventions",
+      "https://github.com/open-webui/open-webui",
+      "https://github.com/openai/openai-agents-python",
+      "https://github.com/openclaw/openclaw",
+      "https://github.com/openresponses/openresponses",
+      "https://github.com/pathwaycom/pathway",
+      "https://github.com/pipecat-ai/pipecat",
+      "https://github.com/promptfoo/promptfoo",
+      "https://github.com/pydantic/pydantic-ai",
+      "https://github.com/qdrant/qdrant",
+      "https://github.com/qodo-ai/pr-agent",
+      "https://github.com/run-llama/llama_index",
+      "https://github.com/simular-ai/Agent-S",
+      "https://github.com/skypilot-org/skypilot",
+      "https://github.com/stanfordnlp/dspy",
+      "https://github.com/sweepai/sweep",
+      "https://github.com/tavily-ai/tavily-python",
+      "https://github.com/temporalio/temporal",
+      "https://github.com/tempoxyz/mpp",
+      "https://github.com/unclecode/crawl4ai",
+      "https://github.com/vercel-labs/open-plugin-spec",
+      "https://github.com/vibrantlabsai/ragas",
+      "https://github.com/w3c/did",
+      "https://github.com/warpdotdev/warp",
+      "https://github.com/weaviate/weaviate",
+      "https://github.com/wong2/litemcp",
+      "https://github.com/xlang-ai/OSWorld"
+    ]
   },
   "data": [
     {
@@ -66,6 +175,11 @@
       "repo": "https://github.com/a2aproject/A2A",
       "month": "2025-07-01",
       "cumulative_release_count": 9
+    },
+    {
+      "repo": "https://github.com/a2aproject/A2A",
+      "month": "2026-03-01",
+      "cumulative_release_count": 10
     },
     {
       "repo": "https://github.com/open-telemetry/semantic-conventions",
@@ -136,6 +250,11 @@
       "repo": "https://github.com/open-telemetry/semantic-conventions",
       "month": "2026-02-01",
       "cumulative_release_count": 21
+    },
+    {
+      "repo": "https://github.com/open-telemetry/semantic-conventions",
+      "month": "2026-04-01",
+      "cumulative_release_count": 22
     },
     {
       "repo": "https://github.com/OAI/OpenAPI-Specification",
@@ -213,6 +332,16 @@
       "cumulative_release_count": 294
     },
     {
+      "repo": "https://github.com/agntcy/slim",
+      "month": "2026-03-01",
+      "cumulative_release_count": 350
+    },
+    {
+      "repo": "https://github.com/agntcy/slim",
+      "month": "2026-04-01",
+      "cumulative_release_count": 375
+    },
+    {
       "repo": "https://github.com/agntcy/oasf",
       "month": "2025-03-01",
       "cumulative_release_count": 2
@@ -261,6 +390,11 @@
       "repo": "https://github.com/agntcy/oasf",
       "month": "2026-02-01",
       "cumulative_release_count": 31
+    },
+    {
+      "repo": "https://github.com/agntcy/oasf",
+      "month": "2026-03-01",
+      "cumulative_release_count": 34
     },
     {
       "repo": "https://github.com/langchain-ai/langgraph",
@@ -366,6 +500,16 @@
       "repo": "https://github.com/langchain-ai/langgraph",
       "month": "2026-02-01",
       "cumulative_release_count": 473
+    },
+    {
+      "repo": "https://github.com/langchain-ai/langgraph",
+      "month": "2026-03-01",
+      "cumulative_release_count": 488
+    },
+    {
+      "repo": "https://github.com/langchain-ai/langgraph",
+      "month": "2026-04-01",
+      "cumulative_release_count": 514
     },
     {
       "repo": "https://github.com/langchain-ai/langchain",
@@ -488,6 +632,16 @@
       "cumulative_release_count": 1167
     },
     {
+      "repo": "https://github.com/langchain-ai/langchain",
+      "month": "2026-03-01",
+      "cumulative_release_count": 1191
+    },
+    {
+      "repo": "https://github.com/langchain-ai/langchain",
+      "month": "2026-04-01",
+      "cumulative_release_count": 1226
+    },
+    {
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2024-03-01",
       "cumulative_release_count": 25
@@ -606,6 +760,16 @@
       "repo": "https://github.com/crewAIInc/crewAI",
       "month": "2026-02-01",
       "cumulative_release_count": 140
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2026-03-01",
+      "cumulative_release_count": 159
+    },
+    {
+      "repo": "https://github.com/crewAIInc/crewAI",
+      "month": "2026-04-01",
+      "cumulative_release_count": 183
     },
     {
       "repo": "https://github.com/microsoft/autogen",
@@ -758,6 +922,16 @@
       "cumulative_release_count": 63
     },
     {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2026-03-01",
+      "cumulative_release_count": 78
+    },
+    {
+      "repo": "https://github.com/openai/openai-agents-python",
+      "month": "2026-04-01",
+      "cumulative_release_count": 90
+    },
+    {
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2024-03-01",
       "cumulative_release_count": 81
@@ -876,6 +1050,16 @@
       "repo": "https://github.com/microsoft/semantic-kernel",
       "month": "2026-02-01",
       "cumulative_release_count": 256
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-03-01",
+      "cumulative_release_count": 263
+    },
+    {
+      "repo": "https://github.com/microsoft/semantic-kernel",
+      "month": "2026-04-01",
+      "cumulative_release_count": 267
     },
     {
       "repo": "https://github.com/huggingface/smolagents",
@@ -1023,6 +1207,16 @@
       "cumulative_release_count": 212
     },
     {
+      "repo": "https://github.com/pydantic/pydantic-ai",
+      "month": "2026-03-01",
+      "cumulative_release_count": 223
+    },
+    {
+      "repo": "https://github.com/pydantic/pydantic-ai",
+      "month": "2026-04-01",
+      "cumulative_release_count": 240
+    },
+    {
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2025-04-01",
       "cumulative_release_count": 6
@@ -1071,6 +1265,16 @@
       "repo": "https://github.com/mastra-ai/mastra",
       "month": "2026-02-01",
       "cumulative_release_count": 68
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2026-03-01",
+      "cumulative_release_count": 76
+    },
+    {
+      "repo": "https://github.com/mastra-ai/mastra",
+      "month": "2026-04-01",
+      "cumulative_release_count": 82
     },
     {
       "repo": "https://github.com/camel-ai/camel",
@@ -1188,6 +1392,16 @@
       "cumulative_release_count": 202
     },
     {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2026-03-01",
+      "cumulative_release_count": 205
+    },
+    {
+      "repo": "https://github.com/camel-ai/camel",
+      "month": "2026-04-01",
+      "cumulative_release_count": 210
+    },
+    {
       "repo": "https://github.com/google/adk-python",
       "month": "2025-04-01",
       "cumulative_release_count": 3
@@ -1241,6 +1455,16 @@
       "repo": "https://github.com/google/adk-python",
       "month": "2026-02-01",
       "cumulative_release_count": 40
+    },
+    {
+      "repo": "https://github.com/google/adk-python",
+      "month": "2026-03-01",
+      "cumulative_release_count": 49
+    },
+    {
+      "repo": "https://github.com/google/adk-python",
+      "month": "2026-04-01",
+      "cumulative_release_count": 56
     },
     {
       "repo": "https://github.com/block/goose",
@@ -1333,6 +1557,16 @@
       "cumulative_release_count": 118
     },
     {
+      "repo": "https://github.com/block/goose",
+      "month": "2026-03-01",
+      "cumulative_release_count": 125
+    },
+    {
+      "repo": "https://github.com/block/goose",
+      "month": "2026-04-01",
+      "cumulative_release_count": 132
+    },
+    {
       "repo": "https://github.com/FoundationAgents/MetaGPT",
       "month": "2024-03-01",
       "cumulative_release_count": 20
@@ -1421,6 +1655,16 @@
       "repo": "https://github.com/temporalio/temporal",
       "month": "2026-02-01",
       "cumulative_release_count": 152
+    },
+    {
+      "repo": "https://github.com/temporalio/temporal",
+      "month": "2026-03-01",
+      "cumulative_release_count": 158
+    },
+    {
+      "repo": "https://github.com/temporalio/temporal",
+      "month": "2026-04-01",
+      "cumulative_release_count": 164
     },
     {
       "repo": "https://github.com/PrefectHQ/prefect",
@@ -1543,6 +1787,16 @@
       "cumulative_release_count": 739
     },
     {
+      "repo": "https://github.com/PrefectHQ/prefect",
+      "month": "2026-03-01",
+      "cumulative_release_count": 768
+    },
+    {
+      "repo": "https://github.com/PrefectHQ/prefect",
+      "month": "2026-04-01",
+      "cumulative_release_count": 795
+    },
+    {
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2024-04-01",
       "cumulative_release_count": 21
@@ -1631,6 +1885,16 @@
       "repo": "https://github.com/Significant-Gravitas/AutoGPT",
       "month": "2026-02-01",
       "cumulative_release_count": 93
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2026-03-01",
+      "cumulative_release_count": 97
+    },
+    {
+      "repo": "https://github.com/Significant-Gravitas/AutoGPT",
+      "month": "2026-04-01",
+      "cumulative_release_count": 102
     },
     {
       "repo": "https://github.com/infiniflow/ragflow",
@@ -1728,6 +1992,11 @@
       "cumulative_release_count": 40
     },
     {
+      "repo": "https://github.com/infiniflow/ragflow",
+      "month": "2026-04-01",
+      "cumulative_release_count": 42
+    },
+    {
       "repo": "https://github.com/agentscope-ai/agentscope",
       "month": "2024-03-01",
       "cumulative_release_count": 2
@@ -1808,6 +2077,16 @@
       "cumulative_release_count": 31
     },
     {
+      "repo": "https://github.com/agentscope-ai/agentscope",
+      "month": "2026-03-01",
+      "cumulative_release_count": 33
+    },
+    {
+      "repo": "https://github.com/agentscope-ai/agentscope",
+      "month": "2026-04-01",
+      "cumulative_release_count": 35
+    },
+    {
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2025-11-01",
       "cumulative_release_count": 7
@@ -1826,6 +2105,16 @@
       "repo": "https://github.com/openclaw/openclaw",
       "month": "2026-02-01",
       "cumulative_release_count": 56
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2026-03-01",
+      "cumulative_release_count": 78
+    },
+    {
+      "repo": "https://github.com/openclaw/openclaw",
+      "month": "2026-04-01",
+      "cumulative_release_count": 125
     },
     {
       "repo": "https://github.com/OpenHands/OpenHands",
@@ -1933,6 +2222,11 @@
       "cumulative_release_count": 99
     },
     {
+      "repo": "https://github.com/OpenHands/OpenHands",
+      "month": "2026-03-01",
+      "cumulative_release_count": 101
+    },
+    {
       "repo": "https://github.com/cline/cline",
       "month": "2024-07-01",
       "cumulative_release_count": 9
@@ -2026,6 +2320,16 @@
       "repo": "https://github.com/cline/cline",
       "month": "2026-02-01",
       "cumulative_release_count": 237
+    },
+    {
+      "repo": "https://github.com/cline/cline",
+      "month": "2026-03-01",
+      "cumulative_release_count": 245
+    },
+    {
+      "repo": "https://github.com/cline/cline",
+      "month": "2026-04-01",
+      "cumulative_release_count": 250
     },
     {
       "repo": "https://github.com/Aider-AI/aider",
@@ -2273,6 +2577,16 @@
       "cumulative_release_count": 66
     },
     {
+      "repo": "https://github.com/assafelovic/gpt-researcher",
+      "month": "2026-03-01",
+      "cumulative_release_count": 68
+    },
+    {
+      "repo": "https://github.com/assafelovic/gpt-researcher",
+      "month": "2026-04-01",
+      "cumulative_release_count": 69
+    },
+    {
       "repo": "https://github.com/OpenInterpreter/open-interpreter",
       "month": "2024-03-01",
       "cumulative_release_count": 31
@@ -2378,6 +2692,16 @@
       "cumulative_release_count": 117
     },
     {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2026-03-01",
+      "cumulative_release_count": 122
+    },
+    {
+      "repo": "https://github.com/browser-use/browser-use",
+      "month": "2026-04-01",
+      "cumulative_release_count": 123
+    },
+    {
       "repo": "https://github.com/firecrawl/firecrawl",
       "month": "2024-09-01",
       "cumulative_release_count": 1
@@ -2453,6 +2777,11 @@
       "cumulative_release_count": 32
     },
     {
+      "repo": "https://github.com/firecrawl/firecrawl",
+      "month": "2026-04-01",
+      "cumulative_release_count": 33
+    },
+    {
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2025-03-01",
       "cumulative_release_count": 1
@@ -2496,6 +2825,11 @@
       "repo": "https://github.com/unclecode/crawl4ai",
       "month": "2026-01-01",
       "cumulative_release_count": 13
+    },
+    {
+      "repo": "https://github.com/unclecode/crawl4ai",
+      "month": "2026-03-01",
+      "cumulative_release_count": 14
     },
     {
       "repo": "https://github.com/xlang-ai/OSWorld",
@@ -2643,6 +2977,16 @@
       "cumulative_release_count": 76
     },
     {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2026-03-01",
+      "cumulative_release_count": 84
+    },
+    {
+      "repo": "https://github.com/e2b-dev/code-interpreter",
+      "month": "2026-04-01",
+      "cumulative_release_count": 89
+    },
+    {
       "repo": "https://github.com/microsoft/OmniParser",
       "month": "2025-02-01",
       "cumulative_release_count": 2
@@ -2733,6 +3077,11 @@
       "cumulative_release_count": 49
     },
     {
+      "repo": "https://github.com/modelcontextprotocol/inspector",
+      "month": "2026-04-01",
+      "cumulative_release_count": 50
+    },
+    {
       "repo": "https://github.com/PrefectHQ/fastmcp",
       "month": "2024-11-01",
       "cumulative_release_count": 2
@@ -2798,6 +3147,16 @@
       "cumulative_release_count": 87
     },
     {
+      "repo": "https://github.com/PrefectHQ/fastmcp",
+      "month": "2026-03-01",
+      "cumulative_release_count": 91
+    },
+    {
+      "repo": "https://github.com/PrefectHQ/fastmcp",
+      "month": "2026-04-01",
+      "cumulative_release_count": 96
+    },
+    {
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2025-06-01",
       "cumulative_release_count": 3
@@ -2841,6 +3200,16 @@
       "repo": "https://github.com/ibm/mcp-context-forge",
       "month": "2026-02-01",
       "cumulative_release_count": 14
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2026-03-01",
+      "cumulative_release_count": 15
+    },
+    {
+      "repo": "https://github.com/ibm/mcp-context-forge",
+      "month": "2026-04-01",
+      "cumulative_release_count": 16
     },
     {
       "repo": "https://github.com/AmoyLab/Unla",
@@ -2988,6 +3357,11 @@
       "cumulative_release_count": 174
     },
     {
+      "repo": "https://github.com/letta-ai/letta",
+      "month": "2026-03-01",
+      "cumulative_release_count": 176
+    },
+    {
       "repo": "https://github.com/run-llama/llama_index",
       "month": "2024-03-01",
       "cumulative_release_count": 332
@@ -3108,6 +3482,16 @@
       "cumulative_release_count": 488
     },
     {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2026-03-01",
+      "cumulative_release_count": 491
+    },
+    {
+      "repo": "https://github.com/run-llama/llama_index",
+      "month": "2026-04-01",
+      "cumulative_release_count": 493
+    },
+    {
       "repo": "https://github.com/microsoft/graphrag",
       "month": "2024-07-01",
       "cumulative_release_count": 2
@@ -3188,6 +3572,16 @@
       "cumulative_release_count": 35
     },
     {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-03-01",
+      "cumulative_release_count": 38
+    },
+    {
+      "repo": "https://github.com/microsoft/graphrag",
+      "month": "2026-04-01",
+      "cumulative_release_count": 39
+    },
+    {
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2024-12-01",
       "cumulative_release_count": 6
@@ -3261,6 +3655,16 @@
       "repo": "https://github.com/HKUDS/LightRAG",
       "month": "2026-02-01",
       "cumulative_release_count": 64
+    },
+    {
+      "repo": "https://github.com/HKUDS/LightRAG",
+      "month": "2026-03-01",
+      "cumulative_release_count": 67
+    },
+    {
+      "repo": "https://github.com/HKUDS/LightRAG",
+      "month": "2026-04-01",
+      "cumulative_release_count": 71
     },
     {
       "repo": "https://github.com/stanfordnlp/dspy",
@@ -3361,6 +3765,11 @@
       "repo": "https://github.com/stanfordnlp/dspy",
       "month": "2026-02-01",
       "cumulative_release_count": 106
+    },
+    {
+      "repo": "https://github.com/stanfordnlp/dspy",
+      "month": "2026-04-01",
+      "cumulative_release_count": 107
     },
     {
       "repo": "https://github.com/vibrantlabsai/ragas",
@@ -3583,6 +3992,16 @@
       "cumulative_release_count": 502
     },
     {
+      "repo": "https://github.com/weaviate/weaviate",
+      "month": "2026-03-01",
+      "cumulative_release_count": 515
+    },
+    {
+      "repo": "https://github.com/weaviate/weaviate",
+      "month": "2026-04-01",
+      "cumulative_release_count": 526
+    },
+    {
       "repo": "https://github.com/qdrant/qdrant",
       "month": "2024-03-01",
       "cumulative_release_count": 66
@@ -3688,6 +4107,11 @@
       "cumulative_release_count": 110
     },
     {
+      "repo": "https://github.com/qdrant/qdrant",
+      "month": "2026-03-01",
+      "cumulative_release_count": 111
+    },
+    {
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2024-04-01",
       "cumulative_release_count": 55
@@ -3781,6 +4205,16 @@
       "repo": "https://github.com/chroma-core/chroma",
       "month": "2026-02-01",
       "cumulative_release_count": 127
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2026-03-01",
+      "cumulative_release_count": 129
+    },
+    {
+      "repo": "https://github.com/chroma-core/chroma",
+      "month": "2026-04-01",
+      "cumulative_release_count": 134
     },
     {
       "repo": "https://github.com/milvus-io/milvus",
@@ -3903,6 +4337,16 @@
       "cumulative_release_count": 153
     },
     {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2026-03-01",
+      "cumulative_release_count": 156
+    },
+    {
+      "repo": "https://github.com/milvus-io/milvus",
+      "month": "2026-04-01",
+      "cumulative_release_count": 158
+    },
+    {
       "repo": "https://github.com/microsoft/playwright",
       "month": "2024-03-01",
       "cumulative_release_count": 121
@@ -4006,6 +4450,11 @@
       "repo": "https://github.com/microsoft/playwright",
       "month": "2026-02-01",
       "cumulative_release_count": 158
+    },
+    {
+      "repo": "https://github.com/microsoft/playwright",
+      "month": "2026-04-01",
+      "cumulative_release_count": 160
     },
     {
       "repo": "https://github.com/ComposioHQ/composio",
@@ -4128,6 +4577,16 @@
       "cumulative_release_count": 584
     },
     {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2026-03-01",
+      "cumulative_release_count": 652
+    },
+    {
+      "repo": "https://github.com/ComposioHQ/composio",
+      "month": "2026-04-01",
+      "cumulative_release_count": 744
+    },
+    {
       "repo": "https://github.com/567-labs/instructor",
       "month": "2024-03-01",
       "cumulative_release_count": 46
@@ -4226,6 +4685,11 @@
       "repo": "https://github.com/567-labs/instructor",
       "month": "2026-01-01",
       "cumulative_release_count": 106
+    },
+    {
+      "repo": "https://github.com/567-labs/instructor",
+      "month": "2026-04-01",
+      "cumulative_release_count": 108
     },
     {
       "repo": "https://github.com/deepset-ai/haystack",
@@ -4348,6 +4812,16 @@
       "cumulative_release_count": 212
     },
     {
+      "repo": "https://github.com/deepset-ai/haystack",
+      "month": "2026-03-01",
+      "cumulative_release_count": 219
+    },
+    {
+      "repo": "https://github.com/deepset-ai/haystack",
+      "month": "2026-04-01",
+      "cumulative_release_count": 223
+    },
+    {
       "repo": "https://github.com/BerriAI/litellm",
       "month": "2024-03-01",
       "cumulative_release_count": 197
@@ -4468,6 +4942,16 @@
       "cumulative_release_count": 1222
     },
     {
+      "repo": "https://github.com/BerriAI/litellm",
+      "month": "2026-03-01",
+      "cumulative_release_count": 1290
+    },
+    {
+      "repo": "https://github.com/BerriAI/litellm",
+      "month": "2026-04-01",
+      "cumulative_release_count": 1314
+    },
+    {
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2024-03-01",
       "cumulative_release_count": 31
@@ -4581,6 +5065,16 @@
       "repo": "https://github.com/pathwaycom/pathway",
       "month": "2026-02-01",
       "cumulative_release_count": 84
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-03-01",
+      "cumulative_release_count": 85
+    },
+    {
+      "repo": "https://github.com/pathwaycom/pathway",
+      "month": "2026-04-01",
+      "cumulative_release_count": 86
     },
     {
       "repo": "https://github.com/langfuse/langfuse",
@@ -4703,6 +5197,16 @@
       "cumulative_release_count": 536
     },
     {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2026-03-01",
+      "cumulative_release_count": 544
+    },
+    {
+      "repo": "https://github.com/langfuse/langfuse",
+      "month": "2026-04-01",
+      "cumulative_release_count": 558
+    },
+    {
       "repo": "https://github.com/Arize-ai/phoenix",
       "month": "2024-03-01",
       "cumulative_release_count": 138
@@ -4823,6 +5327,16 @@
       "cumulative_release_count": 621
     },
     {
+      "repo": "https://github.com/Arize-ai/phoenix",
+      "month": "2026-03-01",
+      "cumulative_release_count": 647
+    },
+    {
+      "repo": "https://github.com/Arize-ai/phoenix",
+      "month": "2026-04-01",
+      "cumulative_release_count": 685
+    },
+    {
       "repo": "https://github.com/comet-ml/opik",
       "month": "2024-03-01",
       "cumulative_release_count": 21
@@ -4936,6 +5450,16 @@
       "repo": "https://github.com/comet-ml/opik",
       "month": "2026-02-01",
       "cumulative_release_count": 379
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2026-03-01",
+      "cumulative_release_count": 403
+    },
+    {
+      "repo": "https://github.com/comet-ml/opik",
+      "month": "2026-04-01",
+      "cumulative_release_count": 440
     },
     {
       "repo": "https://github.com/confident-ai/deepeval",
@@ -5128,6 +5652,16 @@
       "cumulative_release_count": 393
     },
     {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2026-03-01",
+      "cumulative_release_count": 399
+    },
+    {
+      "repo": "https://github.com/promptfoo/promptfoo",
+      "month": "2026-04-01",
+      "cumulative_release_count": 406
+    },
+    {
       "repo": "https://github.com/ShishirPatil/gorilla",
       "month": "2024-03-01",
       "cumulative_release_count": 2
@@ -5268,6 +5802,11 @@
       "cumulative_release_count": 29
     },
     {
+      "repo": "https://github.com/NVIDIA-NeMo/Guardrails",
+      "month": "2026-03-01",
+      "cumulative_release_count": 30
+    },
+    {
       "repo": "https://github.com/guardrails-ai/guardrails",
       "month": "2024-03-01",
       "cumulative_release_count": 27
@@ -5353,74 +5892,14 @@
       "cumulative_release_count": 64
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-03-01",
-      "cumulative_release_count": 3
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2026-03-01",
+      "cumulative_release_count": 65
     },
     {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-04-01",
-      "cumulative_release_count": 4
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-05-01",
-      "cumulative_release_count": 5
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-06-01",
-      "cumulative_release_count": 6
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-08-01",
-      "cumulative_release_count": 7
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-11-01",
-      "cumulative_release_count": 8
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2024-12-01",
-      "cumulative_release_count": 9
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-02-01",
-      "cumulative_release_count": 10
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-03-01",
-      "cumulative_release_count": 12
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-04-01",
-      "cumulative_release_count": 13
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-05-01",
-      "cumulative_release_count": 14
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-09-01",
-      "cumulative_release_count": 15
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2025-12-01",
-      "cumulative_release_count": 16
-    },
-    {
-      "repo": "https://github.com/Azure/PyRIT",
-      "month": "2026-02-01",
-      "cumulative_release_count": 17
+      "repo": "https://github.com/guardrails-ai/guardrails",
+      "month": "2026-04-01",
+      "cumulative_release_count": 67
     },
     {
       "repo": "https://github.com/NVIDIA/garak",
@@ -5496,6 +5975,11 @@
       "repo": "https://github.com/NVIDIA/garak",
       "month": "2026-02-01",
       "cumulative_release_count": 28
+    },
+    {
+      "repo": "https://github.com/NVIDIA/garak",
+      "month": "2026-04-01",
+      "cumulative_release_count": 29
     },
     {
       "repo": "https://github.com/ollama/ollama",
@@ -5618,6 +6102,16 @@
       "cumulative_release_count": 186
     },
     {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2026-03-01",
+      "cumulative_release_count": 196
+    },
+    {
+      "repo": "https://github.com/ollama/ollama",
+      "month": "2026-04-01",
+      "cumulative_release_count": 210
+    },
+    {
       "repo": "https://github.com/huggingface/transformers",
       "month": "2024-03-01",
       "cumulative_release_count": 137
@@ -5738,6 +6232,16 @@
       "cumulative_release_count": 236
     },
     {
+      "repo": "https://github.com/huggingface/transformers",
+      "month": "2026-03-01",
+      "cumulative_release_count": 238
+    },
+    {
+      "repo": "https://github.com/huggingface/transformers",
+      "month": "2026-04-01",
+      "cumulative_release_count": 247
+    },
+    {
       "repo": "https://github.com/continuedev/continue",
       "month": "2024-03-01",
       "cumulative_release_count": 5
@@ -5856,6 +6360,11 @@
       "repo": "https://github.com/continuedev/continue",
       "month": "2026-02-01",
       "cumulative_release_count": 801
+    },
+    {
+      "repo": "https://github.com/continuedev/continue",
+      "month": "2026-03-01",
+      "cumulative_release_count": 822
     },
     {
       "repo": "https://github.com/aurelio-labs/semantic-router",
@@ -6023,6 +6532,11 @@
       "cumulative_release_count": 32
     },
     {
+      "repo": "https://github.com/skypilot-org/skypilot",
+      "month": "2026-03-01",
+      "cumulative_release_count": 34
+    },
+    {
       "repo": "https://github.com/kserve/kserve",
       "month": "2024-04-01",
       "cumulative_release_count": 31
@@ -6086,6 +6600,16 @@
       "repo": "https://github.com/kserve/kserve",
       "month": "2025-11-01",
       "cumulative_release_count": 47
+    },
+    {
+      "repo": "https://github.com/kserve/kserve",
+      "month": "2026-03-01",
+      "cumulative_release_count": 50
+    },
+    {
+      "repo": "https://github.com/kserve/kserve",
+      "month": "2026-04-01",
+      "cumulative_release_count": 53
     },
     {
       "repo": "https://github.com/daytonaio/daytona",
@@ -6181,6 +6705,16 @@
       "repo": "https://github.com/daytonaio/daytona",
       "month": "2026-02-01",
       "cumulative_release_count": 161
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2026-03-01",
+      "cumulative_release_count": 174
+    },
+    {
+      "repo": "https://github.com/daytonaio/daytona",
+      "month": "2026-04-01",
+      "cumulative_release_count": 186
     },
     {
       "repo": "https://github.com/open-webui/open-webui",
@@ -6303,6 +6837,16 @@
       "cumulative_release_count": 149
     },
     {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2026-03-01",
+      "cumulative_release_count": 156
+    },
+    {
+      "repo": "https://github.com/open-webui/open-webui",
+      "month": "2026-04-01",
+      "cumulative_release_count": 159
+    },
+    {
       "repo": "https://github.com/janhq/jan",
       "month": "2024-03-01",
       "cumulative_release_count": 18
@@ -6418,6 +6962,11 @@
       "cumulative_release_count": 97
     },
     {
+      "repo": "https://github.com/janhq/jan",
+      "month": "2026-03-01",
+      "cumulative_release_count": 99
+    },
+    {
       "repo": "https://github.com/livekit/agents",
       "month": "2024-07-01",
       "cumulative_release_count": 19
@@ -6516,6 +7065,16 @@
       "repo": "https://github.com/livekit/agents",
       "month": "2026-02-01",
       "cumulative_release_count": 339
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2026-03-01",
+      "cumulative_release_count": 344
+    },
+    {
+      "repo": "https://github.com/livekit/agents",
+      "month": "2026-04-01",
+      "cumulative_release_count": 350
     },
     {
       "repo": "https://github.com/pipecat-ai/pipecat",
@@ -6628,6 +7187,16 @@
       "cumulative_release_count": 102
     },
     {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2026-03-01",
+      "cumulative_release_count": 107
+    },
+    {
+      "repo": "https://github.com/pipecat-ai/pipecat",
+      "month": "2026-04-01",
+      "cumulative_release_count": 109
+    },
+    {
       "repo": "https://github.com/qodo-ai/pr-agent",
       "month": "2024-03-01",
       "cumulative_release_count": 8
@@ -6681,6 +7250,286 @@
       "repo": "https://github.com/qodo-ai/pr-agent",
       "month": "2026-02-01",
       "cumulative_release_count": 19
+    },
+    {
+      "repo": "https://github.com/qodo-ai/pr-agent",
+      "month": "2026-03-01",
+      "cumulative_release_count": 20
+    },
+    {
+      "repo": "https://github.com/qodo-ai/pr-agent",
+      "month": "2026-04-01",
+      "cumulative_release_count": 21
+    },
+    {
+      "repo": "https://github.com/Universal-Commerce-Protocol/ucp",
+      "month": "2026-01-01",
+      "cumulative_release_count": 2
+    },
+    {
+      "repo": "https://github.com/Universal-Commerce-Protocol/ucp",
+      "month": "2026-04-01",
+      "cumulative_release_count": 3
+    },
+    {
+      "repo": "https://github.com/google-agentic-commerce/AP2",
+      "month": "2025-09-01",
+      "cumulative_release_count": 1
+    },
+    {
+      "repo": "https://github.com/google-agentic-commerce/AP2",
+      "month": "2026-04-01",
+      "cumulative_release_count": 2
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-01-01",
+      "cumulative_release_count": 4
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-02-01",
+      "cumulative_release_count": 17
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-03-01",
+      "cumulative_release_count": 34
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-04-01",
+      "cumulative_release_count": 54
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-05-01",
+      "cumulative_release_count": 65
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-06-01",
+      "cumulative_release_count": 74
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-07-01",
+      "cumulative_release_count": 81
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-08-01",
+      "cumulative_release_count": 88
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-09-01",
+      "cumulative_release_count": 103
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-10-01",
+      "cumulative_release_count": 120
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-11-01",
+      "cumulative_release_count": 133
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2025-12-01",
+      "cumulative_release_count": 150
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2026-01-01",
+      "cumulative_release_count": 163
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2026-02-01",
+      "cumulative_release_count": 170
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2026-03-01",
+      "cumulative_release_count": 177
+    },
+    {
+      "repo": "https://github.com/agno-agi/agno",
+      "month": "2026-04-01",
+      "cumulative_release_count": 187
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-05-01",
+      "cumulative_release_count": 8
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-06-01",
+      "cumulative_release_count": 137
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-07-01",
+      "cumulative_release_count": 273
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-08-01",
+      "cumulative_release_count": 351
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-09-01",
+      "cumulative_release_count": 404
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-10-01",
+      "cumulative_release_count": 450
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-11-01",
+      "cumulative_release_count": 563
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2025-12-01",
+      "cumulative_release_count": 645
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2026-01-01",
+      "cumulative_release_count": 692
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2026-02-01",
+      "cumulative_release_count": 725
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2026-03-01",
+      "cumulative_release_count": 750
+    },
+    {
+      "repo": "https://github.com/anomalyco/opencode",
+      "month": "2026-04-01",
+      "cumulative_release_count": 781
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-03-01",
+      "cumulative_release_count": 8
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-04-01",
+      "cumulative_release_count": 28
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-05-01",
+      "cumulative_release_count": 44
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-06-01",
+      "cumulative_release_count": 71
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-07-01",
+      "cumulative_release_count": 129
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-08-01",
+      "cumulative_release_count": 155
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-09-01",
+      "cumulative_release_count": 178
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-10-01",
+      "cumulative_release_count": 202
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-11-01",
+      "cumulative_release_count": 226
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2025-12-01",
+      "cumulative_release_count": 258
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2026-01-01",
+      "cumulative_release_count": 292
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2026-02-01",
+      "cumulative_release_count": 308
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2026-03-01",
+      "cumulative_release_count": 339
+    },
+    {
+      "repo": "https://github.com/Kilo-Org/kilocode",
+      "month": "2026-04-01",
+      "cumulative_release_count": 375
+    },
+    {
+      "repo": "https://github.com/NousResearch/hermes-agent",
+      "month": "2026-03-01",
+      "cumulative_release_count": 5
+    },
+    {
+      "repo": "https://github.com/NousResearch/hermes-agent",
+      "month": "2026-04-01",
+      "cumulative_release_count": 11
+    },
+    {
+      "repo": "https://github.com/warpdotdev/warp",
+      "month": "2026-04-01",
+      "cumulative_release_count": 4
+    },
+    {
+      "repo": "https://github.com/badlogic/pi-mono",
+      "month": "2025-12-01",
+      "cumulative_release_count": 76
+    },
+    {
+      "repo": "https://github.com/badlogic/pi-mono",
+      "month": "2026-01-01",
+      "cumulative_release_count": 132
+    },
+    {
+      "repo": "https://github.com/badlogic/pi-mono",
+      "month": "2026-02-01",
+      "cumulative_release_count": 162
+    },
+    {
+      "repo": "https://github.com/badlogic/pi-mono",
+      "month": "2026-03-01",
+      "cumulative_release_count": 183
+    },
+    {
+      "repo": "https://github.com/badlogic/pi-mono",
+      "month": "2026-04-01",
+      "cumulative_release_count": 207
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -24,12 +24,6 @@
           "optional": false
         },
         {
-          "name": "license",
-          "type": "string",
-          "description": "License identifier",
-          "optional": false
-        },
-        {
           "name": "github_url",
           "type": "string",
           "description": "GitHub repository URL",
@@ -43,7 +37,6 @@
       "rank": 1,
       "name": "MCP (Model Context Protocol)",
       "layer": "Protocols & Standards",
-      "license": "MIT",
       "github_url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "github_url_display": "https://github.com/modelcontextprotocol/modelcontextprotocol"
     },
@@ -51,7 +44,6 @@
       "rank": 2,
       "name": "Agent2Agent (A2A) Protocol",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/google/A2A",
       "github_url_display": "https://github.com/a2aproject/A2A"
     },
@@ -59,7 +51,6 @@
       "rank": 3,
       "name": "AGENTS.md",
       "layer": "Protocols & Standards",
-      "license": "MIT",
       "github_url": "https://github.com/agentsmd/agentsmd",
       "github_url_display": "https://github.com/agentsmd/agents.md"
     },
@@ -67,7 +58,6 @@
       "rank": 4,
       "name": "AGNTCY",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/agntcy/acp-spec",
       "github_url_display": "https://github.com/agntcy/acp-spec"
     },
@@ -75,7 +65,6 @@
       "rank": 5,
       "name": "OpenTelemetry AI Semantic Conventions",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/open-telemetry/semantic-conventions",
       "github_url_display": "https://github.com/open-telemetry/semantic-conventions"
     },
@@ -83,7 +72,6 @@
       "rank": 6,
       "name": "OpenAPI Specification",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/OAI/OpenAPI-Specification",
       "github_url_display": "https://github.com/OAI/OpenAPI-Specification"
     },
@@ -91,7 +79,6 @@
       "rank": 7,
       "name": "W3C DID / Verifiable Credentials",
       "layer": "Protocols & Standards",
-      "license": "W3C Open",
       "github_url": "https://github.com/w3c/did-core",
       "github_url_display": "https://github.com/w3c/did"
     },
@@ -99,7 +86,6 @@
       "rank": 8,
       "name": "SLIM (LF)",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/agntcy/slim",
       "github_url_display": "https://github.com/agntcy/slim"
     },
@@ -107,7 +93,6 @@
       "rank": 9,
       "name": "Open Agent Schema Framework (OASF)",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/agntcy/oasf",
       "github_url_display": "https://github.com/agntcy/oasf"
     },
@@ -115,7 +100,6 @@
       "rank": 10,
       "name": "A2UI",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/google/a2ui",
       "github_url_display": "https://github.com/google/a2ui"
     },
@@ -123,7 +107,6 @@
       "rank": 11,
       "name": "Agentic Commerce Protocol (ACP)",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol",
       "github_url_display": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol"
     },
@@ -131,7 +114,6 @@
       "rank": 12,
       "name": "Universal Commerce Protocol (UCP)",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/Universal-Commerce-Protocol/ucp",
       "github_url_display": "https://github.com/Universal-Commerce-Protocol/ucp"
     },
@@ -139,7 +121,6 @@
       "rank": 13,
       "name": "Agent Payments Protocol (AP2)",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/google-agentic-commerce/AP2",
       "github_url_display": "https://github.com/google-agentic-commerce/AP2"
     },
@@ -147,7 +128,6 @@
       "rank": 14,
       "name": "Machine Payments Protocol (MPP)",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/tempoxyz/mpp",
       "github_url_display": "https://github.com/tempoxyz/mpp"
     },
@@ -155,7 +135,6 @@
       "rank": 15,
       "name": "Open Plugins Specification",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/vercel-labs/open-plugin-spec",
       "github_url_display": "https://github.com/vercel-labs/open-plugin-spec"
     },
@@ -163,7 +142,6 @@
       "rank": 16,
       "name": "Open Responses",
       "layer": "Protocols & Standards",
-      "license": null,
       "github_url": "https://github.com/openresponses/openresponses",
       "github_url_display": "https://github.com/openresponses/openresponses"
     },
@@ -171,7 +149,6 @@
       "rank": 17,
       "name": "LangGraph",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/langchain-ai/langgraph",
       "github_url_display": "https://github.com/langchain-ai/langgraph"
     },
@@ -179,7 +156,6 @@
       "rank": 18,
       "name": "LangChain",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/langchain-ai/langchain",
       "github_url_display": "https://github.com/langchain-ai/langchain"
     },
@@ -187,7 +163,6 @@
       "rank": 19,
       "name": "CrewAI",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/crewAIInc/crewAI",
       "github_url_display": "https://github.com/crewAIInc/crewAI"
     },
@@ -195,7 +170,6 @@
       "rank": 20,
       "name": "AutoGen (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/microsoft/autogen",
       "github_url_display": "https://github.com/microsoft/autogen"
     },
@@ -203,7 +177,6 @@
       "rank": 21,
       "name": "OpenAI Agents SDK",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/openai/openai-agents-python",
       "github_url_display": "https://github.com/openai/openai-agents-python"
     },
@@ -211,7 +184,6 @@
       "rank": 22,
       "name": "Semantic Kernel (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/microsoft/semantic-kernel",
       "github_url_display": "https://github.com/microsoft/semantic-kernel"
     },
@@ -219,7 +191,6 @@
       "rank": 23,
       "name": "SmolAgents (Hugging Face)",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/huggingface/smolagents",
       "github_url_display": "https://github.com/huggingface/smolagents"
     },
@@ -227,7 +198,6 @@
       "rank": 24,
       "name": "PydanticAI",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/pydantic/pydantic-ai",
       "github_url_display": "https://github.com/pydantic/pydantic-ai"
     },
@@ -235,7 +205,6 @@
       "rank": 25,
       "name": "Mastra",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/mastra-ai/mastra",
       "github_url_display": "https://github.com/mastra-ai/mastra"
     },
@@ -243,7 +212,6 @@
       "rank": 26,
       "name": "CAMEL-AI / OWL",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/camel-ai/agent-s",
       "github_url_display": "https://github.com/camel-ai/camel"
     },
@@ -251,7 +219,6 @@
       "rank": 27,
       "name": "Google Agent Development Kit (ADK)",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/google/adk-python",
       "github_url_display": "https://github.com/google/adk-python"
     },
@@ -259,7 +226,6 @@
       "rank": 28,
       "name": "goose (Block)",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/block/goose",
       "github_url_display": "https://github.com/block/goose"
     },
@@ -267,7 +233,6 @@
       "rank": 29,
       "name": "MetaGPT",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/geekan/MetaGPT",
       "github_url_display": "https://github.com/FoundationAgents/MetaGPT"
     },
@@ -275,7 +240,6 @@
       "rank": 30,
       "name": "Temporal",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/temporalio/temporal",
       "github_url_display": "https://github.com/temporalio/temporal"
     },
@@ -283,7 +247,6 @@
       "rank": 31,
       "name": "Prefect",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/PrefectHQ/prefect",
       "github_url_display": "https://github.com/PrefectHQ/prefect"
     },
@@ -291,7 +254,6 @@
       "rank": 32,
       "name": "AutoGPT",
       "layer": "Orchestration & Multi-Agent",
-      "license": "MIT",
       "github_url": "https://github.com/Significant-Gravitas/AutoGPT",
       "github_url_display": "https://github.com/Significant-Gravitas/AutoGPT"
     },
@@ -299,7 +261,6 @@
       "rank": 33,
       "name": "RAGFlow",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/infiniflow/ragflow",
       "github_url_display": "https://github.com/infiniflow/ragflow"
     },
@@ -307,7 +268,6 @@
       "rank": 34,
       "name": "AgentScope (Alibaba)",
       "layer": "Orchestration & Multi-Agent",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/modelscope/agentscope",
       "github_url_display": "https://github.com/agentscope-ai/agentscope"
     },
@@ -315,7 +275,6 @@
       "rank": 35,
       "name": "OWL",
       "layer": "Orchestration & Multi-Agent",
-      "license": null,
       "github_url": "https://github.com/camel-ai/owl",
       "github_url_display": "https://github.com/camel-ai/owl"
     },
@@ -323,7 +282,6 @@
       "rank": 36,
       "name": "Agno",
       "layer": "Orchestration & Multi-Agent",
-      "license": null,
       "github_url": "https://github.com/agno-agi/agno",
       "github_url_display": "https://github.com/agno-agi/agno"
     },
@@ -331,7 +289,6 @@
       "rank": 37,
       "name": "DeerFlow",
       "layer": "Orchestration & Multi-Agent",
-      "license": null,
       "github_url": "https://github.com/bytedance/deer-flow",
       "github_url_display": "https://github.com/bytedance/deer-flow"
     },
@@ -339,7 +296,6 @@
       "rank": 38,
       "name": "OpenClaw",
       "layer": "Personal & Coding Agents",
-      "license": "MIT",
       "github_url": "https://github.com/openclaw/openclaw",
       "github_url_display": "https://github.com/openclaw/openclaw"
     },
@@ -347,7 +303,6 @@
       "rank": 39,
       "name": "OpenHands (OpenDevin)",
       "layer": "Personal & Coding Agents",
-      "license": "MIT",
       "github_url": "https://github.com/OpenHands/OpenHands",
       "github_url_display": "https://github.com/OpenHands/OpenHands"
     },
@@ -355,7 +310,6 @@
       "rank": 40,
       "name": "Cline",
       "layer": "Personal & Coding Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/cline/cline",
       "github_url_display": "https://github.com/cline/cline"
     },
@@ -363,7 +317,6 @@
       "rank": 41,
       "name": "Aider",
       "layer": "Personal & Coding Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/Aider-AI/aider",
       "github_url_display": "https://github.com/Aider-AI/aider"
     },
@@ -371,7 +324,6 @@
       "rank": 42,
       "name": "SWE-agent (Princeton)",
       "layer": "Personal & Coding Agents",
-      "license": "MIT",
       "github_url": "https://github.com/princeton-nlp/SWE-agent",
       "github_url_display": "https://github.com/SWE-agent/SWE-agent"
     },
@@ -379,7 +331,6 @@
       "rank": 43,
       "name": "Agentless (UIUC)",
       "layer": "Personal & Coding Agents",
-      "license": "MIT",
       "github_url": "https://github.com/OpenAutoCoder/Agentless",
       "github_url_display": "https://github.com/OpenAutoCoder/Agentless"
     },
@@ -387,7 +338,6 @@
       "rank": 44,
       "name": "GPT Researcher",
       "layer": "Personal & Coding Agents",
-      "license": "MIT",
       "github_url": "https://github.com/assafelovic/gpt-researcher",
       "github_url_display": "https://github.com/assafelovic/gpt-researcher"
     },
@@ -395,7 +345,6 @@
       "rank": 45,
       "name": "Open Interpreter",
       "layer": "Personal & Coding Agents",
-      "license": "AGPL-3.0",
       "github_url": "https://github.com/OpenInterpreter/open-interpreter",
       "github_url_display": "https://github.com/OpenInterpreter/open-interpreter"
     },
@@ -403,7 +352,6 @@
       "rank": 46,
       "name": "Sweep",
       "layer": "Personal & Coding Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/sweepai/sweep",
       "github_url_display": "https://github.com/sweepai/sweep"
     },
@@ -411,7 +359,6 @@
       "rank": 47,
       "name": "OpenCode",
       "layer": "Personal & Coding Agents",
-      "license": null,
       "github_url": "https://github.com/anomalyco/opencode",
       "github_url_display": "https://github.com/anomalyco/opencode"
     },
@@ -419,7 +366,6 @@
       "rank": 48,
       "name": "Kilo",
       "layer": "Personal & Coding Agents",
-      "license": null,
       "github_url": "https://github.com/Kilo-Org/kilocode",
       "github_url_display": "https://github.com/Kilo-Org/kilocode"
     },
@@ -427,7 +373,6 @@
       "rank": 49,
       "name": "Hermes",
       "layer": "Personal & Coding Agents",
-      "license": null,
       "github_url": "https://github.com/NousResearch/hermes-agent",
       "github_url_display": "https://github.com/NousResearch/hermes-agent"
     },
@@ -435,7 +380,6 @@
       "rank": 50,
       "name": "Warp",
       "layer": "Personal & Coding Agents",
-      "license": null,
       "github_url": "https://github.com/warpdotdev/warp",
       "github_url_display": "https://github.com/warpdotdev/warp"
     },
@@ -443,7 +387,6 @@
       "rank": 51,
       "name": "Browser-Use",
       "layer": "Computer Use & Browser Agents",
-      "license": "MIT",
       "github_url": "https://github.com/browser-use/browser-use",
       "github_url_display": "https://github.com/browser-use/browser-use"
     },
@@ -451,7 +394,6 @@
       "rank": 52,
       "name": "Firecrawl",
       "layer": "Computer Use & Browser Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/mendableai/firecrawl",
       "github_url_display": "https://github.com/firecrawl/firecrawl"
     },
@@ -459,7 +401,6 @@
       "rank": 53,
       "name": "Crawl4AI",
       "layer": "Computer Use & Browser Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/unclecode/crawl4ai",
       "github_url_display": "https://github.com/unclecode/crawl4ai"
     },
@@ -467,7 +408,6 @@
       "rank": 54,
       "name": "OSWorld / WindowsAgentArena",
       "layer": "Computer Use & Browser Agents",
-      "license": "MIT",
       "github_url": "https://github.com/xlang-ai/OSWorld",
       "github_url_display": "https://github.com/xlang-ai/OSWorld"
     },
@@ -475,7 +415,6 @@
       "rank": 55,
       "name": "Agent S (Simular AI)",
       "layer": "Computer Use & Browser Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/simular-ai/Agent-S",
       "github_url_display": "https://github.com/simular-ai/Agent-S"
     },
@@ -483,7 +422,6 @@
       "rank": 56,
       "name": "E2B Code Interpreter SDK",
       "layer": "Computer Use & Browser Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/e2b-dev/code-interpreter",
       "github_url_display": "https://github.com/e2b-dev/code-interpreter"
     },
@@ -491,7 +429,6 @@
       "rank": 57,
       "name": "OmniParser (Microsoft Research)",
       "layer": "Computer Use & Browser Agents",
-      "license": "MIT",
       "github_url": "https://github.com/microsoft/OmniParser",
       "github_url_display": "https://github.com/microsoft/OmniParser"
     },
@@ -499,7 +436,6 @@
       "rank": 58,
       "name": "MCP Inspector",
       "layer": "MCP Infrastructure",
-      "license": "MIT",
       "github_url": "https://github.com/modelcontextprotocol/inspector",
       "github_url_display": "https://github.com/modelcontextprotocol/inspector"
     },
@@ -507,7 +443,6 @@
       "rank": 59,
       "name": "FastMCP",
       "layer": "MCP Infrastructure",
-      "license": "MIT",
       "github_url": "https://github.com/PrefectHQ/fastmcp",
       "github_url_display": "https://github.com/PrefectHQ/fastmcp"
     },
@@ -515,7 +450,6 @@
       "rank": 60,
       "name": "LiteMCP",
       "layer": "MCP Infrastructure",
-      "license": "MIT",
       "github_url": "https://github.com/wong2/litemcp",
       "github_url_display": "https://github.com/wong2/litemcp"
     },
@@ -523,7 +457,6 @@
       "rank": 61,
       "name": "IBM MCP Context Forge",
       "layer": "MCP Infrastructure",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/ibm/mcp-context-forge",
       "github_url_display": "https://github.com/ibm/mcp-context-forge"
     },
@@ -531,7 +464,6 @@
       "rank": 62,
       "name": "Unla MCP Gateway",
       "layer": "MCP Infrastructure",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/AmoyLab/Unla",
       "github_url_display": "https://github.com/AmoyLab/Unla"
     },
@@ -539,7 +471,6 @@
       "rank": 63,
       "name": "Letta (MemGPT)",
       "layer": "Memory & Retrieval",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/letta-ai/letta",
       "github_url_display": "https://github.com/letta-ai/letta"
     },
@@ -547,7 +478,6 @@
       "rank": 64,
       "name": "LlamaIndex",
       "layer": "Memory & Retrieval",
-      "license": "MIT",
       "github_url": "https://github.com/run-llama/llama_index",
       "github_url_display": "https://github.com/run-llama/llama_index"
     },
@@ -555,7 +485,6 @@
       "rank": 65,
       "name": "GraphRAG (Microsoft)",
       "layer": "Memory & Retrieval",
-      "license": "MIT",
       "github_url": "https://github.com/microsoft/graphrag",
       "github_url_display": "https://github.com/microsoft/graphrag"
     },
@@ -563,7 +492,6 @@
       "rank": 66,
       "name": "LightRAG",
       "layer": "Memory & Retrieval",
-      "license": "MIT",
       "github_url": "https://github.com/HKUDS/LightRAG",
       "github_url_display": "https://github.com/HKUDS/LightRAG"
     },
@@ -571,7 +499,6 @@
       "rank": 67,
       "name": "DSPy (Stanford)",
       "layer": "Memory & Retrieval",
-      "license": "MIT",
       "github_url": "https://github.com/stanfordnlp/dspy",
       "github_url_display": "https://github.com/stanfordnlp/dspy"
     },
@@ -579,7 +506,6 @@
       "rank": 68,
       "name": "Ragas",
       "layer": "Memory & Retrieval",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/explodinggradients/ragas",
       "github_url_display": "https://github.com/vibrantlabsai/ragas"
     },
@@ -587,7 +513,6 @@
       "rank": 69,
       "name": "Weaviate",
       "layer": "Memory & Retrieval",
-      "license": "BSD-3",
       "github_url": "https://github.com/weaviate/weaviate",
       "github_url_display": "https://github.com/weaviate/weaviate"
     },
@@ -595,7 +520,6 @@
       "rank": 70,
       "name": "Qdrant",
       "layer": "Memory & Retrieval",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/qdrant/qdrant",
       "github_url_display": "https://github.com/qdrant/qdrant"
     },
@@ -603,7 +527,6 @@
       "rank": 71,
       "name": "Chroma",
       "layer": "Memory & Retrieval",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/chroma-core/chroma",
       "github_url_display": "https://github.com/chroma-core/chroma"
     },
@@ -611,7 +534,6 @@
       "rank": 72,
       "name": "Milvus",
       "layer": "Memory & Retrieval",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/milvus-io/milvus",
       "github_url_display": "https://github.com/milvus-io/milvus"
     },
@@ -619,7 +541,6 @@
       "rank": 73,
       "name": "Playwright (Microsoft)",
       "layer": "Tool Use & Integration",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/microsoft/playwright",
       "github_url_display": "https://github.com/microsoft/playwright"
     },
@@ -627,7 +548,6 @@
       "rank": 74,
       "name": "Composio",
       "layer": "Tool Use & Integration",
-      "license": "MIT",
       "github_url": "https://github.com/ComposioHQ/composio",
       "github_url_display": "https://github.com/ComposioHQ/composio"
     },
@@ -635,7 +555,6 @@
       "rank": 75,
       "name": "Instructor",
       "layer": "Tool Use & Integration",
-      "license": "MIT",
       "github_url": "https://github.com/jxnl/instructor",
       "github_url_display": "https://github.com/567-labs/instructor"
     },
@@ -643,7 +562,6 @@
       "rank": 76,
       "name": "Haystack (deepset)",
       "layer": "Tool Use & Integration",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/deepset-ai/haystack",
       "github_url_display": "https://github.com/deepset-ai/haystack"
     },
@@ -651,7 +569,6 @@
       "rank": 77,
       "name": "LiteLLM",
       "layer": "Tool Use & Integration",
-      "license": "MIT",
       "github_url": "https://github.com/BerriAI/litellm",
       "github_url_display": "https://github.com/BerriAI/litellm"
     },
@@ -659,7 +576,6 @@
       "rank": 78,
       "name": "Pathway",
       "layer": "Tool Use & Integration",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/pathwaycom/pathway",
       "github_url_display": "https://github.com/pathwaycom/pathway"
     },
@@ -667,7 +583,6 @@
       "rank": 79,
       "name": "Langfuse",
       "layer": "Evaluation & Observability",
-      "license": "MIT",
       "github_url": "https://github.com/langfuse/langfuse",
       "github_url_display": "https://github.com/langfuse/langfuse"
     },
@@ -675,7 +590,6 @@
       "rank": 80,
       "name": "Arize Phoenix",
       "layer": "Evaluation & Observability",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/Arize-ai/phoenix",
       "github_url_display": "https://github.com/Arize-ai/phoenix"
     },
@@ -683,7 +597,6 @@
       "rank": 81,
       "name": "Comet Opik",
       "layer": "Evaluation & Observability",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/comet-ml/opik",
       "github_url_display": "https://github.com/comet-ml/opik"
     },
@@ -691,7 +604,6 @@
       "rank": 82,
       "name": "DeepEval",
       "layer": "Evaluation & Observability",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/confident-ai/deepeval",
       "github_url_display": "https://github.com/confident-ai/deepeval"
     },
@@ -699,7 +611,6 @@
       "rank": 83,
       "name": "SWE-bench",
       "layer": "Evaluation & Observability",
-      "license": "MIT",
       "github_url": "https://github.com/princeton-nlp/SWE-bench",
       "github_url_display": "https://github.com/SWE-bench/SWE-bench"
     },
@@ -707,7 +618,6 @@
       "rank": 84,
       "name": "Inspect AI (UK AISI)",
       "layer": "Evaluation & Observability",
-      "license": "MIT",
       "github_url": null,
       "github_url_display": null
     },
@@ -715,7 +625,6 @@
       "rank": 85,
       "name": "PromptFoo",
       "layer": "Evaluation & Observability",
-      "license": "MIT",
       "github_url": "https://github.com/promptfoo/promptfoo",
       "github_url_display": "https://github.com/promptfoo/promptfoo"
     },
@@ -723,7 +632,6 @@
       "rank": 86,
       "name": "Qwen2.5 / Qwen3 (Alibaba)",
       "layer": "Agent-Optimized Models",
-      "license": "Apache 2.0",
       "github_url": null,
       "github_url_display": null
     },
@@ -731,7 +639,6 @@
       "rank": 87,
       "name": "xLAM (Salesforce)",
       "layer": "Agent-Optimized Models",
-      "license": "Apache 2.0",
       "github_url": null,
       "github_url_display": null
     },
@@ -739,7 +646,6 @@
       "rank": 88,
       "name": "Gorilla LLM (Berkeley)",
       "layer": "Agent-Optimized Models",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/ShishirPatil/gorilla",
       "github_url_display": "https://github.com/ShishirPatil/gorilla"
     },
@@ -747,7 +653,6 @@
       "rank": 89,
       "name": "Mistral Tool-Use Variants",
       "layer": "Agent-Optimized Models",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/mistralai/mistral-inference",
       "github_url_display": "https://github.com/mistralai/mistral-inference"
     },
@@ -755,7 +660,6 @@
       "rank": 90,
       "name": "Llama 3 Tool-Use (Meta)",
       "layer": "Agent-Optimized Models",
-      "license": "Llama License",
       "github_url": null,
       "github_url_display": null
     },
@@ -763,7 +667,6 @@
       "rank": 91,
       "name": "Granite (IBM)",
       "layer": "Agent-Optimized Models",
-      "license": "Apache 2.0",
       "github_url": null,
       "github_url_display": null
     },
@@ -771,7 +674,6 @@
       "rank": 92,
       "name": "DeepSeek-R1",
       "layer": "Agent-Optimized Models",
-      "license": null,
       "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-r1",
       "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-r1"
     },
@@ -779,7 +681,6 @@
       "rank": 93,
       "name": "DeepSeek-V3.2",
       "layer": "Agent-Optimized Models",
-      "license": null,
       "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-v32",
       "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-v32"
     },
@@ -787,7 +688,6 @@
       "rank": 94,
       "name": "LlamaGuard (Meta)",
       "layer": "Safety & Guardrails",
-      "license": "Llama License",
       "github_url": null,
       "github_url_display": null
     },
@@ -795,7 +695,6 @@
       "rank": 95,
       "name": "NeMo Guardrails (NVIDIA)",
       "layer": "Safety & Guardrails",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/NVIDIA/NeMo-Guardrails",
       "github_url_display": "https://github.com/NVIDIA-NeMo/Guardrails"
     },
@@ -803,7 +702,6 @@
       "rank": 96,
       "name": "Guardrails AI",
       "layer": "Safety & Guardrails",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/guardrails-ai/guardrails",
       "github_url_display": "https://github.com/guardrails-ai/guardrails"
     },
@@ -811,7 +709,6 @@
       "rank": 97,
       "name": "Microsoft PyRIT",
       "layer": "Safety & Guardrails",
-      "license": "MIT",
       "github_url": "https://github.com/Azure/PyRIT",
       "github_url_display": "https://github.com/Azure/PyRIT"
     },
@@ -819,7 +716,6 @@
       "rank": 98,
       "name": "Garak",
       "layer": "Safety & Guardrails",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/leondz/garak",
       "github_url_display": "https://github.com/NVIDIA/garak"
     },
@@ -827,7 +723,6 @@
       "rank": 99,
       "name": "Ollama",
       "layer": "Developer Tooling & SDKs",
-      "license": "MIT",
       "github_url": "https://github.com/ollama/ollama",
       "github_url_display": "https://github.com/ollama/ollama"
     },
@@ -835,7 +730,6 @@
       "rank": 100,
       "name": "Hugging Face Transformers",
       "layer": "Developer Tooling & SDKs",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/huggingface/transformers",
       "github_url_display": "https://github.com/huggingface/transformers"
     },
@@ -843,7 +737,6 @@
       "rank": 101,
       "name": "Continue.dev",
       "layer": "Developer Tooling & SDKs",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/continuedev/continue",
       "github_url_display": "https://github.com/continuedev/continue"
     },
@@ -851,7 +744,6 @@
       "rank": 102,
       "name": "Semantic Router",
       "layer": "Developer Tooling & SDKs",
-      "license": "MIT",
       "github_url": "https://github.com/aurelio-ai/semantic-router",
       "github_url_display": "https://github.com/aurelio-labs/semantic-router"
     },
@@ -859,7 +751,6 @@
       "rank": 103,
       "name": "TaskWeaver (Microsoft)",
       "layer": "Developer Tooling & SDKs",
-      "license": "MIT",
       "github_url": "https://github.com/microsoft/TaskWeaver",
       "github_url_display": "https://github.com/microsoft/TaskWeaver"
     },
@@ -867,7 +758,6 @@
       "rank": 104,
       "name": "pi-mono",
       "layer": "Developer Tooling & SDKs",
-      "license": null,
       "github_url": "https://github.com/badlogic/pi-mono",
       "github_url_display": "https://github.com/badlogic/pi-mono"
     },
@@ -875,7 +765,6 @@
       "rank": 105,
       "name": "Agent Skills",
       "layer": "Developer Tooling & SDKs",
-      "license": null,
       "github_url": "https://github.com/agentskills/agentskills",
       "github_url_display": "https://github.com/agentskills/agentskills"
     },
@@ -883,7 +772,6 @@
       "rank": 106,
       "name": "SkyPilot",
       "layer": "Agent Infrastructure",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/skypilot-org/skypilot",
       "github_url_display": "https://github.com/skypilot-org/skypilot"
     },
@@ -891,7 +779,6 @@
       "rank": 107,
       "name": "KServe",
       "layer": "Agent Infrastructure",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/kserve/kserve",
       "github_url_display": "https://github.com/kserve/kserve"
     },
@@ -899,7 +786,6 @@
       "rank": 108,
       "name": "Daytona",
       "layer": "Agent Infrastructure",
-      "license": "AGPL-3.0",
       "github_url": "https://github.com/daytonaio/daytona",
       "github_url_display": "https://github.com/daytonaio/daytona"
     },
@@ -907,7 +793,6 @@
       "rank": 109,
       "name": "OpenWebUI",
       "layer": "Agent Infrastructure",
-      "license": "MIT",
       "github_url": "https://github.com/open-webui/open-webui",
       "github_url_display": "https://github.com/open-webui/open-webui"
     },
@@ -915,7 +800,6 @@
       "rank": 110,
       "name": "Jan (Local AI)",
       "layer": "Agent Infrastructure",
-      "license": "AGPL-3.0",
       "github_url": "https://github.com/janhq/jan",
       "github_url_display": "https://github.com/janhq/jan"
     },
@@ -923,7 +807,6 @@
       "rank": 111,
       "name": "Livekit Agents",
       "layer": "Voice & Multimodal Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/livekit/agents",
       "github_url_display": "https://github.com/livekit/agents"
     },
@@ -931,7 +814,6 @@
       "rank": 112,
       "name": "Pipecat",
       "layer": "Voice & Multimodal Agents",
-      "license": "BSD-2",
       "github_url": "https://github.com/pipecat-ai/pipecat",
       "github_url_display": "https://github.com/pipecat-ai/pipecat"
     },
@@ -939,7 +821,6 @@
       "rank": 113,
       "name": "PR-Agent (CodiumAI)",
       "layer": "Research & Vertical Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/Codium-ai/pr-agent",
       "github_url_display": "https://github.com/qodo-ai/pr-agent"
     },
@@ -947,7 +828,6 @@
       "rank": 114,
       "name": "Tavily",
       "layer": "Research & Vertical Agents",
-      "license": "Apache 2.0",
       "github_url": "https://github.com/tavily-com/tavily-python",
       "github_url_display": "https://github.com/tavily-ai/tavily-python"
     }

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -113,14 +113,62 @@
     },
     {
       "rank": 10,
-      "name": "Open Agent Network (OAN)",
+      "name": "A2UI",
       "layer": "Protocols & Standards",
-      "license": "Apache 2.0",
-      "github_url": null,
-      "github_url_display": null
+      "license": null,
+      "github_url": "https://github.com/google/a2ui",
+      "github_url_display": "https://github.com/google/a2ui"
     },
     {
       "rank": 11,
+      "name": "Agentic Commerce Protocol (ACP)",
+      "layer": "Protocols & Standards",
+      "license": null,
+      "github_url": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol",
+      "github_url_display": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol"
+    },
+    {
+      "rank": 12,
+      "name": "Universal Commerce Protocol (UCP)",
+      "layer": "Protocols & Standards",
+      "license": null,
+      "github_url": "https://github.com/Universal-Commerce-Protocol/ucp",
+      "github_url_display": "https://github.com/Universal-Commerce-Protocol/ucp"
+    },
+    {
+      "rank": 13,
+      "name": "Agent Payments Protocol (AP2)",
+      "layer": "Protocols & Standards",
+      "license": null,
+      "github_url": "https://github.com/google-agentic-commerce/AP2",
+      "github_url_display": "https://github.com/google-agentic-commerce/AP2"
+    },
+    {
+      "rank": 14,
+      "name": "Machine Payments Protocol (MPP)",
+      "layer": "Protocols & Standards",
+      "license": null,
+      "github_url": "https://github.com/tempoxyz/mpp",
+      "github_url_display": "https://github.com/tempoxyz/mpp"
+    },
+    {
+      "rank": 15,
+      "name": "Open Plugins Specification",
+      "layer": "Protocols & Standards",
+      "license": null,
+      "github_url": "https://github.com/vercel-labs/open-plugin-spec",
+      "github_url_display": "https://github.com/vercel-labs/open-plugin-spec"
+    },
+    {
+      "rank": 16,
+      "name": "Open Responses",
+      "layer": "Protocols & Standards",
+      "license": null,
+      "github_url": "https://github.com/openresponses/openresponses",
+      "github_url_display": "https://github.com/openresponses/openresponses"
+    },
+    {
+      "rank": 17,
       "name": "LangGraph",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -128,7 +176,7 @@
       "github_url_display": "https://github.com/langchain-ai/langgraph"
     },
     {
-      "rank": 12,
+      "rank": 18,
       "name": "LangChain",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -136,7 +184,7 @@
       "github_url_display": "https://github.com/langchain-ai/langchain"
     },
     {
-      "rank": 13,
+      "rank": 19,
       "name": "CrewAI",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -144,7 +192,7 @@
       "github_url_display": "https://github.com/crewAIInc/crewAI"
     },
     {
-      "rank": 14,
+      "rank": 20,
       "name": "AutoGen (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -152,7 +200,7 @@
       "github_url_display": "https://github.com/microsoft/autogen"
     },
     {
-      "rank": 15,
+      "rank": 21,
       "name": "OpenAI Agents SDK",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -160,7 +208,7 @@
       "github_url_display": "https://github.com/openai/openai-agents-python"
     },
     {
-      "rank": 16,
+      "rank": 22,
       "name": "Semantic Kernel (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -168,7 +216,7 @@
       "github_url_display": "https://github.com/microsoft/semantic-kernel"
     },
     {
-      "rank": 17,
+      "rank": 23,
       "name": "SmolAgents (Hugging Face)",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -176,7 +224,7 @@
       "github_url_display": "https://github.com/huggingface/smolagents"
     },
     {
-      "rank": 18,
+      "rank": 24,
       "name": "PydanticAI",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -184,7 +232,7 @@
       "github_url_display": "https://github.com/pydantic/pydantic-ai"
     },
     {
-      "rank": 19,
+      "rank": 25,
       "name": "Mastra",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -192,7 +240,7 @@
       "github_url_display": "https://github.com/mastra-ai/mastra"
     },
     {
-      "rank": 20,
+      "rank": 26,
       "name": "CAMEL-AI / OWL",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -200,7 +248,7 @@
       "github_url_display": "https://github.com/camel-ai/camel"
     },
     {
-      "rank": 21,
+      "rank": 27,
       "name": "Google Agent Development Kit (ADK)",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -208,7 +256,7 @@
       "github_url_display": "https://github.com/google/adk-python"
     },
     {
-      "rank": 22,
+      "rank": 28,
       "name": "goose (Block)",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -216,7 +264,7 @@
       "github_url_display": "https://github.com/block/goose"
     },
     {
-      "rank": 23,
+      "rank": 29,
       "name": "MetaGPT",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -224,7 +272,7 @@
       "github_url_display": "https://github.com/FoundationAgents/MetaGPT"
     },
     {
-      "rank": 24,
+      "rank": 30,
       "name": "Temporal",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -232,7 +280,7 @@
       "github_url_display": "https://github.com/temporalio/temporal"
     },
     {
-      "rank": 25,
+      "rank": 31,
       "name": "Prefect",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -240,7 +288,7 @@
       "github_url_display": "https://github.com/PrefectHQ/prefect"
     },
     {
-      "rank": 26,
+      "rank": 32,
       "name": "AutoGPT",
       "layer": "Orchestration & Multi-Agent",
       "license": "MIT",
@@ -248,7 +296,7 @@
       "github_url_display": "https://github.com/Significant-Gravitas/AutoGPT"
     },
     {
-      "rank": 27,
+      "rank": 33,
       "name": "RAGFlow",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -256,7 +304,7 @@
       "github_url_display": "https://github.com/infiniflow/ragflow"
     },
     {
-      "rank": 28,
+      "rank": 34,
       "name": "AgentScope (Alibaba)",
       "layer": "Orchestration & Multi-Agent",
       "license": "Apache 2.0",
@@ -264,7 +312,31 @@
       "github_url_display": "https://github.com/agentscope-ai/agentscope"
     },
     {
-      "rank": 29,
+      "rank": 35,
+      "name": "OWL",
+      "layer": "Orchestration & Multi-Agent",
+      "license": null,
+      "github_url": "https://github.com/camel-ai/owl",
+      "github_url_display": "https://github.com/camel-ai/owl"
+    },
+    {
+      "rank": 36,
+      "name": "Agno",
+      "layer": "Orchestration & Multi-Agent",
+      "license": null,
+      "github_url": "https://github.com/agno-agi/agno",
+      "github_url_display": "https://github.com/agno-agi/agno"
+    },
+    {
+      "rank": 37,
+      "name": "DeerFlow",
+      "layer": "Orchestration & Multi-Agent",
+      "license": null,
+      "github_url": "https://github.com/bytedance/deer-flow",
+      "github_url_display": "https://github.com/bytedance/deer-flow"
+    },
+    {
+      "rank": 38,
       "name": "OpenClaw",
       "layer": "Personal & Coding Agents",
       "license": "MIT",
@@ -272,7 +344,7 @@
       "github_url_display": "https://github.com/openclaw/openclaw"
     },
     {
-      "rank": 30,
+      "rank": 39,
       "name": "OpenHands (OpenDevin)",
       "layer": "Personal & Coding Agents",
       "license": "MIT",
@@ -280,7 +352,7 @@
       "github_url_display": "https://github.com/OpenHands/OpenHands"
     },
     {
-      "rank": 31,
+      "rank": 40,
       "name": "Cline",
       "layer": "Personal & Coding Agents",
       "license": "Apache 2.0",
@@ -288,7 +360,7 @@
       "github_url_display": "https://github.com/cline/cline"
     },
     {
-      "rank": 32,
+      "rank": 41,
       "name": "Aider",
       "layer": "Personal & Coding Agents",
       "license": "Apache 2.0",
@@ -296,7 +368,7 @@
       "github_url_display": "https://github.com/Aider-AI/aider"
     },
     {
-      "rank": 33,
+      "rank": 42,
       "name": "SWE-agent (Princeton)",
       "layer": "Personal & Coding Agents",
       "license": "MIT",
@@ -304,7 +376,7 @@
       "github_url_display": "https://github.com/SWE-agent/SWE-agent"
     },
     {
-      "rank": 34,
+      "rank": 43,
       "name": "Agentless (UIUC)",
       "layer": "Personal & Coding Agents",
       "license": "MIT",
@@ -312,7 +384,7 @@
       "github_url_display": "https://github.com/OpenAutoCoder/Agentless"
     },
     {
-      "rank": 35,
+      "rank": 44,
       "name": "GPT Researcher",
       "layer": "Personal & Coding Agents",
       "license": "MIT",
@@ -320,7 +392,7 @@
       "github_url_display": "https://github.com/assafelovic/gpt-researcher"
     },
     {
-      "rank": 36,
+      "rank": 45,
       "name": "Open Interpreter",
       "layer": "Personal & Coding Agents",
       "license": "AGPL-3.0",
@@ -328,7 +400,7 @@
       "github_url_display": "https://github.com/OpenInterpreter/open-interpreter"
     },
     {
-      "rank": 37,
+      "rank": 46,
       "name": "Sweep",
       "layer": "Personal & Coding Agents",
       "license": "Apache 2.0",
@@ -336,7 +408,39 @@
       "github_url_display": "https://github.com/sweepai/sweep"
     },
     {
-      "rank": 38,
+      "rank": 47,
+      "name": "OpenCode",
+      "layer": "Personal & Coding Agents",
+      "license": null,
+      "github_url": "https://github.com/anomalyco/opencode",
+      "github_url_display": "https://github.com/anomalyco/opencode"
+    },
+    {
+      "rank": 48,
+      "name": "Kilo",
+      "layer": "Personal & Coding Agents",
+      "license": null,
+      "github_url": "https://github.com/Kilo-Org/kilocode",
+      "github_url_display": "https://github.com/Kilo-Org/kilocode"
+    },
+    {
+      "rank": 49,
+      "name": "Hermes",
+      "layer": "Personal & Coding Agents",
+      "license": null,
+      "github_url": "https://github.com/NousResearch/hermes-agent",
+      "github_url_display": "https://github.com/NousResearch/hermes-agent"
+    },
+    {
+      "rank": 50,
+      "name": "Warp",
+      "layer": "Personal & Coding Agents",
+      "license": null,
+      "github_url": "https://github.com/warpdotdev/warp",
+      "github_url_display": "https://github.com/warpdotdev/warp"
+    },
+    {
+      "rank": 51,
       "name": "Browser-Use",
       "layer": "Computer Use & Browser Agents",
       "license": "MIT",
@@ -344,7 +448,7 @@
       "github_url_display": "https://github.com/browser-use/browser-use"
     },
     {
-      "rank": 39,
+      "rank": 52,
       "name": "Firecrawl",
       "layer": "Computer Use & Browser Agents",
       "license": "Apache 2.0",
@@ -352,7 +456,7 @@
       "github_url_display": "https://github.com/firecrawl/firecrawl"
     },
     {
-      "rank": 40,
+      "rank": 53,
       "name": "Crawl4AI",
       "layer": "Computer Use & Browser Agents",
       "license": "Apache 2.0",
@@ -360,7 +464,7 @@
       "github_url_display": "https://github.com/unclecode/crawl4ai"
     },
     {
-      "rank": 41,
+      "rank": 54,
       "name": "OSWorld / WindowsAgentArena",
       "layer": "Computer Use & Browser Agents",
       "license": "MIT",
@@ -368,7 +472,7 @@
       "github_url_display": "https://github.com/xlang-ai/OSWorld"
     },
     {
-      "rank": 42,
+      "rank": 55,
       "name": "Agent S (Simular AI)",
       "layer": "Computer Use & Browser Agents",
       "license": "Apache 2.0",
@@ -376,7 +480,7 @@
       "github_url_display": "https://github.com/simular-ai/Agent-S"
     },
     {
-      "rank": 43,
+      "rank": 56,
       "name": "E2B Code Interpreter SDK",
       "layer": "Computer Use & Browser Agents",
       "license": "Apache 2.0",
@@ -384,7 +488,7 @@
       "github_url_display": "https://github.com/e2b-dev/code-interpreter"
     },
     {
-      "rank": 44,
+      "rank": 57,
       "name": "OmniParser (Microsoft Research)",
       "layer": "Computer Use & Browser Agents",
       "license": "MIT",
@@ -392,7 +496,7 @@
       "github_url_display": "https://github.com/microsoft/OmniParser"
     },
     {
-      "rank": 45,
+      "rank": 58,
       "name": "MCP Inspector",
       "layer": "MCP Infrastructure",
       "license": "MIT",
@@ -400,7 +504,7 @@
       "github_url_display": "https://github.com/modelcontextprotocol/inspector"
     },
     {
-      "rank": 46,
+      "rank": 59,
       "name": "FastMCP",
       "layer": "MCP Infrastructure",
       "license": "MIT",
@@ -408,7 +512,7 @@
       "github_url_display": "https://github.com/PrefectHQ/fastmcp"
     },
     {
-      "rank": 47,
+      "rank": 60,
       "name": "LiteMCP",
       "layer": "MCP Infrastructure",
       "license": "MIT",
@@ -416,7 +520,7 @@
       "github_url_display": "https://github.com/wong2/litemcp"
     },
     {
-      "rank": 48,
+      "rank": 61,
       "name": "IBM MCP Context Forge",
       "layer": "MCP Infrastructure",
       "license": "Apache 2.0",
@@ -424,7 +528,7 @@
       "github_url_display": "https://github.com/ibm/mcp-context-forge"
     },
     {
-      "rank": 49,
+      "rank": 62,
       "name": "Unla MCP Gateway",
       "layer": "MCP Infrastructure",
       "license": "Apache 2.0",
@@ -432,7 +536,7 @@
       "github_url_display": "https://github.com/AmoyLab/Unla"
     },
     {
-      "rank": 50,
+      "rank": 63,
       "name": "Letta (MemGPT)",
       "layer": "Memory & Retrieval",
       "license": "Apache 2.0",
@@ -440,7 +544,7 @@
       "github_url_display": "https://github.com/letta-ai/letta"
     },
     {
-      "rank": 51,
+      "rank": 64,
       "name": "LlamaIndex",
       "layer": "Memory & Retrieval",
       "license": "MIT",
@@ -448,7 +552,7 @@
       "github_url_display": "https://github.com/run-llama/llama_index"
     },
     {
-      "rank": 52,
+      "rank": 65,
       "name": "GraphRAG (Microsoft)",
       "layer": "Memory & Retrieval",
       "license": "MIT",
@@ -456,7 +560,7 @@
       "github_url_display": "https://github.com/microsoft/graphrag"
     },
     {
-      "rank": 53,
+      "rank": 66,
       "name": "LightRAG",
       "layer": "Memory & Retrieval",
       "license": "MIT",
@@ -464,7 +568,7 @@
       "github_url_display": "https://github.com/HKUDS/LightRAG"
     },
     {
-      "rank": 54,
+      "rank": 67,
       "name": "DSPy (Stanford)",
       "layer": "Memory & Retrieval",
       "license": "MIT",
@@ -472,7 +576,7 @@
       "github_url_display": "https://github.com/stanfordnlp/dspy"
     },
     {
-      "rank": 55,
+      "rank": 68,
       "name": "Ragas",
       "layer": "Memory & Retrieval",
       "license": "Apache 2.0",
@@ -480,7 +584,7 @@
       "github_url_display": "https://github.com/vibrantlabsai/ragas"
     },
     {
-      "rank": 56,
+      "rank": 69,
       "name": "Weaviate",
       "layer": "Memory & Retrieval",
       "license": "BSD-3",
@@ -488,7 +592,7 @@
       "github_url_display": "https://github.com/weaviate/weaviate"
     },
     {
-      "rank": 57,
+      "rank": 70,
       "name": "Qdrant",
       "layer": "Memory & Retrieval",
       "license": "Apache 2.0",
@@ -496,7 +600,7 @@
       "github_url_display": "https://github.com/qdrant/qdrant"
     },
     {
-      "rank": 58,
+      "rank": 71,
       "name": "Chroma",
       "layer": "Memory & Retrieval",
       "license": "Apache 2.0",
@@ -504,7 +608,7 @@
       "github_url_display": "https://github.com/chroma-core/chroma"
     },
     {
-      "rank": 59,
+      "rank": 72,
       "name": "Milvus",
       "layer": "Memory & Retrieval",
       "license": "Apache 2.0",
@@ -512,7 +616,7 @@
       "github_url_display": "https://github.com/milvus-io/milvus"
     },
     {
-      "rank": 60,
+      "rank": 73,
       "name": "Playwright (Microsoft)",
       "layer": "Tool Use & Integration",
       "license": "Apache 2.0",
@@ -520,7 +624,7 @@
       "github_url_display": "https://github.com/microsoft/playwright"
     },
     {
-      "rank": 61,
+      "rank": 74,
       "name": "Composio",
       "layer": "Tool Use & Integration",
       "license": "MIT",
@@ -528,7 +632,7 @@
       "github_url_display": "https://github.com/ComposioHQ/composio"
     },
     {
-      "rank": 62,
+      "rank": 75,
       "name": "Instructor",
       "layer": "Tool Use & Integration",
       "license": "MIT",
@@ -536,7 +640,7 @@
       "github_url_display": "https://github.com/567-labs/instructor"
     },
     {
-      "rank": 63,
+      "rank": 76,
       "name": "Haystack (deepset)",
       "layer": "Tool Use & Integration",
       "license": "Apache 2.0",
@@ -544,7 +648,7 @@
       "github_url_display": "https://github.com/deepset-ai/haystack"
     },
     {
-      "rank": 64,
+      "rank": 77,
       "name": "LiteLLM",
       "layer": "Tool Use & Integration",
       "license": "MIT",
@@ -552,7 +656,7 @@
       "github_url_display": "https://github.com/BerriAI/litellm"
     },
     {
-      "rank": 65,
+      "rank": 78,
       "name": "Pathway",
       "layer": "Tool Use & Integration",
       "license": "Apache 2.0",
@@ -560,7 +664,7 @@
       "github_url_display": "https://github.com/pathwaycom/pathway"
     },
     {
-      "rank": 66,
+      "rank": 79,
       "name": "Langfuse",
       "layer": "Evaluation & Observability",
       "license": "MIT",
@@ -568,7 +672,7 @@
       "github_url_display": "https://github.com/langfuse/langfuse"
     },
     {
-      "rank": 67,
+      "rank": 80,
       "name": "Arize Phoenix",
       "layer": "Evaluation & Observability",
       "license": "Apache 2.0",
@@ -576,7 +680,7 @@
       "github_url_display": "https://github.com/Arize-ai/phoenix"
     },
     {
-      "rank": 68,
+      "rank": 81,
       "name": "Comet Opik",
       "layer": "Evaluation & Observability",
       "license": "Apache 2.0",
@@ -584,7 +688,7 @@
       "github_url_display": "https://github.com/comet-ml/opik"
     },
     {
-      "rank": 69,
+      "rank": 82,
       "name": "DeepEval",
       "layer": "Evaluation & Observability",
       "license": "Apache 2.0",
@@ -592,15 +696,7 @@
       "github_url_display": "https://github.com/confident-ai/deepeval"
     },
     {
-      "rank": 70,
-      "name": "GAIA Benchmark",
-      "layer": "Evaluation & Observability",
-      "license": "Apache 2.0",
-      "github_url": null,
-      "github_url_display": null
-    },
-    {
-      "rank": 71,
+      "rank": 83,
       "name": "SWE-bench",
       "layer": "Evaluation & Observability",
       "license": "MIT",
@@ -608,7 +704,7 @@
       "github_url_display": "https://github.com/SWE-bench/SWE-bench"
     },
     {
-      "rank": 72,
+      "rank": 84,
       "name": "Inspect AI (UK AISI)",
       "layer": "Evaluation & Observability",
       "license": "MIT",
@@ -616,7 +712,7 @@
       "github_url_display": null
     },
     {
-      "rank": 73,
+      "rank": 85,
       "name": "PromptFoo",
       "layer": "Evaluation & Observability",
       "license": "MIT",
@@ -624,7 +720,7 @@
       "github_url_display": "https://github.com/promptfoo/promptfoo"
     },
     {
-      "rank": 74,
+      "rank": 86,
       "name": "Qwen2.5 / Qwen3 (Alibaba)",
       "layer": "Agent-Optimized Models",
       "license": "Apache 2.0",
@@ -632,15 +728,7 @@
       "github_url_display": null
     },
     {
-      "rank": 75,
-      "name": "DeepSeek-V3 / R1",
-      "layer": "Agent-Optimized Models",
-      "license": "MIT",
-      "github_url": null,
-      "github_url_display": null
-    },
-    {
-      "rank": 76,
+      "rank": 87,
       "name": "xLAM (Salesforce)",
       "layer": "Agent-Optimized Models",
       "license": "Apache 2.0",
@@ -648,7 +736,7 @@
       "github_url_display": null
     },
     {
-      "rank": 77,
+      "rank": 88,
       "name": "Gorilla LLM (Berkeley)",
       "layer": "Agent-Optimized Models",
       "license": "Apache 2.0",
@@ -656,7 +744,7 @@
       "github_url_display": "https://github.com/ShishirPatil/gorilla"
     },
     {
-      "rank": 78,
+      "rank": 89,
       "name": "Mistral Tool-Use Variants",
       "layer": "Agent-Optimized Models",
       "license": "Apache 2.0",
@@ -664,7 +752,7 @@
       "github_url_display": "https://github.com/mistralai/mistral-inference"
     },
     {
-      "rank": 79,
+      "rank": 90,
       "name": "Llama 3 Tool-Use (Meta)",
       "layer": "Agent-Optimized Models",
       "license": "Llama License",
@@ -672,7 +760,7 @@
       "github_url_display": null
     },
     {
-      "rank": 80,
+      "rank": 91,
       "name": "Granite (IBM)",
       "layer": "Agent-Optimized Models",
       "license": "Apache 2.0",
@@ -680,7 +768,23 @@
       "github_url_display": null
     },
     {
-      "rank": 81,
+      "rank": 92,
+      "name": "DeepSeek-R1",
+      "layer": "Agent-Optimized Models",
+      "license": null,
+      "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-r1",
+      "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-r1"
+    },
+    {
+      "rank": 93,
+      "name": "DeepSeek-V3.2",
+      "layer": "Agent-Optimized Models",
+      "license": null,
+      "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-v32",
+      "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-v32"
+    },
+    {
+      "rank": 94,
       "name": "LlamaGuard (Meta)",
       "layer": "Safety & Guardrails",
       "license": "Llama License",
@@ -688,7 +792,7 @@
       "github_url_display": null
     },
     {
-      "rank": 82,
+      "rank": 95,
       "name": "NeMo Guardrails (NVIDIA)",
       "layer": "Safety & Guardrails",
       "license": "Apache 2.0",
@@ -696,7 +800,7 @@
       "github_url_display": "https://github.com/NVIDIA-NeMo/Guardrails"
     },
     {
-      "rank": 83,
+      "rank": 96,
       "name": "Guardrails AI",
       "layer": "Safety & Guardrails",
       "license": "Apache 2.0",
@@ -704,7 +808,7 @@
       "github_url_display": "https://github.com/guardrails-ai/guardrails"
     },
     {
-      "rank": 84,
+      "rank": 97,
       "name": "Microsoft PyRIT",
       "layer": "Safety & Guardrails",
       "license": "MIT",
@@ -712,7 +816,7 @@
       "github_url_display": "https://github.com/Azure/PyRIT"
     },
     {
-      "rank": 85,
+      "rank": 98,
       "name": "Garak",
       "layer": "Safety & Guardrails",
       "license": "Apache 2.0",
@@ -720,7 +824,7 @@
       "github_url_display": "https://github.com/NVIDIA/garak"
     },
     {
-      "rank": 86,
+      "rank": 99,
       "name": "Ollama",
       "layer": "Developer Tooling & SDKs",
       "license": "MIT",
@@ -728,7 +832,7 @@
       "github_url_display": "https://github.com/ollama/ollama"
     },
     {
-      "rank": 87,
+      "rank": 100,
       "name": "Hugging Face Transformers",
       "layer": "Developer Tooling & SDKs",
       "license": "Apache 2.0",
@@ -736,7 +840,7 @@
       "github_url_display": "https://github.com/huggingface/transformers"
     },
     {
-      "rank": 88,
+      "rank": 101,
       "name": "Continue.dev",
       "layer": "Developer Tooling & SDKs",
       "license": "Apache 2.0",
@@ -744,7 +848,7 @@
       "github_url_display": "https://github.com/continuedev/continue"
     },
     {
-      "rank": 89,
+      "rank": 102,
       "name": "Semantic Router",
       "layer": "Developer Tooling & SDKs",
       "license": "MIT",
@@ -752,7 +856,7 @@
       "github_url_display": "https://github.com/aurelio-labs/semantic-router"
     },
     {
-      "rank": 90,
+      "rank": 103,
       "name": "TaskWeaver (Microsoft)",
       "layer": "Developer Tooling & SDKs",
       "license": "MIT",
@@ -760,7 +864,23 @@
       "github_url_display": "https://github.com/microsoft/TaskWeaver"
     },
     {
-      "rank": 91,
+      "rank": 104,
+      "name": "pi-mono",
+      "layer": "Developer Tooling & SDKs",
+      "license": null,
+      "github_url": "https://github.com/badlogic/pi-mono",
+      "github_url_display": "https://github.com/badlogic/pi-mono"
+    },
+    {
+      "rank": 105,
+      "name": "Agent Skills",
+      "layer": "Developer Tooling & SDKs",
+      "license": null,
+      "github_url": "https://github.com/agentskills/agentskills",
+      "github_url_display": "https://github.com/agentskills/agentskills"
+    },
+    {
+      "rank": 106,
       "name": "SkyPilot",
       "layer": "Agent Infrastructure",
       "license": "Apache 2.0",
@@ -768,7 +888,7 @@
       "github_url_display": "https://github.com/skypilot-org/skypilot"
     },
     {
-      "rank": 92,
+      "rank": 107,
       "name": "KServe",
       "layer": "Agent Infrastructure",
       "license": "Apache 2.0",
@@ -776,7 +896,7 @@
       "github_url_display": "https://github.com/kserve/kserve"
     },
     {
-      "rank": 93,
+      "rank": 108,
       "name": "Daytona",
       "layer": "Agent Infrastructure",
       "license": "AGPL-3.0",
@@ -784,7 +904,7 @@
       "github_url_display": "https://github.com/daytonaio/daytona"
     },
     {
-      "rank": 94,
+      "rank": 109,
       "name": "OpenWebUI",
       "layer": "Agent Infrastructure",
       "license": "MIT",
@@ -792,7 +912,7 @@
       "github_url_display": "https://github.com/open-webui/open-webui"
     },
     {
-      "rank": 95,
+      "rank": 110,
       "name": "Jan (Local AI)",
       "layer": "Agent Infrastructure",
       "license": "AGPL-3.0",
@@ -800,7 +920,7 @@
       "github_url_display": "https://github.com/janhq/jan"
     },
     {
-      "rank": 96,
+      "rank": 111,
       "name": "Livekit Agents",
       "layer": "Voice & Multimodal Agents",
       "license": "Apache 2.0",
@@ -808,7 +928,7 @@
       "github_url_display": "https://github.com/livekit/agents"
     },
     {
-      "rank": 97,
+      "rank": 112,
       "name": "Pipecat",
       "layer": "Voice & Multimodal Agents",
       "license": "BSD-2",
@@ -816,7 +936,7 @@
       "github_url_display": "https://github.com/pipecat-ai/pipecat"
     },
     {
-      "rank": 98,
+      "rank": 113,
       "name": "PR-Agent (CodiumAI)",
       "layer": "Research & Vertical Agents",
       "license": "Apache 2.0",
@@ -824,20 +944,12 @@
       "github_url_display": "https://github.com/qodo-ai/pr-agent"
     },
     {
-      "rank": 99,
+      "rank": 114,
       "name": "Tavily",
       "layer": "Research & Vertical Agents",
       "license": "Apache 2.0",
       "github_url": "https://github.com/tavily-com/tavily-python",
       "github_url_display": "https://github.com/tavily-ai/tavily-python"
-    },
-    {
-      "rank": 100,
-      "name": "Generative Agents (Stanford)",
-      "layer": "Research & Vertical Agents",
-      "license": "MIT",
-      "github_url": "https://github.com/joonspk-research/generative_agents",
-      "github_url_display": "https://github.com/joonspk-research/generative_agents"
     }
   ]
 }

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -6,12 +6,6 @@
       "description": "Top-100 agentic AI projects metadata.",
       "fields": [
         {
-          "name": "rank",
-          "type": "number",
-          "description": "Project rank",
-          "optional": false
-        },
-        {
           "name": "name",
           "type": "string",
           "description": "Project display name",
@@ -34,798 +28,684 @@
   },
   "data": [
     {
-      "rank": 1,
       "name": "MCP (Model Context Protocol)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "github_url_display": "https://github.com/modelcontextprotocol/modelcontextprotocol"
     },
     {
-      "rank": 2,
       "name": "Agent2Agent (A2A) Protocol",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/google/A2A",
       "github_url_display": "https://github.com/a2aproject/A2A"
     },
     {
-      "rank": 3,
       "name": "AGENTS.md",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agentsmd/agentsmd",
       "github_url_display": "https://github.com/agentsmd/agents.md"
     },
     {
-      "rank": 4,
       "name": "AGNTCY",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agntcy/acp-spec",
       "github_url_display": "https://github.com/agntcy/acp-spec"
     },
     {
-      "rank": 5,
       "name": "OpenTelemetry AI Semantic Conventions",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/open-telemetry/semantic-conventions",
       "github_url_display": "https://github.com/open-telemetry/semantic-conventions"
     },
     {
-      "rank": 6,
       "name": "OpenAPI Specification",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/OAI/OpenAPI-Specification",
       "github_url_display": "https://github.com/OAI/OpenAPI-Specification"
     },
     {
-      "rank": 7,
       "name": "W3C DID / Verifiable Credentials",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/w3c/did-core",
       "github_url_display": "https://github.com/w3c/did"
     },
     {
-      "rank": 8,
       "name": "SLIM (LF)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agntcy/slim",
       "github_url_display": "https://github.com/agntcy/slim"
     },
     {
-      "rank": 9,
       "name": "Open Agent Schema Framework (OASF)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agntcy/oasf",
       "github_url_display": "https://github.com/agntcy/oasf"
     },
     {
-      "rank": 10,
       "name": "A2UI",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/google/a2ui",
       "github_url_display": "https://github.com/google/a2ui"
     },
     {
-      "rank": 11,
       "name": "Agentic Commerce Protocol (ACP)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol",
       "github_url_display": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol"
     },
     {
-      "rank": 12,
       "name": "Universal Commerce Protocol (UCP)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/Universal-Commerce-Protocol/ucp",
       "github_url_display": "https://github.com/Universal-Commerce-Protocol/ucp"
     },
     {
-      "rank": 13,
       "name": "Agent Payments Protocol (AP2)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/google-agentic-commerce/AP2",
       "github_url_display": "https://github.com/google-agentic-commerce/AP2"
     },
     {
-      "rank": 14,
       "name": "Machine Payments Protocol (MPP)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/tempoxyz/mpp",
       "github_url_display": "https://github.com/tempoxyz/mpp"
     },
     {
-      "rank": 15,
       "name": "Open Plugins Specification",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/vercel-labs/open-plugin-spec",
       "github_url_display": "https://github.com/vercel-labs/open-plugin-spec"
     },
     {
-      "rank": 16,
       "name": "Open Responses",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/openresponses/openresponses",
       "github_url_display": "https://github.com/openresponses/openresponses"
     },
     {
-      "rank": 17,
       "name": "LangGraph",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/langchain-ai/langgraph",
       "github_url_display": "https://github.com/langchain-ai/langgraph"
     },
     {
-      "rank": 18,
       "name": "LangChain",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/langchain-ai/langchain",
       "github_url_display": "https://github.com/langchain-ai/langchain"
     },
     {
-      "rank": 19,
       "name": "CrewAI",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/crewAIInc/crewAI",
       "github_url_display": "https://github.com/crewAIInc/crewAI"
     },
     {
-      "rank": 20,
       "name": "AutoGen (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/microsoft/autogen",
       "github_url_display": "https://github.com/microsoft/autogen"
     },
     {
-      "rank": 21,
       "name": "OpenAI Agents SDK",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/openai/openai-agents-python",
       "github_url_display": "https://github.com/openai/openai-agents-python"
     },
     {
-      "rank": 22,
       "name": "Semantic Kernel (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/microsoft/semantic-kernel",
       "github_url_display": "https://github.com/microsoft/semantic-kernel"
     },
     {
-      "rank": 23,
       "name": "SmolAgents (Hugging Face)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/huggingface/smolagents",
       "github_url_display": "https://github.com/huggingface/smolagents"
     },
     {
-      "rank": 24,
       "name": "PydanticAI",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/pydantic/pydantic-ai",
       "github_url_display": "https://github.com/pydantic/pydantic-ai"
     },
     {
-      "rank": 25,
       "name": "Mastra",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/mastra-ai/mastra",
       "github_url_display": "https://github.com/mastra-ai/mastra"
     },
     {
-      "rank": 26,
       "name": "CAMEL-AI / OWL",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/camel-ai/agent-s",
       "github_url_display": "https://github.com/camel-ai/camel"
     },
     {
-      "rank": 27,
       "name": "Google Agent Development Kit (ADK)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/google/adk-python",
       "github_url_display": "https://github.com/google/adk-python"
     },
     {
-      "rank": 28,
       "name": "goose (Block)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/block/goose",
       "github_url_display": "https://github.com/block/goose"
     },
     {
-      "rank": 29,
       "name": "MetaGPT",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/geekan/MetaGPT",
       "github_url_display": "https://github.com/FoundationAgents/MetaGPT"
     },
     {
-      "rank": 30,
       "name": "Temporal",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/temporalio/temporal",
       "github_url_display": "https://github.com/temporalio/temporal"
     },
     {
-      "rank": 31,
       "name": "Prefect",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/PrefectHQ/prefect",
       "github_url_display": "https://github.com/PrefectHQ/prefect"
     },
     {
-      "rank": 32,
       "name": "AutoGPT",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/Significant-Gravitas/AutoGPT",
       "github_url_display": "https://github.com/Significant-Gravitas/AutoGPT"
     },
     {
-      "rank": 33,
       "name": "RAGFlow",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/infiniflow/ragflow",
       "github_url_display": "https://github.com/infiniflow/ragflow"
     },
     {
-      "rank": 34,
       "name": "AgentScope (Alibaba)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/modelscope/agentscope",
       "github_url_display": "https://github.com/agentscope-ai/agentscope"
     },
     {
-      "rank": 35,
       "name": "OWL",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/camel-ai/owl",
       "github_url_display": "https://github.com/camel-ai/owl"
     },
     {
-      "rank": 36,
       "name": "Agno",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/agno-agi/agno",
       "github_url_display": "https://github.com/agno-agi/agno"
     },
     {
-      "rank": 37,
       "name": "DeerFlow",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/bytedance/deer-flow",
       "github_url_display": "https://github.com/bytedance/deer-flow"
     },
     {
-      "rank": 38,
       "name": "OpenClaw",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/openclaw/openclaw",
       "github_url_display": "https://github.com/openclaw/openclaw"
     },
     {
-      "rank": 39,
       "name": "OpenHands (OpenDevin)",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/OpenHands/OpenHands",
       "github_url_display": "https://github.com/OpenHands/OpenHands"
     },
     {
-      "rank": 40,
       "name": "Cline",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/cline/cline",
       "github_url_display": "https://github.com/cline/cline"
     },
     {
-      "rank": 41,
       "name": "Aider",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/Aider-AI/aider",
       "github_url_display": "https://github.com/Aider-AI/aider"
     },
     {
-      "rank": 42,
       "name": "SWE-agent (Princeton)",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/princeton-nlp/SWE-agent",
       "github_url_display": "https://github.com/SWE-agent/SWE-agent"
     },
     {
-      "rank": 43,
       "name": "Agentless (UIUC)",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/OpenAutoCoder/Agentless",
       "github_url_display": "https://github.com/OpenAutoCoder/Agentless"
     },
     {
-      "rank": 44,
       "name": "GPT Researcher",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/assafelovic/gpt-researcher",
       "github_url_display": "https://github.com/assafelovic/gpt-researcher"
     },
     {
-      "rank": 45,
       "name": "Open Interpreter",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/OpenInterpreter/open-interpreter",
       "github_url_display": "https://github.com/OpenInterpreter/open-interpreter"
     },
     {
-      "rank": 46,
       "name": "Sweep",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/sweepai/sweep",
       "github_url_display": "https://github.com/sweepai/sweep"
     },
     {
-      "rank": 47,
       "name": "OpenCode",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/anomalyco/opencode",
       "github_url_display": "https://github.com/anomalyco/opencode"
     },
     {
-      "rank": 48,
       "name": "Kilo",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/Kilo-Org/kilocode",
       "github_url_display": "https://github.com/Kilo-Org/kilocode"
     },
     {
-      "rank": 49,
       "name": "Hermes",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/NousResearch/hermes-agent",
       "github_url_display": "https://github.com/NousResearch/hermes-agent"
     },
     {
-      "rank": 50,
       "name": "Warp",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/warpdotdev/warp",
       "github_url_display": "https://github.com/warpdotdev/warp"
     },
     {
-      "rank": 51,
       "name": "Browser-Use",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/browser-use/browser-use",
       "github_url_display": "https://github.com/browser-use/browser-use"
     },
     {
-      "rank": 52,
       "name": "Firecrawl",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/mendableai/firecrawl",
       "github_url_display": "https://github.com/firecrawl/firecrawl"
     },
     {
-      "rank": 53,
       "name": "Crawl4AI",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/unclecode/crawl4ai",
       "github_url_display": "https://github.com/unclecode/crawl4ai"
     },
     {
-      "rank": 54,
       "name": "OSWorld / WindowsAgentArena",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/xlang-ai/OSWorld",
       "github_url_display": "https://github.com/xlang-ai/OSWorld"
     },
     {
-      "rank": 55,
       "name": "Agent S (Simular AI)",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/simular-ai/Agent-S",
       "github_url_display": "https://github.com/simular-ai/Agent-S"
     },
     {
-      "rank": 56,
       "name": "E2B Code Interpreter SDK",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/e2b-dev/code-interpreter",
       "github_url_display": "https://github.com/e2b-dev/code-interpreter"
     },
     {
-      "rank": 57,
       "name": "OmniParser (Microsoft Research)",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/microsoft/OmniParser",
       "github_url_display": "https://github.com/microsoft/OmniParser"
     },
     {
-      "rank": 58,
       "name": "MCP Inspector",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/modelcontextprotocol/inspector",
       "github_url_display": "https://github.com/modelcontextprotocol/inspector"
     },
     {
-      "rank": 59,
       "name": "FastMCP",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/PrefectHQ/fastmcp",
       "github_url_display": "https://github.com/PrefectHQ/fastmcp"
     },
     {
-      "rank": 60,
       "name": "LiteMCP",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/wong2/litemcp",
       "github_url_display": "https://github.com/wong2/litemcp"
     },
     {
-      "rank": 61,
       "name": "IBM MCP Context Forge",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/ibm/mcp-context-forge",
       "github_url_display": "https://github.com/ibm/mcp-context-forge"
     },
     {
-      "rank": 62,
       "name": "Unla MCP Gateway",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/AmoyLab/Unla",
       "github_url_display": "https://github.com/AmoyLab/Unla"
     },
     {
-      "rank": 63,
       "name": "Letta (MemGPT)",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/letta-ai/letta",
       "github_url_display": "https://github.com/letta-ai/letta"
     },
     {
-      "rank": 64,
       "name": "LlamaIndex",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/run-llama/llama_index",
       "github_url_display": "https://github.com/run-llama/llama_index"
     },
     {
-      "rank": 65,
       "name": "GraphRAG (Microsoft)",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/microsoft/graphrag",
       "github_url_display": "https://github.com/microsoft/graphrag"
     },
     {
-      "rank": 66,
       "name": "LightRAG",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/HKUDS/LightRAG",
       "github_url_display": "https://github.com/HKUDS/LightRAG"
     },
     {
-      "rank": 67,
       "name": "DSPy (Stanford)",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/stanfordnlp/dspy",
       "github_url_display": "https://github.com/stanfordnlp/dspy"
     },
     {
-      "rank": 68,
       "name": "Ragas",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/explodinggradients/ragas",
       "github_url_display": "https://github.com/vibrantlabsai/ragas"
     },
     {
-      "rank": 69,
       "name": "Weaviate",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/weaviate/weaviate",
       "github_url_display": "https://github.com/weaviate/weaviate"
     },
     {
-      "rank": 70,
       "name": "Qdrant",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/qdrant/qdrant",
       "github_url_display": "https://github.com/qdrant/qdrant"
     },
     {
-      "rank": 71,
       "name": "Chroma",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/chroma-core/chroma",
       "github_url_display": "https://github.com/chroma-core/chroma"
     },
     {
-      "rank": 72,
       "name": "Milvus",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/milvus-io/milvus",
       "github_url_display": "https://github.com/milvus-io/milvus"
     },
     {
-      "rank": 73,
       "name": "Playwright (Microsoft)",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/microsoft/playwright",
       "github_url_display": "https://github.com/microsoft/playwright"
     },
     {
-      "rank": 74,
       "name": "Composio",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/ComposioHQ/composio",
       "github_url_display": "https://github.com/ComposioHQ/composio"
     },
     {
-      "rank": 75,
       "name": "Instructor",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/jxnl/instructor",
       "github_url_display": "https://github.com/567-labs/instructor"
     },
     {
-      "rank": 76,
       "name": "Haystack (deepset)",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/deepset-ai/haystack",
       "github_url_display": "https://github.com/deepset-ai/haystack"
     },
     {
-      "rank": 77,
       "name": "LiteLLM",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/BerriAI/litellm",
       "github_url_display": "https://github.com/BerriAI/litellm"
     },
     {
-      "rank": 78,
       "name": "Pathway",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/pathwaycom/pathway",
       "github_url_display": "https://github.com/pathwaycom/pathway"
     },
     {
-      "rank": 79,
       "name": "Langfuse",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/langfuse/langfuse",
       "github_url_display": "https://github.com/langfuse/langfuse"
     },
     {
-      "rank": 80,
       "name": "Arize Phoenix",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/Arize-ai/phoenix",
       "github_url_display": "https://github.com/Arize-ai/phoenix"
     },
     {
-      "rank": 81,
       "name": "Comet Opik",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/comet-ml/opik",
       "github_url_display": "https://github.com/comet-ml/opik"
     },
     {
-      "rank": 82,
       "name": "DeepEval",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/confident-ai/deepeval",
       "github_url_display": "https://github.com/confident-ai/deepeval"
     },
     {
-      "rank": 83,
       "name": "SWE-bench",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/princeton-nlp/SWE-bench",
       "github_url_display": "https://github.com/SWE-bench/SWE-bench"
     },
     {
-      "rank": 84,
       "name": "Inspect AI (UK AISI)",
       "layer": "Evaluation & Observability",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "rank": 85,
       "name": "PromptFoo",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/promptfoo/promptfoo",
       "github_url_display": "https://github.com/promptfoo/promptfoo"
     },
     {
-      "rank": 86,
       "name": "Qwen2.5 / Qwen3 (Alibaba)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "rank": 87,
       "name": "xLAM (Salesforce)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "rank": 88,
       "name": "Gorilla LLM (Berkeley)",
       "layer": "Agent-Optimized Models",
       "github_url": "https://github.com/ShishirPatil/gorilla",
       "github_url_display": "https://github.com/ShishirPatil/gorilla"
     },
     {
-      "rank": 89,
       "name": "Mistral Tool-Use Variants",
       "layer": "Agent-Optimized Models",
       "github_url": "https://github.com/mistralai/mistral-inference",
       "github_url_display": "https://github.com/mistralai/mistral-inference"
     },
     {
-      "rank": 90,
       "name": "Llama 3 Tool-Use (Meta)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "rank": 91,
       "name": "Granite (IBM)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "rank": 92,
       "name": "DeepSeek-R1",
       "layer": "Agent-Optimized Models",
       "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-r1",
       "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-r1"
     },
     {
-      "rank": 93,
       "name": "DeepSeek-V3.2",
       "layer": "Agent-Optimized Models",
       "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-v32",
       "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-v32"
     },
     {
-      "rank": 94,
       "name": "LlamaGuard (Meta)",
       "layer": "Safety & Guardrails",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "rank": 95,
       "name": "NeMo Guardrails (NVIDIA)",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/NVIDIA/NeMo-Guardrails",
       "github_url_display": "https://github.com/NVIDIA-NeMo/Guardrails"
     },
     {
-      "rank": 96,
       "name": "Guardrails AI",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/guardrails-ai/guardrails",
       "github_url_display": "https://github.com/guardrails-ai/guardrails"
     },
     {
-      "rank": 97,
       "name": "Microsoft PyRIT",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/Azure/PyRIT",
       "github_url_display": "https://github.com/Azure/PyRIT"
     },
     {
-      "rank": 98,
       "name": "Garak",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/leondz/garak",
       "github_url_display": "https://github.com/NVIDIA/garak"
     },
     {
-      "rank": 99,
       "name": "Ollama",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/ollama/ollama",
       "github_url_display": "https://github.com/ollama/ollama"
     },
     {
-      "rank": 100,
       "name": "Hugging Face Transformers",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/huggingface/transformers",
       "github_url_display": "https://github.com/huggingface/transformers"
     },
     {
-      "rank": 101,
       "name": "Continue.dev",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/continuedev/continue",
       "github_url_display": "https://github.com/continuedev/continue"
     },
     {
-      "rank": 102,
       "name": "Semantic Router",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/aurelio-ai/semantic-router",
       "github_url_display": "https://github.com/aurelio-labs/semantic-router"
     },
     {
-      "rank": 103,
       "name": "TaskWeaver (Microsoft)",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/microsoft/TaskWeaver",
       "github_url_display": "https://github.com/microsoft/TaskWeaver"
     },
     {
-      "rank": 104,
       "name": "pi-mono",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/badlogic/pi-mono",
       "github_url_display": "https://github.com/badlogic/pi-mono"
     },
     {
-      "rank": 105,
       "name": "Agent Skills",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/agentskills/agentskills",
       "github_url_display": "https://github.com/agentskills/agentskills"
     },
     {
-      "rank": 106,
       "name": "SkyPilot",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/skypilot-org/skypilot",
       "github_url_display": "https://github.com/skypilot-org/skypilot"
     },
     {
-      "rank": 107,
       "name": "KServe",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/kserve/kserve",
       "github_url_display": "https://github.com/kserve/kserve"
     },
     {
-      "rank": 108,
       "name": "Daytona",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/daytonaio/daytona",
       "github_url_display": "https://github.com/daytonaio/daytona"
     },
     {
-      "rank": 109,
       "name": "OpenWebUI",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/open-webui/open-webui",
       "github_url_display": "https://github.com/open-webui/open-webui"
     },
     {
-      "rank": 110,
       "name": "Jan (Local AI)",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/janhq/jan",
       "github_url_display": "https://github.com/janhq/jan"
     },
     {
-      "rank": 111,
       "name": "Livekit Agents",
       "layer": "Voice & Multimodal Agents",
       "github_url": "https://github.com/livekit/agents",
       "github_url_display": "https://github.com/livekit/agents"
     },
     {
-      "rank": 112,
       "name": "Pipecat",
       "layer": "Voice & Multimodal Agents",
       "github_url": "https://github.com/pipecat-ai/pipecat",
       "github_url_display": "https://github.com/pipecat-ai/pipecat"
     },
     {
-      "rank": 113,
       "name": "PR-Agent (CodiumAI)",
       "layer": "Research & Vertical Agents",
       "github_url": "https://github.com/Codium-ai/pr-agent",
       "github_url_display": "https://github.com/qodo-ai/pr-agent"
     },
     {
-      "rank": 114,
       "name": "Tavily",
       "layer": "Research & Vertical Agents",
       "github_url": "https://github.com/tavily-com/tavily-python",

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -84,7 +84,7 @@
     {
       "name": "A2UI",
       "layer": "Protocols & Standards",
-      "github_url": "https://github.com/google/a2ui",
+      "github_url": "https://github.com/google/A2UI",
       "github_url_display": "https://github.com/google/a2ui"
     },
     {
@@ -318,7 +318,7 @@
     {
       "name": "Hermes",
       "layer": "Personal & Coding Agents",
-      "github_url": "https://github.com/NousResearch/hermes-agent",
+      "github_url": "https://github.com/nousresearch/hermes-agent",
       "github_url_display": "https://github.com/NousResearch/hermes-agent"
     },
     {

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -6,12 +6,6 @@
       "description": "Top-100 agentic AI projects metadata.",
       "fields": [
         {
-          "name": "name",
-          "type": "string",
-          "description": "Project display name",
-          "optional": false
-        },
-        {
           "name": "layer",
           "type": "string",
           "description": "Ecosystem layer",
@@ -28,673 +22,561 @@
   },
   "data": [
     {
-      "name": "MCP (Model Context Protocol)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/modelcontextprotocol/modelcontextprotocol",
       "github_url_display": "https://github.com/modelcontextprotocol/modelcontextprotocol"
     },
     {
-      "name": "Agent2Agent (A2A) Protocol",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/google/A2A",
       "github_url_display": "https://github.com/a2aproject/A2A"
     },
     {
-      "name": "AGENTS.md",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agentsmd/agentsmd",
       "github_url_display": "https://github.com/agentsmd/agents.md"
     },
     {
-      "name": "AGNTCY",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agntcy/acp-spec",
       "github_url_display": "https://github.com/agntcy/acp-spec"
     },
     {
-      "name": "OpenTelemetry AI Semantic Conventions",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/open-telemetry/semantic-conventions",
       "github_url_display": "https://github.com/open-telemetry/semantic-conventions"
     },
     {
-      "name": "OpenAPI Specification",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/OAI/OpenAPI-Specification",
       "github_url_display": "https://github.com/OAI/OpenAPI-Specification"
     },
     {
-      "name": "W3C DID / Verifiable Credentials",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/w3c/did-core",
       "github_url_display": "https://github.com/w3c/did"
     },
     {
-      "name": "SLIM (LF)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agntcy/slim",
       "github_url_display": "https://github.com/agntcy/slim"
     },
     {
-      "name": "Open Agent Schema Framework (OASF)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agntcy/oasf",
       "github_url_display": "https://github.com/agntcy/oasf"
     },
     {
-      "name": "A2UI",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/google/A2UI",
       "github_url_display": "https://github.com/google/a2ui"
     },
     {
-      "name": "Agentic Commerce Protocol (ACP)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol",
       "github_url_display": "https://github.com/agentic-commerce-protocol/agentic-commerce-protocol"
     },
     {
-      "name": "Universal Commerce Protocol (UCP)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/Universal-Commerce-Protocol/ucp",
       "github_url_display": "https://github.com/Universal-Commerce-Protocol/ucp"
     },
     {
-      "name": "Agent Payments Protocol (AP2)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/google-agentic-commerce/AP2",
       "github_url_display": "https://github.com/google-agentic-commerce/AP2"
     },
     {
-      "name": "Machine Payments Protocol (MPP)",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/tempoxyz/mpp",
       "github_url_display": "https://github.com/tempoxyz/mpp"
     },
     {
-      "name": "Open Plugins Specification",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/vercel-labs/open-plugin-spec",
       "github_url_display": "https://github.com/vercel-labs/open-plugin-spec"
     },
     {
-      "name": "Open Responses",
       "layer": "Protocols & Standards",
       "github_url": "https://github.com/openresponses/openresponses",
       "github_url_display": "https://github.com/openresponses/openresponses"
     },
     {
-      "name": "LangGraph",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/langchain-ai/langgraph",
       "github_url_display": "https://github.com/langchain-ai/langgraph"
     },
     {
-      "name": "LangChain",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/langchain-ai/langchain",
       "github_url_display": "https://github.com/langchain-ai/langchain"
     },
     {
-      "name": "CrewAI",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/crewAIInc/crewAI",
       "github_url_display": "https://github.com/crewAIInc/crewAI"
     },
     {
-      "name": "AutoGen (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/microsoft/autogen",
       "github_url_display": "https://github.com/microsoft/autogen"
     },
     {
-      "name": "OpenAI Agents SDK",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/openai/openai-agents-python",
       "github_url_display": "https://github.com/openai/openai-agents-python"
     },
     {
-      "name": "Semantic Kernel (Microsoft)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/microsoft/semantic-kernel",
       "github_url_display": "https://github.com/microsoft/semantic-kernel"
     },
     {
-      "name": "PydanticAI",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/pydantic/pydantic-ai",
       "github_url_display": "https://github.com/pydantic/pydantic-ai"
     },
     {
-      "name": "Mastra",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/mastra-ai/mastra",
       "github_url_display": "https://github.com/mastra-ai/mastra"
     },
     {
-      "name": "CAMEL-AI / OWL",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/camel-ai/agent-s",
       "github_url_display": "https://github.com/camel-ai/camel"
     },
     {
-      "name": "Google Agent Development Kit (ADK)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/google/adk-python",
       "github_url_display": "https://github.com/google/adk-python"
     },
     {
-      "name": "goose (Block)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/block/goose",
       "github_url_display": "https://github.com/block/goose"
     },
     {
-      "name": "MetaGPT",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/geekan/MetaGPT",
       "github_url_display": "https://github.com/FoundationAgents/MetaGPT"
     },
     {
-      "name": "Temporal",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/temporalio/temporal",
       "github_url_display": "https://github.com/temporalio/temporal"
     },
     {
-      "name": "Prefect",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/PrefectHQ/prefect",
       "github_url_display": "https://github.com/PrefectHQ/prefect"
     },
     {
-      "name": "AutoGPT",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/Significant-Gravitas/AutoGPT",
       "github_url_display": "https://github.com/Significant-Gravitas/AutoGPT"
     },
     {
-      "name": "RAGFlow",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/infiniflow/ragflow",
       "github_url_display": "https://github.com/infiniflow/ragflow"
     },
     {
-      "name": "AgentScope (Alibaba)",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/modelscope/agentscope",
       "github_url_display": "https://github.com/agentscope-ai/agentscope"
     },
     {
-      "name": "OWL",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/camel-ai/owl",
       "github_url_display": "https://github.com/camel-ai/owl"
     },
     {
-      "name": "Agno",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/agno-agi/agno",
       "github_url_display": "https://github.com/agno-agi/agno"
     },
     {
-      "name": "DeerFlow",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/bytedance/deer-flow",
       "github_url_display": "https://github.com/bytedance/deer-flow"
     },
     {
-      "name": "OpenClaw",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/openclaw/openclaw",
       "github_url_display": "https://github.com/openclaw/openclaw"
     },
     {
-      "name": "OpenHands (OpenDevin)",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/OpenHands/OpenHands",
       "github_url_display": "https://github.com/OpenHands/OpenHands"
     },
     {
-      "name": "Cline",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/cline/cline",
       "github_url_display": "https://github.com/cline/cline"
     },
     {
-      "name": "Aider",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/Aider-AI/aider",
       "github_url_display": "https://github.com/Aider-AI/aider"
     },
     {
-      "name": "SWE-agent (Princeton)",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/princeton-nlp/SWE-agent",
       "github_url_display": "https://github.com/SWE-agent/SWE-agent"
     },
     {
-      "name": "Agentless (UIUC)",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/OpenAutoCoder/Agentless",
       "github_url_display": "https://github.com/OpenAutoCoder/Agentless"
     },
     {
-      "name": "GPT Researcher",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/assafelovic/gpt-researcher",
       "github_url_display": "https://github.com/assafelovic/gpt-researcher"
     },
     {
-      "name": "Open Interpreter",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/OpenInterpreter/open-interpreter",
       "github_url_display": "https://github.com/OpenInterpreter/open-interpreter"
     },
     {
-      "name": "Sweep",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/sweepai/sweep",
       "github_url_display": "https://github.com/sweepai/sweep"
     },
     {
-      "name": "OpenCode",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/anomalyco/opencode",
       "github_url_display": "https://github.com/anomalyco/opencode"
     },
     {
-      "name": "Kilo",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/Kilo-Org/kilocode",
       "github_url_display": "https://github.com/Kilo-Org/kilocode"
     },
     {
-      "name": "Hermes",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/nousresearch/hermes-agent",
       "github_url_display": "https://github.com/NousResearch/hermes-agent"
     },
     {
-      "name": "Warp",
       "layer": "Personal & Coding Agents",
       "github_url": "https://github.com/warpdotdev/warp",
       "github_url_display": "https://github.com/warpdotdev/warp"
     },
     {
-      "name": "Browser-Use",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/browser-use/browser-use",
       "github_url_display": "https://github.com/browser-use/browser-use"
     },
     {
-      "name": "Firecrawl",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/mendableai/firecrawl",
       "github_url_display": "https://github.com/firecrawl/firecrawl"
     },
     {
-      "name": "Crawl4AI",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/unclecode/crawl4ai",
       "github_url_display": "https://github.com/unclecode/crawl4ai"
     },
     {
-      "name": "OSWorld / WindowsAgentArena",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/xlang-ai/OSWorld",
       "github_url_display": "https://github.com/xlang-ai/OSWorld"
     },
     {
-      "name": "Agent S (Simular AI)",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/simular-ai/Agent-S",
       "github_url_display": "https://github.com/simular-ai/Agent-S"
     },
     {
-      "name": "E2B Code Interpreter SDK",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/e2b-dev/code-interpreter",
       "github_url_display": "https://github.com/e2b-dev/code-interpreter"
     },
     {
-      "name": "OmniParser (Microsoft Research)",
       "layer": "Computer Use & Browser Agents",
       "github_url": "https://github.com/microsoft/OmniParser",
       "github_url_display": "https://github.com/microsoft/OmniParser"
     },
     {
-      "name": "MCP Inspector",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/modelcontextprotocol/inspector",
       "github_url_display": "https://github.com/modelcontextprotocol/inspector"
     },
     {
-      "name": "FastMCP",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/PrefectHQ/fastmcp",
       "github_url_display": "https://github.com/PrefectHQ/fastmcp"
     },
     {
-      "name": "LiteMCP",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/wong2/litemcp",
       "github_url_display": "https://github.com/wong2/litemcp"
     },
     {
-      "name": "IBM MCP Context Forge",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/ibm/mcp-context-forge",
       "github_url_display": "https://github.com/ibm/mcp-context-forge"
     },
     {
-      "name": "Unla MCP Gateway",
       "layer": "MCP Infrastructure",
       "github_url": "https://github.com/AmoyLab/Unla",
       "github_url_display": "https://github.com/AmoyLab/Unla"
     },
     {
-      "name": "Letta (MemGPT)",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/letta-ai/letta",
       "github_url_display": "https://github.com/letta-ai/letta"
     },
     {
-      "name": "LlamaIndex",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/run-llama/llama_index",
       "github_url_display": "https://github.com/run-llama/llama_index"
     },
     {
-      "name": "GraphRAG (Microsoft)",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/microsoft/graphrag",
       "github_url_display": "https://github.com/microsoft/graphrag"
     },
     {
-      "name": "LightRAG",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/HKUDS/LightRAG",
       "github_url_display": "https://github.com/HKUDS/LightRAG"
     },
     {
-      "name": "DSPy (Stanford)",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/stanfordnlp/dspy",
       "github_url_display": "https://github.com/stanfordnlp/dspy"
     },
     {
-      "name": "Ragas",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/explodinggradients/ragas",
       "github_url_display": "https://github.com/vibrantlabsai/ragas"
     },
     {
-      "name": "Weaviate",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/weaviate/weaviate",
       "github_url_display": "https://github.com/weaviate/weaviate"
     },
     {
-      "name": "Qdrant",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/qdrant/qdrant",
       "github_url_display": "https://github.com/qdrant/qdrant"
     },
     {
-      "name": "Chroma",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/chroma-core/chroma",
       "github_url_display": "https://github.com/chroma-core/chroma"
     },
     {
-      "name": "Milvus",
       "layer": "Memory & Retrieval",
       "github_url": "https://github.com/milvus-io/milvus",
       "github_url_display": "https://github.com/milvus-io/milvus"
     },
     {
-      "name": "Playwright (Microsoft)",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/microsoft/playwright",
       "github_url_display": "https://github.com/microsoft/playwright"
     },
     {
-      "name": "Composio",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/ComposioHQ/composio",
       "github_url_display": "https://github.com/ComposioHQ/composio"
     },
     {
-      "name": "Instructor",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/jxnl/instructor",
       "github_url_display": "https://github.com/567-labs/instructor"
     },
     {
-      "name": "Haystack (deepset)",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/deepset-ai/haystack",
       "github_url_display": "https://github.com/deepset-ai/haystack"
     },
     {
-      "name": "LiteLLM",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/BerriAI/litellm",
       "github_url_display": "https://github.com/BerriAI/litellm"
     },
     {
-      "name": "Pathway",
       "layer": "Tool Use & Integration",
       "github_url": "https://github.com/pathwaycom/pathway",
       "github_url_display": "https://github.com/pathwaycom/pathway"
     },
     {
-      "name": "Langfuse",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/langfuse/langfuse",
       "github_url_display": "https://github.com/langfuse/langfuse"
     },
     {
-      "name": "Arize Phoenix",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/Arize-ai/phoenix",
       "github_url_display": "https://github.com/Arize-ai/phoenix"
     },
     {
-      "name": "Comet Opik",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/comet-ml/opik",
       "github_url_display": "https://github.com/comet-ml/opik"
     },
     {
-      "name": "DeepEval",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/confident-ai/deepeval",
       "github_url_display": "https://github.com/confident-ai/deepeval"
     },
     {
-      "name": "SWE-bench",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/princeton-nlp/SWE-bench",
       "github_url_display": "https://github.com/SWE-bench/SWE-bench"
     },
     {
-      "name": "Inspect AI (UK AISI)",
       "layer": "Evaluation & Observability",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "name": "PromptFoo",
       "layer": "Evaluation & Observability",
       "github_url": "https://github.com/promptfoo/promptfoo",
       "github_url_display": "https://github.com/promptfoo/promptfoo"
     },
     {
-      "name": "Qwen2.5 / Qwen3 (Alibaba)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "name": "xLAM (Salesforce)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "name": "Gorilla LLM (Berkeley)",
       "layer": "Agent-Optimized Models",
       "github_url": "https://github.com/ShishirPatil/gorilla",
       "github_url_display": "https://github.com/ShishirPatil/gorilla"
     },
     {
-      "name": "Mistral Tool-Use Variants",
       "layer": "Agent-Optimized Models",
       "github_url": "https://github.com/mistralai/mistral-inference",
       "github_url_display": "https://github.com/mistralai/mistral-inference"
     },
     {
-      "name": "Llama 3 Tool-Use (Meta)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "name": "Granite (IBM)",
       "layer": "Agent-Optimized Models",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "name": "DeepSeek-R1",
       "layer": "Agent-Optimized Models",
       "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-r1",
       "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-r1"
     },
     {
-      "name": "DeepSeek-V3.2",
       "layer": "Agent-Optimized Models",
       "github_url": "https://huggingface.co/collections/deepseek-ai/deepseek-v32",
       "github_url_display": "https://huggingface.co/collections/deepseek-ai/deepseek-v32"
     },
     {
-      "name": "LlamaGuard (Meta)",
       "layer": "Safety & Guardrails",
       "github_url": null,
       "github_url_display": null
     },
     {
-      "name": "NeMo Guardrails (NVIDIA)",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/NVIDIA/NeMo-Guardrails",
       "github_url_display": "https://github.com/NVIDIA-NeMo/Guardrails"
     },
     {
-      "name": "Guardrails AI",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/guardrails-ai/guardrails",
       "github_url_display": "https://github.com/guardrails-ai/guardrails"
     },
     {
-      "name": "Microsoft PyRIT",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/Azure/PyRIT",
       "github_url_display": "https://github.com/Azure/PyRIT"
     },
     {
-      "name": "Garak",
       "layer": "Safety & Guardrails",
       "github_url": "https://github.com/leondz/garak",
       "github_url_display": "https://github.com/NVIDIA/garak"
     },
     {
-      "name": "Ollama",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/ollama/ollama",
       "github_url_display": "https://github.com/ollama/ollama"
     },
     {
-      "name": "Continue.dev",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/continuedev/continue",
       "github_url_display": "https://github.com/continuedev/continue"
     },
     {
-      "name": "Semantic Router",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/aurelio-ai/semantic-router",
       "github_url_display": "https://github.com/aurelio-labs/semantic-router"
     },
     {
-      "name": "TaskWeaver (Microsoft)",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/microsoft/TaskWeaver",
       "github_url_display": "https://github.com/microsoft/TaskWeaver"
     },
     {
-      "name": "pi-mono",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/badlogic/pi-mono",
       "github_url_display": "https://github.com/badlogic/pi-mono"
     },
     {
-      "name": "Agent Skills",
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/agentskills/agentskills",
       "github_url_display": "https://github.com/agentskills/agentskills"
     },
     {
-      "name": "SkyPilot",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/skypilot-org/skypilot",
       "github_url_display": "https://github.com/skypilot-org/skypilot"
     },
     {
-      "name": "KServe",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/kserve/kserve",
       "github_url_display": "https://github.com/kserve/kserve"
     },
     {
-      "name": "Daytona",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/daytonaio/daytona",
       "github_url_display": "https://github.com/daytonaio/daytona"
     },
     {
-      "name": "OpenWebUI",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/open-webui/open-webui",
       "github_url_display": "https://github.com/open-webui/open-webui"
     },
     {
-      "name": "Jan (Local AI)",
       "layer": "Agent Infrastructure",
       "github_url": "https://github.com/janhq/jan",
       "github_url_display": "https://github.com/janhq/jan"
     },
     {
-      "name": "Livekit Agents",
       "layer": "Voice & Multimodal Agents",
       "github_url": "https://github.com/livekit/agents",
       "github_url_display": "https://github.com/livekit/agents"
     },
     {
-      "name": "Pipecat",
       "layer": "Voice & Multimodal Agents",
       "github_url": "https://github.com/pipecat-ai/pipecat",
       "github_url_display": "https://github.com/pipecat-ai/pipecat"
     },
     {
-      "name": "PR-Agent (CodiumAI)",
       "layer": "Research & Vertical Agents",
       "github_url": "https://github.com/Codium-ai/pr-agent",
       "github_url_display": "https://github.com/qodo-ai/pr-agent"
     },
     {
-      "name": "Tavily",
       "layer": "Research & Vertical Agents",
       "github_url": "https://github.com/tavily-com/tavily-python",
       "github_url_display": "https://github.com/tavily-ai/tavily-python"

--- a/frontend/public/data/agentic-ai-momentum/projects.json
+++ b/frontend/public/data/agentic-ai-momentum/projects.json
@@ -160,12 +160,6 @@
       "github_url_display": "https://github.com/microsoft/semantic-kernel"
     },
     {
-      "name": "SmolAgents (Hugging Face)",
-      "layer": "Orchestration & Multi-Agent",
-      "github_url": "https://github.com/huggingface/smolagents",
-      "github_url_display": "https://github.com/huggingface/smolagents"
-    },
-    {
       "name": "PydanticAI",
       "layer": "Orchestration & Multi-Agent",
       "github_url": "https://github.com/pydantic/pydantic-ai",
@@ -620,12 +614,6 @@
       "layer": "Developer Tooling & SDKs",
       "github_url": "https://github.com/ollama/ollama",
       "github_url_display": "https://github.com/ollama/ollama"
-    },
-    {
-      "name": "Hugging Face Transformers",
-      "layer": "Developer Tooling & SDKs",
-      "github_url": "https://github.com/huggingface/transformers",
-      "github_url_display": "https://github.com/huggingface/transformers"
     },
     {
       "name": "Continue.dev",

--- a/frontend/public/data/agentic-ai-momentum/research_papers_count.json
+++ b/frontend/public/data/agentic-ai-momentum/research_papers_count.json
@@ -1,6 +1,6 @@
 {
   "metadata": {
-    "fetched_at": "2026-03-27T10:43:24.226770",
+    "fetched_at": "2026-04-30T16:02:02.240779",
     "schema": {
       "name": "research_papers_count",
       "description": "Monthly arXiv paper counts for agentic-AI topics.",
@@ -24,404 +24,17 @@
           "optional": false
         }
       ]
-    }
+    },
+    "covered_items": [
+      "agent_memory_planning",
+      "agent_safety_alignment",
+      "agentic_rag",
+      "autonomous_agents",
+      "llm_tool_use",
+      "multi_agent_systems"
+    ]
   },
   "data": [
-    {
-      "topic": "autonomous_agents",
-      "month": "pre_window",
-      "paper_count": 409
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-03",
-      "paper_count": 20
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-04",
-      "paper_count": 15
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-05",
-      "paper_count": 26
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-06",
-      "paper_count": 23
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-07",
-      "paper_count": 37
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-08",
-      "paper_count": 17
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-09",
-      "paper_count": 23
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-10",
-      "paper_count": 50
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-11",
-      "paper_count": 33
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2024-12",
-      "paper_count": 36
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-01",
-      "paper_count": 37
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-02",
-      "paper_count": 53
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-03",
-      "paper_count": 53
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-04",
-      "paper_count": 57
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-05",
-      "paper_count": 93
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-06",
-      "paper_count": 88
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-07",
-      "paper_count": 85
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-08",
-      "paper_count": 105
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-09",
-      "paper_count": 110
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-10",
-      "paper_count": 122
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-11",
-      "paper_count": 92
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2025-12",
-      "paper_count": 108
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2026-01",
-      "paper_count": 134
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2026-02",
-      "paper_count": 163
-    },
-    {
-      "topic": "autonomous_agents",
-      "month": "2026-03",
-      "paper_count": 160
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "pre_window",
-      "paper_count": 2640
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-03",
-      "paper_count": 81
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-04",
-      "paper_count": 74
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-05",
-      "paper_count": 76
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-06",
-      "paper_count": 81
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-07",
-      "paper_count": 69
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-08",
-      "paper_count": 89
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-09",
-      "paper_count": 83
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-10",
-      "paper_count": 150
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-11",
-      "paper_count": 102
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2024-12",
-      "paper_count": 130
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-01",
-      "paper_count": 90
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-02",
-      "paper_count": 170
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-03",
-      "paper_count": 186
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-04",
-      "paper_count": 137
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-05",
-      "paper_count": 267
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-06",
-      "paper_count": 209
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-07",
-      "paper_count": 223
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-08",
-      "paper_count": 288
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-09",
-      "paper_count": 269
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-10",
-      "paper_count": 370
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-11",
-      "paper_count": 331
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2025-12",
-      "paper_count": 262
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2026-01",
-      "paper_count": 319
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2026-02",
-      "paper_count": 337
-    },
-    {
-      "topic": "multi_agent_systems",
-      "month": "2026-03",
-      "paper_count": 383
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "pre_window",
-      "paper_count": 23
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-03",
-      "paper_count": 1
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-04",
-      "paper_count": 1
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-05",
-      "paper_count": 4
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-06",
-      "paper_count": 3
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-07",
-      "paper_count": 4
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-08",
-      "paper_count": 2
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-09",
-      "paper_count": 2
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-10",
-      "paper_count": 4
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-11",
-      "paper_count": 4
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2024-12",
-      "paper_count": 3
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-01",
-      "paper_count": 3
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-02",
-      "paper_count": 3
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-03",
-      "paper_count": 4
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-04",
-      "paper_count": 7
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-05",
-      "paper_count": 8
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-06",
-      "paper_count": 5
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-07",
-      "paper_count": 1
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-08",
-      "paper_count": 5
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-09",
-      "paper_count": 6
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-10",
-      "paper_count": 17
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-11",
-      "paper_count": 4
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2025-12",
-      "paper_count": 7
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2026-01",
-      "paper_count": 10
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2026-02",
-      "paper_count": 7
-    },
-    {
-      "topic": "llm_tool_use",
-      "month": "2026-03",
-      "paper_count": 13
-    },
-    {
-      "topic": "agent_memory_planning",
-      "month": "pre_window",
-      "paper_count": 177
-    },
     {
       "topic": "agent_memory_planning",
       "month": "2024-03",
@@ -520,7 +133,7 @@
     {
       "topic": "agent_memory_planning",
       "month": "2025-10",
-      "paper_count": 81
+      "paper_count": 80
     },
     {
       "topic": "agent_memory_planning",
@@ -545,12 +158,22 @@
     {
       "topic": "agent_memory_planning",
       "month": "2026-03",
-      "paper_count": 97
+      "paper_count": 84
     },
     {
-      "topic": "agent_safety_alignment",
+      "topic": "agent_memory_planning",
+      "month": "2026-04",
+      "paper_count": 108
+    },
+    {
+      "topic": "agent_memory_planning",
+      "month": "2026-05",
+      "paper_count": 0
+    },
+    {
+      "topic": "agent_memory_planning",
       "month": "pre_window",
-      "paper_count": 36
+      "paper_count": 177
     },
     {
       "topic": "agent_safety_alignment",
@@ -675,12 +298,22 @@
     {
       "topic": "agent_safety_alignment",
       "month": "2026-03",
-      "paper_count": 19
+      "paper_count": 17
     },
     {
-      "topic": "agentic_rag",
+      "topic": "agent_safety_alignment",
+      "month": "2026-04",
+      "paper_count": 33
+    },
+    {
+      "topic": "agent_safety_alignment",
+      "month": "2026-05",
+      "paper_count": 0
+    },
+    {
+      "topic": "agent_safety_alignment",
       "month": "pre_window",
-      "paper_count": 191
+      "paper_count": 36
     },
     {
       "topic": "agentic_rag",
@@ -780,7 +413,7 @@
     {
       "topic": "agentic_rag",
       "month": "2025-10",
-      "paper_count": 137
+      "paper_count": 136
     },
     {
       "topic": "agentic_rag",
@@ -805,7 +438,442 @@
     {
       "topic": "agentic_rag",
       "month": "2026-03",
+      "paper_count": 149
+    },
+    {
+      "topic": "agentic_rag",
+      "month": "2026-04",
+      "paper_count": 186
+    },
+    {
+      "topic": "agentic_rag",
+      "month": "2026-05",
+      "paper_count": 0
+    },
+    {
+      "topic": "agentic_rag",
+      "month": "pre_window",
+      "paper_count": 191
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-03",
+      "paper_count": 20
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-04",
+      "paper_count": 15
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-05",
+      "paper_count": 26
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-06",
+      "paper_count": 23
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-07",
+      "paper_count": 37
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-08",
+      "paper_count": 17
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-09",
+      "paper_count": 23
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-10",
+      "paper_count": 50
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-11",
+      "paper_count": 33
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2024-12",
+      "paper_count": 36
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-01",
+      "paper_count": 37
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-02",
+      "paper_count": 53
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-03",
+      "paper_count": 54
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-04",
+      "paper_count": 57
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-05",
+      "paper_count": 93
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-06",
+      "paper_count": 88
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-07",
+      "paper_count": 85
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-08",
+      "paper_count": 105
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-09",
+      "paper_count": 110
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-10",
+      "paper_count": 121
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-11",
+      "paper_count": 92
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2025-12",
+      "paper_count": 108
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2026-01",
+      "paper_count": 134
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2026-02",
+      "paper_count": 163
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2026-03",
+      "paper_count": 132
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2026-04",
+      "paper_count": 161
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "2026-05",
+      "paper_count": 0
+    },
+    {
+      "topic": "autonomous_agents",
+      "month": "pre_window",
+      "paper_count": 409
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-03",
+      "paper_count": 1
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-04",
+      "paper_count": 1
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-05",
+      "paper_count": 4
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-06",
+      "paper_count": 3
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-07",
+      "paper_count": 4
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-08",
+      "paper_count": 2
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-09",
+      "paper_count": 2
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-10",
+      "paper_count": 4
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-11",
+      "paper_count": 4
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2024-12",
+      "paper_count": 3
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-01",
+      "paper_count": 3
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-02",
+      "paper_count": 3
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-03",
+      "paper_count": 4
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-04",
+      "paper_count": 7
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-05",
+      "paper_count": 8
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-06",
+      "paper_count": 5
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-07",
+      "paper_count": 1
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-08",
+      "paper_count": 5
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-09",
+      "paper_count": 6
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-10",
+      "paper_count": 17
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-11",
+      "paper_count": 4
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2025-12",
+      "paper_count": 7
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2026-01",
+      "paper_count": 10
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2026-02",
+      "paper_count": 7
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2026-03",
+      "paper_count": 10
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2026-04",
+      "paper_count": 13
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "2026-05",
+      "paper_count": 0
+    },
+    {
+      "topic": "llm_tool_use",
+      "month": "pre_window",
+      "paper_count": 23
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-03",
+      "paper_count": 81
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-04",
+      "paper_count": 74
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-05",
+      "paper_count": 76
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-06",
+      "paper_count": 81
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-07",
+      "paper_count": 69
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-08",
+      "paper_count": 89
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-09",
+      "paper_count": 83
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-10",
+      "paper_count": 150
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-11",
+      "paper_count": 102
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2024-12",
+      "paper_count": 130
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-01",
+      "paper_count": 90
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-02",
       "paper_count": 170
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-03",
+      "paper_count": 187
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-04",
+      "paper_count": 137
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-05",
+      "paper_count": 267
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-06",
+      "paper_count": 209
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-07",
+      "paper_count": 223
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-08",
+      "paper_count": 288
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-09",
+      "paper_count": 269
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-10",
+      "paper_count": 370
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-11",
+      "paper_count": 331
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2025-12",
+      "paper_count": 262
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2026-01",
+      "paper_count": 319
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2026-02",
+      "paper_count": 337
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2026-03",
+      "paper_count": 331
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2026-04",
+      "paper_count": 426
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "2026-05",
+      "paper_count": 0
+    },
+    {
+      "topic": "multi_agent_systems",
+      "month": "pre_window",
+      "paper_count": 2640
     }
   ]
 }

--- a/frontend/server/api/report/agentic-ai-momentum/projects.get.ts
+++ b/frontend/server/api/report/agentic-ai-momentum/projects.get.ts
@@ -47,7 +47,7 @@ export default defineEventHandler(async (_event): Promise<AgenticEnrichedProject
       releasesByUrl.set(normalizeUrl(repo), { latest: latestValue, delta });
     }
 
-    return tbProjects.map((p, index): AgenticEnrichedProject => {
+    return tbProjects.map((p): AgenticEnrichedProject => {
       const normalizedUrl = normalizeUrl(p.github_repo_link);
       const meta = projectMetaByUrl.get(normalizedUrl);
       const releases = releasesByUrl.get(normalizedUrl);
@@ -58,7 +58,6 @@ export default defineEventHandler(async (_event): Promise<AgenticEnrichedProject
         slug: p.slug,
         githubRepoLink: meta?.github_url_display ?? p.github_repo_link,
         layer: meta?.layer ?? '',
-        rank: meta?.rank ?? index + 1,
         // All-time values
         stars: p.stars,
         forks: p.forks,

--- a/frontend/server/api/report/agentic-ai-momentum/projects.get.ts
+++ b/frontend/server/api/report/agentic-ai-momentum/projects.get.ts
@@ -59,7 +59,6 @@ export default defineEventHandler(async (_event): Promise<AgenticEnrichedProject
         githubRepoLink: meta?.github_url_display ?? p.github_repo_link,
         layer: meta?.layer ?? '',
         rank: meta?.rank ?? index + 1,
-        license: meta?.license ?? '',
         // All-time values
         stars: p.stars,
         forks: p.forks,

--- a/frontend/types/report/agentic-ai-momentum.types.ts
+++ b/frontend/types/report/agentic-ai-momentum.types.ts
@@ -25,7 +25,6 @@ export interface AgenticProject {
   rank: number;
   name: string;
   layer: string;
-  license: string;
   github_url: string | null;
   github_url_display: string | null;
 }
@@ -85,7 +84,6 @@ export interface ProjectLeaderboardRow {
   slug: string;
   name: string;
   layer: EcosystemLayer | string;
-  license: string;
   githubUrl: string | null;
   stars: number | null;
   starsDelta: number | null;
@@ -237,7 +235,6 @@ export interface AgenticEnrichedProject {
   githubRepoLink: string;
   layer: EcosystemLayer | string;
   rank: number;
-  license: string;
   // All-time values
   stars: number | null;
   forks: number | null;

--- a/frontend/types/report/agentic-ai-momentum.types.ts
+++ b/frontend/types/report/agentic-ai-momentum.types.ts
@@ -22,7 +22,6 @@ export interface AgenticDataResponse<T> {
 
 // Project metadata
 export interface AgenticProject {
-  rank: number;
   name: string;
   layer: string;
   github_url: string | null;
@@ -80,7 +79,6 @@ export type ResearchTopic =
 
 // Aggregated project data for the leaderboard
 export interface ProjectLeaderboardRow {
-  rank: number;
   slug: string;
   name: string;
   layer: EcosystemLayer | string;
@@ -234,7 +232,6 @@ export interface AgenticEnrichedProject {
   slug: string;
   githubRepoLink: string;
   layer: EcosystemLayer | string;
-  rank: number;
   // All-time values
   stars: number | null;
   forks: number | null;

--- a/frontend/types/report/agentic-ai-momentum.types.ts
+++ b/frontend/types/report/agentic-ai-momentum.types.ts
@@ -22,7 +22,6 @@ export interface AgenticDataResponse<T> {
 
 // Project metadata
 export interface AgenticProject {
-  name: string;
   layer: string;
   github_url: string | null;
   github_url_display: string | null;


### PR DESCRIPTION
- Updates the list of projects in the Agentic AI Momentum report
- Updates the static data files
- Removes some unneeded features/data (license, project rank) from the data and project leaderboard

@epipav The repos URLs added in this PR reflect the most up to date (as of ~1 week ago) URLs I could find after manual review. I've attempted to document the mapping between the repo URLs in the PR and the older repo URL indexed in Insights [here](https://docs.google.com/spreadsheets/d/1Tv5TSbw5lfRwLyXiJ2MhaTJ2cj61T3ohe-Iih91WxPA/edit?gid=1783787834#gid=1783787834). I believe this what you referenced when making the distinction `github_url_display` and `github_url`. I left as is in the PR so please let me know how I can best update things. Thanks! 