### PR TITLE
feat: display repo license info IN-1099

### DIFF
--- a/frontend/app/components/modules/project/components/overview/about-section.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section.vue
@@ -12,6 +12,9 @@ SPDX-License-Identifier: MIT
       <lfx-tags-and-languages />
     </lfx-project-about-section-loading>
     <lfx-project-about-section-loading :is-loading="isProjectLoading">
+      <lfx-licenses />
+    </lfx-project-about-section-loading>
+    <lfx-project-about-section-loading :is-loading="isProjectLoading">
       <lfx-links />
       <lfx-project-about-section-connected-platforms />
     </lfx-project-about-section-loading>
@@ -23,6 +26,7 @@ SPDX-License-Identifier: MIT
 import { storeToRefs } from 'pinia';
 import LfxProjectAboutSoftwareValue from './about-section/about-software-value.vue';
 import LfxTagsAndLanguages from './about-section/tags-ang-languages.vue';
+import LfxLicenses from './about-section/licenses.vue';
 import LfxLinks from './about-section/links.vue';
 import LfxProjectAboutSectionLoading from './about-section/about-section-loading.vue';
 import LfxProjectAboutSectionConnectedPlatforms from '~/components/modules/project/components/overview/about-section/connected-platforms.vue';

--- a/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
@@ -8,17 +8,14 @@ SPDX-License-Identifier: MIT
     class="flex flex-col gap-3 text-xs"
   >
     <div class="text-neutral-400 font-semibold">License(s)</div>
-    <div class="flex flex-wrap gap-1.5">
-      <template
-        v-for="license of displayedLicenses"
-        :key="license"
-      >
-        <lfx-tooltip
-          v-if="isSharedByAllRepos(license)"
-          content="License shared by all repositories"
-          placement="top"
+    <div class="flex flex-col gap-3">
+      <div class="flex flex-wrap gap-1.5">
+        <template
+          v-for="license of displayedLicenses"
+          :key="license"
         >
           <div
+            v-if="isRepoSelected"
             class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
           >
             <lfx-icon
@@ -26,53 +23,69 @@ SPDX-License-Identifier: MIT
               :size="12"
               class="text-neutral-500"
             />
-            <span class="text-neutral-900 font-normal whitespace-nowrap">{{ license }}</span>
+            <div class="text-neutral-900 font-normal whitespace-nowrap">{{ formatLicense(license) }}</div>
           </div>
-        </lfx-tooltip>
-        <lfx-popover
-          v-else
-          trigger-event="hover"
-          placement="bottom-start"
-          :spacing="6"
-        >
-          <div
-            class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
+          <lfx-tooltip
+            v-else-if="isSharedByAllRepos(license)"
+            content="License shared by all repositories"
+            placement="top"
           >
-            <lfx-icon
-              name="scale-balanced"
-              :size="12"
-              class="text-neutral-500"
-            />
-            <span class="text-neutral-900 font-normal whitespace-nowrap">{{ license }}</span>
-          </div>
-          <template #content>
-            <div class="bg-white border border-neutral-100 rounded-xl shadow-lg p-2 flex flex-col overflow-hidden">
-              <div
-                v-for="repo of getReposForLicense(license)"
-                :key="repo.url"
-                class="flex items-center pl-2 py-2 gap-3 w-full rounded-lg cursor-pointer hover:bg-neutral-50"
-                @click="filterByRepo(repo.slug)"
-              >
-                <lfx-icon
-                  name="book"
-                  :size="12"
-                  class="text-neutral-500 shrink-0"
-                />
-                <span
-                  class="text-neutral-900 text-xs font-medium w-52 overflow-hidden text-ellipsis whitespace-nowrap pr-4"
-                  >{{ repo.name }}</span
-                >
-              </div>
+            <div
+              class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
+            >
+              <lfx-icon
+                name="scale-balanced"
+                :size="12"
+                class="text-neutral-500"
+              />
+              <div class="text-neutral-900 font-normal whitespace-nowrap">{{ formatLicense(license) }}</div>
             </div>
