### PR TITLE
fix: sanitize mentions webhook payload to prevent tinybird quarantine

### DIFF
--- a/frontend/server/api/community/[slug].post.ts
+++ b/frontend/server/api/community/[slug].post.ts
@@ -14,17 +14,43 @@ export default defineEventHandler(async (event): Promise<boolean | Error> => {
     throw createError({ statusCode: 422, statusMessage: 'Invalid request' });
   }
 
-  const data = { ...body.data };
-  if (data.viewKeywords.length > 0 && !data.viewKeywords.includes(data.keyword)) {
-    const commonKeywords = data.keywords.filter((kw) => data.viewKeywords.includes(kw));
+  const raw = body.data;
+
+  if (raw.viewKeywords.length > 0 && !raw.viewKeywords.includes(raw.keyword)) {
+    const commonKeywords = raw.keywords.filter((kw) => raw.viewKeywords.includes(kw));
     if (commonKeywords.length > 0) {
-      data.keyword = commonKeywords[0];
+      raw.keyword = commonKeywords[0];
     }
   }
 
-  await addDataToTinybirdDatasource('mentions', {
-    ...data,
+  // Pick only the fields defined in the Tinybird schema to avoid quarantine from extra columns.
+  // Type coercions: viewId must be Int64 (number), subreddit/language default to '' when absent.
+  const record = {
+    sourceId: raw.sourceId ?? '',
+    url: raw.url ?? '',
+    timestamp: raw.timestamp,
+    source: raw.source ?? '',
+    author: raw.author ?? '',
+    authorProfileLink: raw.authorProfileLink ?? '',
+    title: raw.title ?? '',
+    body: raw.body ?? '',
+    imageUrl: raw.imageUrl ?? '',
+    relevanceScore: raw.relevanceScore ?? '',
+    relevanceComment: raw.relevanceComment ?? '',
+    keyword: raw.keyword ?? '',
+    sentimentLabel: raw.sentimentLabel ?? '',
+    subreddit: raw.subreddit ?? '',
+    viewId: Number(raw.viewId) || 0,
+    viewName: raw.viewName ?? '',
+    viewKeywords: raw.viewKeywords ?? [],
+    language: raw.language ?? '',
     projectSlug: slug,
-  });
+    bookmarked: raw.bookmarked ?? 0,
+    keywords: raw.keywords ?? [],
+    authorFollowerCount: raw.authorFollowerCount ?? null,
+    tags: raw.tags ?? [],
+  };
+
+  await addDataToTinybirdDatasource('mentions', record);
   return true;
 });

--- a/frontend/types/community/community.ts
+++ b/frontend/types/community/community.ts
@@ -16,13 +16,18 @@ export interface CommunityMentionsData {
   keywords: string[];
   sentimentLabel: string;
   subreddit?: string;
-  viewId: string;
+  // Tinybird schema expects Int64; Octolens may send as string or number
+  viewId: number | string;
   viewName: string;
   viewKeywords: string[];
+  language?: string;
+  bookmarked?: number;
+  authorFollowerCount?: number | null;
+  tags?: (string | null)[];
 }
 export interface OctolensWebhook {
   action: string;
-  data: CommunityMentions;
+  data: CommunityMentionsData;
 }
 
 export interface CommunityMentions extends CommunityMentionsData {


### PR DESCRIPTION
## Summary

- Replaced the raw `...data` spread in the Octolens mentions webhook with an explicit field-by-field mapping that includes only the 24 columns defined in the Tinybird `mentions` datasource schema
- Coerces `viewId` to `Number` (schema expects `Int64`; Octolens may send a string)
- Defaults optional fields (`subreddit`, `language`, `bookmarked`, `tags`, `authorFollowerCount`) so they are always present with the correct type
- Extra fields in the Octolens payload are dropped before the `addDataToTinybirdDatasource` call, preventing quarantine caused by unknown columns

## Changes

- `frontend/server/api/community/[slug].post.ts` — sanitizes and maps payload to schema before writing to Tinybird
- `frontend/types/community/community.ts` — adds missing schema fields (`language`, `bookmarked`, `authorFollowerCount`, `tags`) and widens `viewId` to `number | string`