### PR TITLE
fix: exclude disabled projects from collection queries

### DIFF
--- a/frontend/server/repo/communityCollection.repo.ts
+++ b/frontend/server/repo/communityCollection.repo.ts
@@ -327,7 +327,7 @@ export class CommunityCollectionRepository {
         `SELECT cip."collectionId", cip."insightsProjectId", cip.starred,
                 ip.name, ip.slug, ip."logoUrl"
          FROM "collectionsInsightsProjects" cip
-         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId"
+         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
          WHERE cip."collectionId" = ANY($1) AND cip."deletedAt" IS NULL`,
         [collectionIds],
       ),
@@ -442,7 +442,7 @@ export class CommunityCollectionRepository {
         `SELECT cip."insightsProjectId", cip.starred,
                 ip.name, ip.slug, ip."logoUrl"
          FROM "collectionsInsightsProjects" cip
-         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId"
+         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
          WHERE cip."collectionId" = $1 AND cip."deletedAt" IS NULL`,
         [collection.id],
       ),
@@ -523,7 +523,7 @@ export class CommunityCollectionRepository {
         `SELECT cip."collectionId", cip."insightsProjectId", cip.starred,
                 ip.name, ip.slug, ip."logoUrl"
          FROM "collectionsInsightsProjects" cip
-         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId"
+         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
          WHERE cip."collectionId" = ANY($1) AND cip."deletedAt" IS NULL`,
         [collectionIds],
       ),
@@ -604,8 +604,9 @@ export class CommunityCollectionRepository {
 
     const [projectsResult, reposResult] = await Promise.all([
       this.pool.query(
-        `SELECT "insightsProjectId" FROM "collectionsInsightsProjects"
-         WHERE "collectionId" = $1 AND "deletedAt" IS NULL`,
+        `SELECT cip."insightsProjectId" FROM "collectionsInsightsProjects" cip
+         JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
+         WHERE cip."collectionId" = $1 AND cip."deletedAt" IS NULL`,
         [collectionId],
       ),
       this.pool.query(

--- a/frontend/server/repo/communityCollection.repo.ts
+++ b/frontend/server/repo/communityCollection.repo.ts
@@ -327,7 +327,7 @@ export class CommunityCollectionRepository {
         `SELECT cip."collectionId", cip."insightsProjectId", cip.starred,
                 ip.name, ip.slug, ip."logoUrl"
          FROM "collectionsInsightsProjects" cip
-         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
+         JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
          WHERE cip."collectionId" = ANY($1) AND cip."deletedAt" IS NULL`,
         [collectionIds],
       ),
@@ -442,7 +442,7 @@ export class CommunityCollectionRepository {
         `SELECT cip."insightsProjectId", cip.starred,
                 ip.name, ip.slug, ip."logoUrl"
          FROM "collectionsInsightsProjects" cip
-         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
+         JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
          WHERE cip."collectionId" = $1 AND cip."deletedAt" IS NULL`,
         [collection.id],
       ),
@@ -523,7 +523,7 @@ export class CommunityCollectionRepository {
         `SELECT cip."collectionId", cip."insightsProjectId", cip.starred,
                 ip.name, ip.slug, ip."logoUrl"
          FROM "collectionsInsightsProjects" cip
-         LEFT JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
+         JOIN "insightsProjects" ip ON ip.id = cip."insightsProjectId" AND ip.enabled = true
          WHERE cip."collectionId" = ANY($1) AND cip."deletedAt" IS NULL`,
         [collectionIds],
       ),


### PR DESCRIPTION
## Summary

- `insightsProjects.enabled` was not checked in any `CommunityCollectionRepository` queries — disabled projects appeared in collection listings and were passed as IDs to Tinybird
- Added `AND ip.enabled = true` on all JOIN conditions to `insightsProjects` (3 list queries + `findProjectIdsBySlug` which feeds `project_repo_insights.json`)

## Related

Complements crowd.dev [PR #4313](https://github.com/linuxfoundation/crowd.dev/pull/4313) which adds `enabled = 1` gates to Tinybird pipes. This PR closes the Postgres side so disabled project IDs are never sent to Tinybird in the first place.

## Files changed

- `frontend/server/repo/communityCollection.repo.ts` — 4 queries patched

## Test plan

- [ ] Verify a disabled project no longer appears in collection detail page (`/collection/details/:slug`)
- [ ] Verify collection list pages no longer show disabled projects in project counts
- [ ] Verify enabled projects still appear correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)