### PR TITLE
feat(collections): remove software value, header gradient, compact achievements

### DIFF
--- a/frontend/app/components/modules/collection/components/details/badge-details.vue
+++ b/frontend/app/components/modules/collection/components/details/badge-details.vue
@@ -3,7 +3,7 @@ Copyright (c) 2025 The Linux Foundation and each contributor.
 SPDX-License-Identifier: MIT
 -->
 <template>
-  <div class="flex items-center gap-2">
+  <div class="flex items-center gap-1">
     <template v-if="badges.length > 0">
       <lfx-popover
         v-for="(count, tier) in badgeCountByTier"
@@ -13,12 +13,13 @@ SPDX-License-Identifier: MIT
         :allow-pass-through="true"
       >
         <lfx-chip
+          size="xsmall"
           :style="{ background: getBadgeColor(tier as BadgeTier) }"
-          class="flex items-center gap-1"
+          class="flex items-center gap-0.5 !px-1.5"
         >
           <lfx-icon
             name="hexagon"
-            :size="12"
+            :size="10"
             class="text-white"
           />
           <span class="text-white text-xs font-semibold">

--- a/frontend/app/components/modules/collection/components/details/collection-project-item.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-project-item.vue
@@ -80,10 +80,9 @@ SPDX-License-Identifier: MIT
           </template>
         </lfx-popover>
       </td>
-      <td class="w-1/12 py-4 px-2 whitespace-nowrap">
+      <td class="w-2/12 py-4 px-2 whitespace-nowrap">
         {{ formatNumber(props.project.contributorCount) }}
       </td>
-      <td class="w-1/12 py-4 px-2 whitespace-nowrap">${{ formatNumberShort(props.project.softwareValue || 0) }}</td>
       <td class="w-3/12 py-4 px-2 whitespace-nowrap">
         <lfx-popover
           placement="top"
@@ -108,8 +107,7 @@ SPDX-License-Identifier: MIT
     </template>
     <template v-else>
       <td class="w-2/12 py-4 px-2 text-neutral-400 whitespace-nowrap">-</td>
-      <td class="w-1/12 py-4 px-2 text-neutral-400 whitespace-nowrap">-</td>
-      <td class="w-1/12 py-4 px-2 text-neutral-400 whitespace-nowrap">-</td>
+      <td class="w-2/12 py-4 px-2 text-neutral-400 whitespace-nowrap">-</td>
       <td class="w-3/12 py-4 px-2 text-neutral-400 whitespace-nowrap">-</td>
       <td class="w-2/12 py-4 px-2 text-neutral-400 whitespace-nowrap">-</td>
     </template>
@@ -175,15 +173,6 @@ SPDX-License-Identifier: MIT
             class="text-neutral-500"
           />
           <span>{{ formatNumber(props.project.contributorCount) }}</span>
-          <template v-if="props.project.softwareValue">
-            <span class="text-neutral-400">・</span>
-            <lfx-icon
-              name="circle-dollar"
-              :size="12"
-              class="text-neutral-500"
-            />
-            <span>${{ formatNumberShort(props.project.softwareValue) }}</span>
-          </template>
         </template>
         <template v-else>
           <span class="text-neutral-400">No data available</span>
@@ -200,7 +189,7 @@ import type { ProjectInsights } from '~~/types/project';
 import LfxOrganizationLogo from '~/components/uikit/organization-logo/organization-logo.vue';
 import LfxArchivedTag from '~/components/shared/components/archived-tag.vue';
 import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
-import { formatNumber, formatNumberShort } from '~/components/shared/utils/formatter';
+import { formatNumber } from '~/components/shared/utils/formatter';
 import { LfxRoutes } from '~/components/shared/types/routes';
 import LfxHealthScore from '~/components/shared/components/health-score.vue';
 import LfxHealthScoreDetails from '~/components/modules/collection/components/details/health-score-details.vue';

--- a/frontend/app/components/modules/collection/components/details/header.vue
+++ b/frontend/app/components/modules/collection/components/details/header.vue
@@ -426,7 +426,7 @@ const { scrollTop } = useScroll();
 const allTabs = computed(() => collectionTabs(user.value));
 
 const collectionTab = computed(() => allTabs.value.find((tab) => tab.type === props.type) || allTabs.value[0]);
