### PR TITLE
docs: add public repositories requirement to what-is-insights

### DIFF
--- a/frontend/docs/introduction/what-is-insights/index.md
+++ b/frontend/docs/introduction/what-is-insights/index.md
@@ -29,6 +29,10 @@ Insights acts as your early warning system. It helps you avoid risky dependencie
 
 Because software development is not just about what works today. It’s about what lasts.
 
+## Requirements
+
+Insights only tracks **public repositories**. Private repositories are not supported.
+
 ## Outlook
 
 Insights was relaunched in May 2025 with a renewed focus on clarity, transparency, and usability for developers.


### PR DESCRIPTION
This pull request adds a new section to the documentation clarifying that Insights only tracks public repositories and does not support private repositories.

- Documentation update:
  * Added a "Requirements" section to `frontend/docs/introduction/what-is-insights/index.md` specifying that Insights only tracks public repositories.