### PR TITLE
fix: pin pnpm to 10.18.2 to prevent lockfile mismatch

### DIFF
--- a/.github/workflows/lint-frontend.yml
+++ b/.github/workflows/lint-frontend.yml
@@ -15,7 +15,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.18.2
 
       - name: Install dependencies
         run: pnpm install --filter lfx-insights...

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10
+          version: 10.18.2
 
       - name: Install dependencies
         run: pnpm install --filter lfx-insights...

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -7,7 +7,7 @@ ARG NODE_VERSION=24
 FROM node:$NODE_VERSION-slim AS base
 
 # Enable corepack and install pnpm (faster than npm install -g pnpm)
-RUN corepack enable && corepack prepare pnpm@latest --activate
+RUN corepack enable && corepack prepare pnpm@10.18.2 --activate
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -1,4 +1,5 @@
 {
+	"packageManager": "pnpm@10.18.2",
 	"devDependencies": {
 		"@commitlint/cli": "^19.8.1",
 		"@commitlint/config-conventional": "^19.8.1",


### PR DESCRIPTION
## Summary

- Pin pnpm to `10.18.2` in `frontend/Dockerfile` (was `pnpm@latest`) so every Docker build uses the same pnpm version that generated the lockfile
- Add `"packageManager": "pnpm@10.18.2"` to root `package.json` so corepack enforces the version consistently across all environments

## Root cause

`corepack prepare pnpm@latest --activate` in the Dockerfile fetched whatever the newest pnpm release was at build time. When a new pnpm version changed how it validates the `overrides` section against the lockfile, Docker builds began failing with `ERR_PNPM_LOCKFILE_CONFIG_MISMATCH` even though `package.json` and `pnpm-lock.yaml` were in sync locally.

## Changes

- `frontend/Dockerfile` — replaced `pnpm@latest` with `pnpm@10.18.2`
- `package.json` — added `"packageManager": "pnpm@10.18.2"` field