### PR TITLE
fix: reject uuid project slugs before tinybird

### DIFF
--- a/frontend/server/data/tinybird/tinybird.ts
+++ b/frontend/server/data/tinybird/tinybird.ts
@@ -86,6 +86,14 @@ export async function fetchFromTinybird<T>(
     !query.bucketId &&
     path !== '/v0/pipes/project_buckets.json'
   ) {
+    // UUIDs are never valid project slugs — reject before touching Tinybird or the semaphore
+    const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+    if (UUID_RE.test(query.project)) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `Invalid project slug: ${query.project}`,
+      });
+    }
     try {
       const bucketId = await getBucketIdForProject(query.project, fetchFromTinybird);
       if (bucketId !== null) {


### PR DESCRIPTION
## Summary

- Adds a UUID regex check in `fetchFromTinybird()` before the bucket lookup is attempted
- If the `project` param is a UUID (e.g. `54940f04-54b8-41ee-94bf-153f977b31e7`), the function throws a 400 immediately — before acquiring a semaphore slot or hitting Tinybird
- Prevents invalid Go-client requests from consuming semaphore capacity and cascading into 503 queue-timeout errors

## Changes

- `frontend/server/data/tinybird/tinybird.ts` — early UUID guard in `fetchFromTinybird()`

## Root cause

The Go client was calling `/api/project/[slug]/...` endpoints with a raw project UUID instead of a slug. The bucket lookup returned `null` for UUIDs, but still held a semaphore slot for the full round-trip. Under load (35 active + 6 queued), these doomed requests exhausted the queue and caused legitimate requests to 503.