-const headerBackgroundStyle = computed(() => headerBackground(props.type, props.collection?.color));
+const headerBackgroundStyle = computed(() => headerBackground());
 
 const projectCount = computed(() => (props.collection?.projectCount || 0) + (props.collection?.repositoryCount || 0));
 

--- a/frontend/app/components/modules/collection/config/collection-type-config.ts
+++ b/frontend/app/components/modules/collection/config/collection-type-config.ts
@@ -56,22 +56,8 @@ export const collectionTabs = (_user?: User | null): CollectionTypesTabs[] => {
   return tabs;
 };
 
-// This only applies to the collection details page header
-export const headerBackground = (type?: CollectionType, curatedColor?: string | null) => {
-  switch (type) {
-    case CollectionTypeEnum.CURATED:
-      return {
-        background: curatedColor
-          ? `linear-gradient(0deg, ${curatedColor}00, ${curatedColor}0D), var(--White, #FFF)`
-          : 'linear-gradient(0deg, #0F172B00, #0F172B0D), var(--White, #FFF)',
-      };
-    case CollectionTypeEnum.COMMUNITY:
-      return {
-        background: 'linear-gradient(0deg, #009AFF00, #009AFF0D), var(--White, #FFF)',
-      };
-    default:
-      return {
-        background: 'linear-gradient(0deg, #8E51FF00, #8E51FF0D), var(--White, #FFF)',
-      };
-  }
-};
+// This only applies to the collection details page header.
+// Collections v2 (IN-1194): headers use a plain, consistent background — no gradient — on every collection type.
+export const headerBackground = () => ({
+  background: 'var(--White, #FFF)',
+});

--- a/frontend/app/components/modules/collection/views/collection-details.vue
+++ b/frontend/app/components/modules/collection/views/collection-details.vue
@@ -53,7 +53,7 @@ SPDX-License-Identifier: MIT
               </th>
               <th class="w-2/12 py-5 px-2 text-left whitespace-nowrap font-semibold">Health Score</th>
               <th
-                class="w-1/12 py-5 px-2 text-left whitespace-nowrap cursor-pointer group"
+                class="w-2/12 py-5 px-2 text-left whitespace-nowrap cursor-pointer group"
                 @click="handleSort('contributorCount')"
               >
                 <span class="inline-flex items-center gap-1">
@@ -65,7 +65,6 @@ SPDX-License-Identifier: MIT
                   />
                 </span>
               </th>
-              <th class="w-1/12 py-5 px-2 text-left whitespace-nowrap font-semibold">Software value</th>
               <th class="w-3/12 py-5 px-2 text-left whitespace-nowrap font-semibold">
                 Contributor/Organization dependency
               </th>


### PR DESCRIPTION
## Summary

- Removes the "Software Value" column from all collection detail pages (Community + LF Foundation) — retired due to AI-generated contribution distortion, no replacement.
- Removes the gradient background from collection detail page headers — all types (curated/community/my-collections) now use a plain white header.
- Redesigns the Achievements badge cluster to a more compact layout (smaller chip size, tighter spacing/icon), same underlying achievement data.

## Ticket

IN-1194 — part of epic IN-1191 (Collections v2 UI). PR targets the epic release branch `release/IN-1191-collections-v2`, not `main`.

## Acceptance criteria

- [x] Software Value column absent from all collection detail pages (table header, row cells, mobile card)
- [x] No gradient background on any collection page header
- [x] Achievements column renders in the new compact layout

## Notes

- Column widths in the projects table were rebalanced (Contributors absorbed the width freed by the removed Software Value column) — verified all columns still sum to 12/12 across the header and both row states (onboarded / not-onboarded).
- `collection-card.vue` (the list-page card gradient) was intentionally left untouched — this ticket scopes only the collection *detail page* header, not list cards.
- Out of scope (per ticket + confirmed plan): Lifecycle/Health-band/Impact score columns belong to the separate Akrites methodology epic.

## Test plan

- [x] `pnpm tsc-check` — clean
- [x] `pnpm lint` — 0 errors (9 pre-existing warnings, unrelated files)
- [ ] Manual QA: open a curated collection and a community collection detail page, confirm no gradient, no Software Value column, compact achievement badges

<https://claude.ai/code/session_01EVEwYbhbFwrXPRHt1HiKeE>

- `release/IN-1191-collections-v2` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat(collections): remove software value, header gradient, compact achievements** :point\_left:
