### PR TITLE
fix: og images returning 500 IN-1172

### DIFF
--- a/frontend/app/components/og-image/project.vue
+++ b/frontend/app/components/og-image/project.vue
@@ -202,12 +202,25 @@ const props = withDefaults(
   },
 );
 
-// Fetch badge data directly in the OG component
-const { data: leaderboardData } = await useFetch<Pagination<Leaderboard>>('/api/leaderboard', {
-  params: { slug: props.projectSlug },
-  key: `og-badge-${props.projectSlug}-${props.badge}`,
-  default: () => ({ data: [], pagination: { page: 1, perPage: 10, total: 0 } }),
-});
+const emptyLeaderboard: Pagination<Leaderboard> = { data: [], page: 0, pageSize: 20, total: 0 };
+
+// Only fetch leaderboard data when a badge is actually requested.
+// Unconditionally calling useFetch here causes 500s in the nuxt-og-image
+// isolated rendering context when no badge is needed (~99% of OG image requests).
+const { data: leaderboardData } = await useAsyncData(
+  `og-badge-${props.projectSlug}-${props.badge}`,
+  async () => {
+    if (!props.badge || !props.projectSlug) return emptyLeaderboard;
+    try {
+      return await $fetch<Pagination<Leaderboard>>('/api/leaderboard', {
+        params: { slug: props.projectSlug },
+      });
+    } catch {
+      return emptyLeaderboard;
+    }
+  },
+  { default: () => emptyLeaderboard },
+);
 
 // Find the specific leaderboard entry for this badge
 const leaderboardEntry = computed(() => {

--- a/frontend/server/plugins/og-image-fallback.ts
+++ b/frontend/server/plugins/og-image-fallback.ts
@@ -8,6 +8,10 @@ export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('error', async (error, { event }) => {
     if (!event?.path?.startsWith('/__og-image__/')) return;
     console.warn(`OG image generation failed for ${event.path}:`, error);
-    await sendRedirect(event, '/og-image.png', 302);
+    try {
+      await sendRedirect(event, '/og-image.png', 302);
+    } catch {
+      // Response may already be committed; nothing we can do
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Replaced unconditional `useFetch('/api/leaderboard')` in `app/components/og-image/project.vue` with `useAsyncData` that skips the HTTP call entirely when no `badge` prop is set (~99% of OG image requests)
- When a badge _is_ requested, the fetch is now wrapped in `try/catch` so leaderboard API failures can't crash the render
- Fixed `server/plugins/og-image-fallback.ts` to wrap `sendRedirect` in `try/catch` so it doesn't throw if the response is already committed when the error hook fires

The root cause: `useFetch` was making an HTTP round-trip to `/api/leaderboard` on every single OG image render inside nuxt-og-image's isolated rendering context. That call failed (even with a `default` set), causing a 500 before the fallback could redirect.

Verified locally against 18 previously-failing URLs — all now return 200 with valid 1200×630 PNG images.

## Ticket

[IN-1172](https://linuxfoundation.atlassian.net/browse/IN-1172)

[IN-1172]: https://linuxfoundation.atlassian.net/browse/IN-1172?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