-          </template>
-        </lfx-popover>
-      </template>
+          </lfx-tooltip>
+          <lfx-popover
+            v-else
+            trigger-event="hover"
+            placement="bottom-start"
+            :spacing="6"
+          >
+            <div
+              class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
+            >
+              <lfx-icon
+                name="scale-balanced"
+                :size="12"
+                class="text-neutral-500"
+              />
+              <div class="text-neutral-900 font-normal whitespace-nowrap">{{ formatLicense(license) }}</div>
+            </div>
+            <template #content>
+              <div class="bg-white border border-neutral-100 rounded-xl shadow-lg p-2 flex flex-col overflow-hidden">
+                <div
+                  v-for="repo of getReposForLicense(license)"
+                  :key="repo.url"
+                  class="flex items-center pl-2 py-2 gap-3 w-full rounded-lg cursor-pointer hover:bg-neutral-50"
+                  @click="filterByRepo(repo.slug)"
+                >
+                  <lfx-icon
+                    name="book"
+                    :size="12"
+                    class="text-neutral-500 shrink-0"
+                  />
+                  <span
+                    class="text-neutral-900 text-xs font-medium w-52 overflow-hidden text-ellipsis whitespace-nowrap pr-4"
+                    >{{ normalizeRepoName(repo) }}</span
+                  >
+                </div>
+              </div>
+            </template>
+          </lfx-popover>
+        </template>
+      </div>
       <button
-        v-if="!isExpanded && activeLicenses.length > 5"
-        class="text-xs text-brand-500 font-normal h-6 flex items-center"
-        @click="isExpanded = true"
+        v-if="activeLicenses.length > 5"
+        class="text-xs text-brand-500 font-normal self-start"
+        @click="isExpanded = !isExpanded"
       >
-        Show more
+        {{ isExpanded ? 'Show less' : 'Show more' }}
       </button>
     </div>
   </div>
@@ -83,6 +96,7 @@ import { storeToRefs } from 'pinia';
 import { computed, ref } from 'vue';
 import { useRouter, useRoute } from 'nuxt/app';
 import { useProjectStore } from '~~/app/components/modules/project/store/project.store';
+import { normalizeRepoName } from '~/components/shared/utils/helper';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
 import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
 import LfxPopover from '~/components/uikit/popover/popover.vue';
@@ -93,22 +107,22 @@ const route = useRoute();
 
 const isExpanded = ref(false);
 
