### PR TITLE
feat: improve tanstack query cache invalidation IN-1156

### DIFF
--- a/frontend/app/components/modules/project/services/project.api.service.ts
+++ b/frontend/app/components/modules/project/services/project.api.service.ts
@@ -117,8 +117,6 @@ class ProjectApiService {
     return useQuery<ProjectCollectionsResponse>({
       queryKey,
       queryFn,
-      staleTime: 0,
-      gcTime: 0,
     });
   }
 
@@ -134,8 +132,6 @@ class ProjectApiService {
       queryKey,
       queryFn,
       enabled: computed(() => !!url.value),
-      staleTime: 0,
-      gcTime: 0,
     });
   }
 }

--- a/frontend/app/plugins/vue-query.ts
+++ b/frontend/app/plugins/vue-query.ts
@@ -9,11 +9,16 @@ import { VueQueryPlugin, QueryClient, hydrate, dehydrate } from '@tanstack/vue-q
 export default defineNuxtPlugin((nuxt: NuxtApp) => {
   const vueQueryState = useState<DehydratedState | null>('vue-query');
 
-  // Modify your Vue Query global settings here
+  // 30s staleTime keeps refetchOnWindowFocus/refetchOnMount active in practice —
+  // a 5-min window made those no-ops and forced users to hard-refresh to see fresh data.
   const queryClient = new QueryClient({
     defaultOptions: {
       queries: {
-        staleTime: 1000 * 60 * 5,
+        staleTime: 1000 * 30,
+        refetchOnWindowFocus: true,
+        refetchOnMount: true,
+        refetchOnReconnect: true,
+        retry: 1,
         // Disable gc timers on the server to prevent orphaned QueryClient instances
         // from being held in memory after SSR completes
         ...(import.meta.server ? { gcTime: 0 } : {}),


### PR DESCRIPTION
## Summary

- Drop `staleTime` from 5 minutes to 30 seconds so `refetchOnWindowFocus` / `refetchOnMount` actually trigger background refetches in practice
- Explicitly set `refetchOnWindowFocus`, `refetchOnMount`, `refetchOnReconnect: true` and `retry: 1` to document intent and ensure consistent behaviour
- Remove redundant `staleTime: 0, gcTime: 0` overrides from `fetchProjectCollections` and `fetchRepositoryCollections` in `project.api.service.ts` — no longer needed with the new defaults

## Changes

- `frontend/app/plugins/vue-query.ts` — tightened `QueryClient` defaults
- `frontend/app/components/modules/project/services/project.api.service.ts` — removed per-query workaround overrides

## Ticket

https://linuxfoundation.atlassian.net/browse/IN-1156