### PR TITLE
fix: render link with empty param

### DIFF
--- a/frontend/app/components/modules/leaderboards/components/minimize-row-displays/organization-row.vue
+++ b/frontend/app/components/modules/leaderboards/components/minimize-row-displays/organization-row.vue
@@ -7,10 +7,10 @@ SPDX-License-Identifier: MIT
   <div class="flex items-center w-full">
     <!-- Organization info -->
     <component
-      :is="isTeamMember ? nuxtLink : 'div'"
-      :to="isTeamMember ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
+      :is="isTeamMember && item.slug ? nuxtLink : 'div'"
+      :to="isTeamMember && item.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
       class="flex-1 min-w-0 flex gap-3 items-center text-inherit no-underline"
-      :class="isTeamMember ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
+      :class="isTeamMember && item.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
     >
       <lfx-avatar
         :src="item.logoUrl"

--- a/frontend/app/components/modules/leaderboards/components/row-displays/organization-row.vue
+++ b/frontend/app/components/modules/leaderboards/components/row-displays/organization-row.vue
@@ -12,11 +12,12 @@ SPDX-License-Identifier: MIT
 
     <!-- Organization info -->
     <component
-      :is="isTeamMember ? nuxtLink : 'div'"
-      :to="isTeamMember ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
+      :is="isTeamMember && item.slug ? nuxtLink : 'div'"
+      :to="isTeamMember && item.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
       class="flex-1 min-w-0 flex gap-3 items-center text-inherit no-underline"
-      :class="isTeamMember ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
+      :class="isTeamMember && item.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
     >
+      aaa
       <lfx-avatar
         :src="item.logoUrl"
         type="organization"


### PR DESCRIPTION
This pull request updates the organization row components to improve the logic for rendering organization links and styles, ensuring that links and interactive styles are only applied when both the user is a team member and the organization has a valid slug. This prevents broken or incorrect links from being rendered.

Component rendering and navigation improvements:

* Updated both `minimize-row-displays/organization-row.vue` and `row-displays/organization-row.vue` to only render the organization as a link (and apply link-related styles) if the user is a team member and the organization has a valid `slug`. This ensures that navigation is only possible when it is valid, preventing potential errors or broken links. [[1]](diffhunk://#diff-d03d785d1a7f3986ff16798a0b015fcb6b07cfaba87d6295795a6990837b326eL10-R13) [[2]](diffhunk://#diff-82bc3b2e0d58db92db8c20327e7b7a8da3212dd0d8de236a43a645999906c72bL15-R20)

Other changes:

* Added a stray `aaa` string in `row-displays/organization-row.vue`, which appears to be an accidental addition and should likely be removed.