### PR TITLE
fix: upsert sso user on login IN-1101

### DIFF
--- a/frontend/server/api/auth/callback.ts
+++ b/frontend/server/api/auth/callback.ts
@@ -9,6 +9,8 @@ import { Pool } from 'pg';
 import { hasLfxInsightsPermission, isLfInsightsTeamMember } from '../../utils/jwt';
 import { isValidRedirectUrl, getSafeRedirectUrl } from '../../utils/redirect';
 import { SecurityAuditRepository } from '../../repo/securityAudit.repo';
+import { InsightsSsoUserRepository } from '../../repo/insightsSsoUser.repo';
+import { getAuthUsername } from '../../utils/common';
 import { type DecodedIdToken } from '~~/types/auth/auth-jwt.types';
 export default defineEventHandler(async (event) => {
   const config = useRuntimeConfig();
@@ -165,6 +167,22 @@ export default defineEventHandler(async (event) => {
 
     // Store the single OpenID Connect token
     setCookie(event, 'auth_oidc_token', oidcToken, tokenCookieOptions);
+
+    // Upsert SSO user on every login so the row exists before any collection action.
+    // Fire-and-forget: a DB failure must not block the login redirect.
+    const cmDbPool = event.context.cmDbPool as Pool | undefined;
+    if (cmDbPool && decodedIdToken.sub) {
+      const ssoUserRepo = new InsightsSsoUserRepository(cmDbPool);
+      ssoUserRepo
+        .upsert({
+          id: decodedIdToken.sub,
+          username: getAuthUsername(decodedIdToken.sub),
+          displayName: decodedIdToken.name,
+          avatarUrl: decodedIdToken.picture,
+          email: decodedIdToken.email,
+        })
+        .catch((err) => console.error('[auth/callback] sso user upsert failed:', err));
+    }
 
     // Store refresh token separately if available
     if (tokenResponse.refresh_token) {


### PR DESCRIPTION
## Summary

- `insightsSsoUsers` row is now upserted on every successful Auth0 login callback, not only when the user first creates a collection
- Uses fire-and-forget pattern so a DB failure cannot block the login redirect
- No schema or migration changes required — reuses the existing `InsightsSsoUserRepository.upsert()` method

## Changes

- `server/api/auth/callback.ts` — import `InsightsSsoUserRepository` and `getAuthUsername`, call `upsert()` after setting the OIDC cookie

## Ticket

https://linuxfoundation.atlassian.net/browse/IN-1101