### PR TITLE
fix: allow security update reruns after previous workflow closes

### DIFF
--- a/frontend/app/components/modules/project/components/security/control-assessment-head.vue
+++ b/frontend/app/components/modules/project/components/security/control-assessment-head.vue
@@ -106,9 +106,19 @@ const handleUpdateResultsClick = async () => {
     );
   } catch (error) {
     console.error('Failed to trigger security update:', error);
-    showToast('An error occurred while triggering the update', ToastTypesEnum.negative, 'circle-exclamation', 5000, {
-      summary: 'Failed to update results',
-    });
+    const statusCode = (error as { statusCode?: number })?.statusCode;
+    const isAlreadyRunning = statusCode === 429;
+    showToast(
+      isAlreadyRunning
+        ? 'A security update is already running for this repository. Please wait for it to finish before triggering another one.'
+        : 'An error occurred while triggering the update',
+      ToastTypesEnum.negative,
+      'circle-exclamation',
+      5000,
+      {
+        summary: isAlreadyRunning ? 'Update already in progress' : 'Failed to update results',
+      },
+    );
   } finally {
     isUpdatingResults.value = false;
   }

--- a/frontend/server/api/security/update.post.ts
+++ b/frontend/server/api/security/update.post.ts
@@ -95,8 +95,9 @@ export default defineEventHandler(async (event): Promise<SecurityUpdateResponse 
       token,
     };
 
-    // Use static workflowId per repo to prevent duplicate workflows for the same repo
-    // WorkflowIdReusePolicy.REJECT_DUPLICATE will reject if workflow is already running
+    // Use static workflowId per repo so concurrent triggers for the same repo collide.
+    // workflowIdConflictPolicy: 'FAIL' rejects only when a workflow with this ID is currently
+    // running; once the previous run has closed, the ID can be reused for a fresh update.
     // Sanitize repoUrl for use in workflowId (replace non-alphanumeric chars with dashes)
     const sanitizedRepo = body.repoUrl.replace(/[^a-zA-Z0-9]/g, '-').replace(/-+/g, '-');
     const workflowId = `security-update-${slug}-${sanitizedRepo}`;
@@ -104,7 +105,8 @@ export default defineEventHandler(async (event): Promise<SecurityUpdateResponse 
     await client.workflow.start(UPSERT_OSPS_BASELINE_WORKFLOW, {
       taskQueue: SECURITY_BEST_PRACTICES_TASK_QUEUE,
       workflowId,
-      workflowIdReusePolicy: 'REJECT_DUPLICATE',
+      workflowIdReusePolicy: 'ALLOW_DUPLICATE',
+      workflowIdConflictPolicy: 'FAIL',
       args: [workflowParams],
     });
 


### PR DESCRIPTION
## Summary

- Triggering a security assessment update for a repo currently returns `429 — A security update is already in progress for this project` even when no workflow is running, after any prior run has closed.
- Root cause: the endpoint used `workflowIdReusePolicy: 'REJECT_DUPLICATE'` with a static workflow ID per repo. `REJECT_DUPLICATE` blocks all reuse once the prior run has *closed* (it is not scoped to running workflows), so the first successful run permanently poisoned that workflow ID.
- Switched to `workflowIdReusePolicy: 'ALLOW_DUPLICATE'` + `workflowIdConflictPolicy: 'FAIL'`. This is the policy combination that matches the original intent: reject only when a workflow with the same ID is *currently running*; allow a fresh run once the prior one has closed.

## Related

- Jira: IN-1187
- GitHub support ticket: https://github.com/linuxfoundation/insights/issues/1971

## Test plan

- [ ] Trigger a security update for a repo that has a previously completed security workflow — expect HTTP 200 and a new workflow to start.
- [ ] While a security update is running for a repo, trigger another update for the same repo — expect HTTP 429 with the existing "already in progress" message.
- [ ] Trigger a security update for a repo that has never had one — expect HTTP 200 (regression check).

🤖 Generated with [Claude Code](https://claude.com/claude-code)