### PR TITLE
fix: terminate deployment when docs build fails IN-1168

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,9 +46,9 @@ COPY frontend ./frontend
 
 WORKDIR /app/frontend
 
-# Build docs and blog in parallel; capture PIDs so both exit codes are checked
-RUN pnpm docs:build & DOCS_PID=$! && \
-    pnpm blog:build & BLOG_PID=$! && \
+# Build docs and blog in parallel; use ; not && so PID assignments run in main shell
+RUN pnpm docs:build & DOCS_PID=$! ; \
+    pnpm blog:build & BLOG_PID=$! ; \
     wait $DOCS_PID && wait $BLOG_PID && \
     mkdir -p public/docs public/blog && \
     cp -r docs/.vitepress/dist/* public/docs/ && \

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -46,8 +46,10 @@ COPY frontend ./frontend
 
 WORKDIR /app/frontend
 
-# Build docs and blog in parallel using shell background processes
-RUN pnpm docs:build & pnpm blog:build & wait && \
+# Build docs and blog in parallel; capture PIDs so both exit codes are checked
+RUN pnpm docs:build & DOCS_PID=$! && \
+    pnpm blog:build & BLOG_PID=$! && \
+    wait $DOCS_PID && wait $BLOG_PID && \
     mkdir -p public/docs public/blog && \
     cp -r docs/.vitepress/dist/* public/docs/ && \
     cp -r blog/.vitepress/dist/* public/blog/


### PR DESCRIPTION
## Summary

- Fix deployment continuing after a docs/blog build failure in the Dockerfile
- Root cause: `wait` with no arguments only returns the exit code of the last background job — if `pnpm docs:build` failed but `pnpm blog:build` succeeded, the Docker build silently continued
- Fix: capture each PID (`DOCS_PID`, `BLOG_PID`) and call `wait` on them individually so any failure aborts the Docker build and terminates the deployment workflow

## Changes

- `frontend/Dockerfile`: replace `pnpm docs:build & pnpm blog:build & wait` with explicit PID capture and per-process `wait` calls

## Test plan

- [ ] Trigger a staging deploy with a broken docs build and verify the workflow fails early instead of deploying