-const activeRepos = computed(() =>
-  selectedRepositories.value.length > 0 ? selectedRepositories.value : projectRepos.value,
-);
+const isRepoSelected = computed(() => selectedRepositories.value.length > 0);
+
+const activeRepos = computed(() => (isRepoSelected.value ? selectedRepositories.value : projectRepos.value));
 
 const activeLicenses = computed(() => {
   const seen = new Set<string>();
   const result: string[] = [];
   for (const repo of activeRepos.value) {
     for (const license of repo.licenses || []) {
-      if (!seen.has(license)) {
+      if (!seen.has(license) && license !== 'NONE') {
         seen.add(license);
         result.push(license);
       }
     }
   }
-  return result;
+  return result.sort((a, b) => (a === 'NOASSERTION' ? 1 : b === 'NOASSERTION' ? -1 : 0));
 });
 
 const displayedLicenses = computed(() => (isExpanded.value ? activeLicenses.value : activeLicenses.value.slice(0, 5)));
@@ -117,6 +131,8 @@ const isSharedByAllRepos = (license: string): boolean =>
   projectRepos.value.length > 0 && projectRepos.value.every((repo) => repo.licenses?.includes(license));
 
 const getReposForLicense = (license: string) => projectRepos.value.filter((repo) => repo.licenses?.includes(license));
+
+const formatLicense = (license: string) => (license === 'NOASSERTION' ? 'Other' : license);
 
 const filterByRepo = (repoSlug: string) => {
   router.push({ query: { ...route.query, repos: repoSlug } });

--- a/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
@@ -58,7 +58,9 @@ SPDX-License-Identifier: MIT
               <div class="text-neutral-900 font-normal whitespace-nowrap">{{ formatLicense(license) }}</div>
             </div>
             <template #content>
-              <div class="bg-white border border-neutral-100 rounded-xl shadow-lg p-2 flex flex-col overflow-hidden">
+              <div
+                class="bg-white border border-neutral-100 rounded-xl shadow-lg p-2 flex flex-col max-h-56 overflow-y-auto"
+              >
                 <div
                   v-for="repo of getReposForLicense(license)"
                   :key="repo.url"
@@ -128,7 +130,7 @@ const activeLicenses = computed(() => {
 const displayedLicenses = computed(() => (isExpanded.value ? activeLicenses.value : activeLicenses.value.slice(0, 5)));
 
 const isSharedByAllRepos = (license: string): boolean =>
-  projectRepos.value.length > 0 && projectRepos.value.every((repo) => repo.licenses?.includes(license));
+  projectRepos.value.length > 1 && projectRepos.value.every((repo) => repo.licenses?.includes(license));
 
 const getReposForLicense = (license: string) => projectRepos.value.filter((repo) => repo.licenses?.includes(license));
 

--- a/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
@@ -1,0 +1,130 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<template>
+  <div
+    v-if="activeLicenses.length > 0"
+    class="flex flex-col gap-3 text-xs"
+  >
+    <div class="text-neutral-400 font-semibold">License(s)</div>
+    <div class="flex flex-wrap gap-1.5">
+      <template
+        v-for="license of displayedLicenses"
+        :key="license"
+      >
+        <lfx-tooltip
+          v-if="isSharedByAllRepos(license)"
+          content="License shared by all repositories"
+          placement="top"
+        >
+          <div
+            class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
+          >
+            <lfx-icon
+              name="scale-balanced"
+              :size="12"
+              class="text-neutral-500"
+            />
+            <span class="text-neutral-900 font-normal whitespace-nowrap">{{ license }}</span>
+          </div>
+        </lfx-tooltip>
+        <lfx-popover
+          v-else
+          trigger-event="hover"
+          placement="bottom-start"
+          :spacing="6"
+        >
+          <div
+            class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
+          >
+            <lfx-icon
+              name="scale-balanced"
+              :size="12"
+              class="text-neutral-500"
+            />
+            <span class="text-neutral-900 font-normal whitespace-nowrap">{{ license }}</span>
+          </div>
+          <template #content>
+            <div class="bg-white border border-neutral-100 rounded-xl shadow-lg p-2 flex flex-col overflow-hidden">
+              <div
+                v-for="repo of getReposForLicense(license)"
+                :key="repo.url"
+                class="flex items-center pl-2 py-2 gap-3 w-full rounded-lg cursor-pointer hover:bg-neutral-50"
+                @click="filterByRepo(repo.slug)"
+              >
+                <lfx-icon
+                  name="book"
+                  :size="12"
+                  class="text-neutral-500 shrink-0"
+                />
+                <span
+                  class="text-neutral-900 text-xs font-medium w-52 overflow-hidden text-ellipsis whitespace-nowrap pr-4"
+                  >{{ repo.name }}</span
+                >
+              </div>
+            </div>
+          </template>
+        </lfx-popover>
+      </template>
+      <button
+        v-if="!isExpanded && activeLicenses.length > 5"
+        class="text-xs text-brand-500 font-normal h-6 flex items-center"
+        @click="isExpanded = true"
+      >
+        Show more
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { storeToRefs } from 'pinia';
+import { computed, ref } from 'vue';
+import { useRouter, useRoute } from 'nuxt/app';
+import { useProjectStore } from '~~/app/components/modules/project/store/project.store';
+import LfxIcon from '~/components/uikit/icon/icon.vue';
+import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
+import LfxPopover from '~/components/uikit/popover/popover.vue';
+
+const { projectRepos, selectedRepositories } = storeToRefs(useProjectStore());
+const router = useRouter();
+const route = useRoute();
+
+const isExpanded = ref(false);
+
+const activeRepos = computed(() =>
+  selectedRepositories.value.length > 0 ? selectedRepositories.value : projectRepos.value,
+);
+
+const activeLicenses = computed(() => {
+  const seen = new Set<string>();
+  const result: string[] = [];
+  for (const repo of activeRepos.value) {
+    for (const license of repo.licenses || []) {
+      if (!seen.has(license)) {
+        seen.add(license);
+        result.push(license);
+      }
+    }
+  }
+  return result;
+});
+
+const displayedLicenses = computed(() => (isExpanded.value ? activeLicenses.value : activeLicenses.value.slice(0, 5)));
+
+const isSharedByAllRepos = (license: string): boolean =>
+  projectRepos.value.length > 0 && projectRepos.value.every((repo) => repo.licenses?.includes(license));
+
+const getReposForLicense = (license: string) => projectRepos.value.filter((repo) => repo.licenses?.includes(license));
+
+const filterByRepo = (repoSlug: string) => {
+  router.push({ query: { ...route.query, repos: repoSlug } });
+};
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxProjectLicenses',
+};
+</script>

--- a/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
+++ b/frontend/app/components/modules/project/components/overview/about-section/licenses.vue
@@ -15,7 +15,7 @@ SPDX-License-Identifier: MIT
           :key="license"
         >
           <div
-            v-if="isRepoSelected"
+            v-if="isRepoSelected || isSingleRepoProject"
             class="bg-white border border-neutral-200 h-6 rounded-full px-2.5 flex items-center gap-1 cursor-default shrink-0"
           >
             <lfx-icon
@@ -110,6 +110,8 @@ const route = useRoute();
 const isExpanded = ref(false);
 
 const isRepoSelected = computed(() => selectedRepositories.value.length > 0);
+
+const isSingleRepoProject = computed(() => projectRepos.value.length <= 1);
 
 const activeRepos = computed(() => (isRepoSelected.value ? selectedRepositories.value : projectRepos.value));
 

--- a/frontend/server/api/project/[slug]/index.ts
+++ b/frontend/server/api/project/[slug]/index.ts
@@ -65,6 +65,12 @@ export default defineEventHandler(async (event): Promise<Project | Error> => {
       {} as Record<string, Partial<ProjectRepository>>,
     );
 
+    const licensesByUrl: Record<string, string[]> = {};
+    for (const [url, license] of project.repoLicenses || []) {
+      if (!licensesByUrl[url]) licensesByUrl[url] = [];
+      licensesByUrl[url].push(license);
+    }
+
     const repositories = project.repositories.map((repoUrl) => {
       const name = getRepoNameFromUrl(repoUrl);
       const slug = getRepoSlugFromName(name);
@@ -75,6 +81,7 @@ export default defineEventHandler(async (event): Promise<Project | Error> => {
         slug,
         score: details.score || 0,
         rank: details.rank || 0,
+        licenses: licensesByUrl[repoUrl] || [],
       };
     });
     const projectLinks = [

--- a/frontend/types/project.ts
+++ b/frontend/types/project.ts
@@ -6,6 +6,7 @@ export interface ProjectRepository {
   slug: string;
   score: number;
   rank: number;
+  licenses: string[];
 }
 
 export interface ProjectRepositoryGroup {
@@ -94,6 +95,7 @@ export interface ProjectTinybird {
   firstCommitUrl?: string;
   connectedPlatforms: string[];
   repoData: ProjectRepoData[];
+  repoLicenses: [string, string][];
   status: string;
   lastVulnerabilityScanStatus: string;
   maturity?: string;


### PR DESCRIPTION
## Summary

- Map `repoLicenses` tuples from Tinybird into per-repository `licenses` arrays in the project API endpoint
- Add new `LfxProjectLicenses` component to the project about section displaying license chips with tooltip/popover interactions
- Filter out `NONE` licenses, display `NOASSERTION` as "Other", sort "Other" last
- Show tooltip ("License shared by all repositories") for universal licenses; show popover with repo list for partial licenses
- Suppress tooltip/popover when a single repository is selected
- "Show more / Show less" toggle for > 5 licenses, 12px below chips, left-aligned
- Format repo names in popover using `normalizeRepoName` (same as repository selector)

## Changes

- `frontend/types/project.ts` — added `licenses: string[]` to `ProjectRepository`, `repoLicenses: [string, string][]` to `ProjectTinybird`
- `frontend/server/api/project/[slug]/index.ts` — map repo licenses from Tinybird response onto each repository object
- `frontend/app/components/modules/project/components/overview/about-section/licenses.vue` — new licenses display component
- `frontend/app/components/modules/project/components/overview/about-section.vue` — mount `<lfx-licenses />` in the about section
