### PR TITLE
fix: remove downloads from AAIM dashboard

### DIFF
--- a/frontend/app/components/modules/report/agentic-ai-momentum/components/metric-explorer.vue
+++ b/frontend/app/components/modules/report/agentic-ai-momentum/components/metric-explorer.vue
@@ -250,7 +250,6 @@ const METRIC_CONFIG: MetricOption[] = [
   // Growth
   { key: 'stars', label: 'Stars', format: 'number', group: 'Growth' },
   { key: 'forks', label: 'Forks', format: 'number', group: 'Growth' },
-  { key: 'downloads', label: 'Downloads', format: 'number', group: 'Growth' },
   { key: 'dockerHubPulls', label: 'Docker Pulls', format: 'number', group: 'Growth' },
   { key: 'dependentRepositories', label: 'Dependent Repos', format: 'number', group: 'Growth' },
   { key: 'dependentPackages', label: 'Dependent Pkgs', format: 'number', group: 'Growth' },
@@ -316,8 +315,6 @@ function getMetricValue(project: AgenticEnrichedProject, metric: MetricKey): num
       return project.contributors;
     case 'newContributors':
       return project.newContributors30d;
-    case 'downloads':
-      return project.downloads;
     case 'dockerHubPulls':
       return project.dockerPulls;
     case 'dependentRepositories':

--- a/frontend/app/components/modules/report/agentic-ai-momentum/components/project-leaderboard.vue
+++ b/frontend/app/components/modules/report/agentic-ai-momentum/components/project-leaderboard.vue
@@ -144,21 +144,6 @@ SPDX-License-Identifier: MIT
               </div>
             </th>
             <th
-              v-if="activeColumns.includes('downloads')"
-              key="col-downloads"
-              class="text-right py-3 px-2 font-semibold text-neutral-700 cursor-pointer hover:bg-neutral-50"
-              @click="sortBy('downloads')"
-            >
-              <div class="flex items-center justify-end gap-1">
-                Downloads
-                <lfx-icon
-                  v-if="sortColumn === 'downloads'"
-                  :name="sortDirection === 'asc' ? 'arrow-up' : 'arrow-down'"
-                  :size="14"
-                />
-              </div>
-            </th>
-            <th
               v-if="activeColumns.includes('dockerHubPulls')"
               key="col-dockerHubPulls"
               class="text-right py-3 px-2 font-semibold text-neutral-700 cursor-pointer hover:bg-neutral-50"
@@ -437,13 +422,6 @@ SPDX-License-Identifier: MIT
               </div>
             </td>
             <td
-              v-if="activeColumns.includes('downloads')"
-              key="col-downloads"
-              class="py-3 px-2 text-right"
-            >
-              {{ hasData(row.downloads) ? formatNumberShort(row.downloads) : '-' }}
-            </td>
-            <td
               v-if="activeColumns.includes('dockerHubPulls')"
               key="col-dockerHubPulls"
               class="py-3 px-2 text-right"
@@ -681,7 +659,6 @@ type ColumnGroup = (typeof COLUMN_GROUPS)[number];
 const COLUMN_CONFIG = [
   { key: 'stars', label: 'Stars', defaultOn: true, group: 'Growth' as ColumnGroup },
   { key: 'forks', label: 'Forks', defaultOn: false, group: 'Growth' as ColumnGroup },
-  { key: 'downloads', label: 'Downloads', defaultOn: true, group: 'Growth' as ColumnGroup },
   { key: 'dockerHubPulls', label: 'Docker Pulls', defaultOn: false, group: 'Growth' as ColumnGroup },
   { key: 'dependentRepositories', label: 'Dependent Repos', defaultOn: false, group: 'Growth' as ColumnGroup },
   { key: 'dependentPackages', label: 'Dependent Pkgs', defaultOn: false, group: 'Growth' as ColumnGroup },
@@ -762,7 +739,6 @@ type SortColumn =
   | 'timeToClose'
   | 'issueResponseTime'
   | 'noResponseIssues'
-  | 'downloads'
   | 'dockerHubPulls'
   | 'dependentRepositories'
   | 'dependentPackages'
@@ -815,8 +791,6 @@ const leaderboardData = computed<ProjectLeaderboardRow[]>(() => {
     issueResponseTimeDelta: p.issueResponseTimeDays30d,
     noResponseIssues: p.noResponseIssues,
     noResponseIssuesDelta: p.noResponseIssues30d,
-    downloads: p.downloads,
-    downloadsDelta: p.downloads30d,
     cocomoValue: p.cocomoValue,
     prTimeToResolve: p.prResolveTimeDays,
     prTimeToResolveDelta: p.prResolveTimeDays30d,
@@ -897,8 +871,6 @@ const sortedData = computed(() => {
         return cmpNullLast(a.issueResponseTime, b.issueResponseTime, dir);
       case 'noResponseIssues':
         return cmpNullLast(a.noResponseIssues, b.noResponseIssues, dir);
-      case 'downloads':
-        return cmpNullLast(a.downloads, b.downloads, dir);
       case 'dockerHubPulls':
         return cmpNullLast(a.dockerHubPulls, b.dockerHubPulls, dir);
       case 'dependentRepositories':

--- a/frontend/server/api/report/agentic-ai-momentum/projects.get.ts
+++ b/frontend/server/api/report/agentic-ai-momentum/projects.get.ts
@@ -1,16 +1,20 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { fetchAgenticProjectsList } from '~~/server/data/tinybird/report/agentic-ai-momentum';
 import type {
   AgenticDataResponse,
+  AgenticEnrichedProject,
   AgenticProject,
   GitHubReleasesData,
-  AgenticEnrichedProject,
 } from '~~/types/report/agentic-ai-momentum.types';
+import { fetchAgenticProjectsList } from '~~/server/data/tinybird/report/agentic-ai-momentum';
 import projectsData from '~~/public/data/agentic-ai-momentum/projects.json';
 import releasesData from '~~/public/data/agentic-ai-momentum/github_releases_count.json';
 
 const SECONDS_PER_DAY = 86400;
+
+function normalizeUrl(url: string): string {
+  return url.toLowerCase().replace(/\/$/, '');
+}
 
 function secToDays(v: number | null): number | null {
   return v != null ? v / SECONDS_PER_DAY : null;
@@ -61,7 +65,6 @@ export default defineEventHandler(async (_event): Promise<AgenticEnrichedProject
         // All-time values
         stars: p.stars,
         forks: p.forks,
-        downloads: p.downloads,
         dockerPulls: p.docker_pulls,
         dependentRepos: p.dependent_repos,
         dependentPackages: p.dependent_packages,
@@ -79,7 +82,6 @@ export default defineEventHandler(async (_event): Promise<AgenticEnrichedProject
         // 30d delta values
         stars30d: p.stars_30d,
         forks30d: p.forks_30d,
-        downloads30d: p.downloads_30d,
         dockerPulls30d: p.docker_pulls_30d,
         commits30d: p.commits_30d,
         contributors30d: p.contributors_30d,
@@ -103,7 +105,3 @@ export default defineEventHandler(async (_event): Promise<AgenticEnrichedProject
     });
   }
 });
-
-function normalizeUrl(url: string): string {
-  return url.toLowerCase().replace(/\/$/, '');
-}

--- a/frontend/types/report/agentic-ai-momentum.types.ts
+++ b/frontend/types/report/agentic-ai-momentum.types.ts
@@ -94,8 +94,6 @@ export interface ProjectLeaderboardRow {
   mergeRateDelta: number | null;
   timeToClose: number | null;
   timeToCloseDelta: number | null;
-  downloads: number | null;
-  downloadsDelta: number | null;
   cocomoValue: number | null;
   prTimeToResolve: number | null;
   prTimeToResolveDelta: number | null;
@@ -122,7 +120,6 @@ export type MetricKey =
   | 'stars'
   | 'forks'
   | 'contributors'
-  | 'downloads'
   | 'mergeRate'
   | 'timeToClose'
   | 'commits'
@@ -198,8 +195,6 @@ export interface AgenticTbProjectRow {
   stars_30d: number | null;
   forks: number | null;
   forks_30d: number | null;
-  downloads: number | null;
-  downloads_30d: number | null;
   docker_pulls: number | null;
   docker_pulls_30d: number | null;
   dependent_repos: number | null;
@@ -234,7 +229,6 @@ export interface AgenticEnrichedProject {
   // All-time values
   stars: number | null;
   forks: number | null;
-  downloads: number | null;
   dockerPulls: number | null;
   dependentRepos: number | null;
   dependentPackages: number | null;
@@ -252,7 +246,6 @@ export interface AgenticEnrichedProject {
   // 30d delta values
   stars30d: number | null;
   forks30d: number | null;
-  downloads30d: number | null;
   dockerPulls30d: number | null;
   commits30d: number | null;
   contributors30d: number | null;


### PR DESCRIPTION
Removes download counts from project leaderboard and metric explorer for the AAIm dashboard. There were concerns about reliability and consistency so we decided to remove them altogether.