### PR TITLE
fix: collection edit modal not reflecting changes IN-1158

### DIFF
--- a/frontend/app/components/modules/collection/components/edit-modal/edit-collection-modal.vue
+++ b/frontend/app/components/modules/collection/components/edit-modal/edit-collection-modal.vue
@@ -83,6 +83,7 @@ SPDX-License-Identifier: MIT
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue';
+import { useQueryClient } from '@tanstack/vue-query';
 import LfEditModalSettings from './edit-modal-settings.vue';
 import LfEditModalProjects from './edit-modal-projects.vue';
 import LfxModal from '~/components/uikit/modal/modal.vue';
@@ -93,6 +94,7 @@ import LfxTabs from '~/components/uikit/tabs/tabs.vue';
 import { COLLECTIONS_API_SERVICE } from '~/components/modules/collection/services/collections.api.service';
 import useToastService from '~/components/uikit/toast/toast.service';
 import { ToastTypesEnum } from '~/components/uikit/toast/types/toast.types';
+import { TanstackKey } from '~/components/shared/types/tanstack';
 import type { Collection } from '~~/types/collection';
 import type { ProjectInsights } from '~~/types/project';
 import type { Pagination } from '~~/types/shared/pagination';
@@ -142,6 +144,7 @@ const collectionProjects = computed<ProjectInsights[]>(
 );
 
 const { showToast } = useToastService();
+const queryClient = useQueryClient();
 
 const activeTab = ref<'settings' | 'projects'>('settings');
 const isUpdating = ref(false);
@@ -239,6 +242,9 @@ const updateCollection = async () => {
 
   try {
     const updated = await COLLECTIONS_API_SERVICE.updateCollection(props.collection.id, payload);
+    queryClient.invalidateQueries({ queryKey: [TanstackKey.COLLECTIONS] });
+    queryClient.invalidateQueries({ queryKey: [TanstackKey.MY_COLLECTIONS] });
+    queryClient.invalidateQueries({ queryKey: [TanstackKey.COLLECTION_PROJECTS] });
     showToast('Collection updated successfully', ToastTypesEnum.positive);
     emit('updated', updated);
     isModalOpen.value = false;


### PR DESCRIPTION
## Summary

- After editing a community collection (adding or removing projects/repos), the edit modal showed stale data on next open until the page was reloaded
- Root cause: `updateCollection()` in the edit modal did not invalidate TanStack Query caches after a successful mutation
- Fix: invalidate `COLLECTIONS`, `MY_COLLECTIONS`, and `COLLECTION_PROJECTS` query caches on successful update, matching the pattern used in `add-to-collection-modal`

## Changes

- `edit-collection-modal.vue`: added `useQueryClient` and three `invalidateQueries` calls after successful `updateCollection()` response
