### PR TITLE
chore: enable organization page (IN-1174)

### DIFF
--- a/frontend/app/components/modules/explore/components/top-organizations.vue
+++ b/frontend/app/components/modules/explore/components/top-organizations.vue
@@ -17,8 +17,14 @@ SPDX-License-Identifier: MIT
         v-for="(row, index) in tableData"
         :key="row.id"
         class="lfx-table-row text-inherit"
+        :class="row.slug ? 'cursor-pointer' : ''"
       >
-        <div class="name-col grow !gap-3">
+        <component
+          :is="row.slug ? nuxtLink : 'div'"
+          :to="row.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: row.slug } } : undefined"
+          class="name-col grow !gap-3 text-inherit no-underline"
+          :class="row.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
+        >
           <div class="mr-1 text-neutral-400 text-xs">#{{ index + 1 }}</div>
           <lfx-avatar
             :src="row.logo"
@@ -31,18 +37,19 @@ SPDX-License-Identifier: MIT
           >
             {{ row.displayName }}
           </div>
-        </div>
+        </component>
       </div>
     </div>
   </lfx-project-load-state>
 </template>
 
 <script setup lang="ts">
-import { computed, onServerPrefetch } from 'vue';
+import { computed, resolveComponent, onServerPrefetch } from 'vue';
 import { EXPLORE_API_SERVICE } from '~/components/modules/explore/services/explore.api.service';
 import LfxAvatar from '~/components/uikit/avatar/avatar.vue';
 import { isEmptyData } from '~/components/shared/utils/helper';
 import LfxProjectLoadState from '~/components/modules/project/components/shared/load-state.vue';
+import { LfxRoutes } from '~/components/shared/types/routes';
 
 const props = defineProps<{
   isFullList?: boolean;
@@ -52,6 +59,7 @@ const { data, isPending, status, error, suspense } = EXPLORE_API_SERVICE.fetchTo
   props.isFullList ? 100 : 10,
 );
 
+const nuxtLink = resolveComponent('NuxtLink');
 const tableData = computed(() => data.value);
 
 const isEmpty = computed(() => isEmptyData(tableData.value as unknown as Record<string, unknown>[]));

--- a/frontend/app/components/modules/leaderboards/components/minimize-row-displays/organization-row.vue
+++ b/frontend/app/components/modules/leaderboards/components/minimize-row-displays/organization-row.vue
@@ -4,13 +4,16 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-  <div class="flex items-center w-full">
+  <div
+    class="flex items-center w-full"
+    :class="item.slug ? 'cursor-pointer' : ''"
+  >
     <!-- Organization info -->
     <component
-      :is="isTeamMember && item.slug ? nuxtLink : 'div'"
-      :to="isTeamMember && item.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
+      :is="item.slug ? nuxtLink : 'div'"
+      :to="item.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
       class="flex-1 min-w-0 flex gap-3 items-center text-inherit no-underline"
-      :class="isTeamMember && item.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
+      :class="item.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
     >
       <lfx-avatar
         :src="item.logoUrl"
@@ -35,13 +38,12 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed, resolveComponent } from 'vue';
+import { resolveComponent } from 'vue';
 import type { LeaderboardConfig } from '../../config/types/leaderboard.types';
 import NumericDataDisplay from '../data-displays/numeric.vue';
 import type { Leaderboard } from '~~/types/leaderboard/leaderboard';
 import LfxAvatar from '~/components/uikit/avatar/avatar.vue';
 import { LfxRoutes } from '~/components/shared/types/routes';
-import { useAuth } from '~~/composables/useAuth';
 
 defineProps<{
   item: Leaderboard;
@@ -49,8 +51,6 @@ defineProps<{
 }>();
 
 const nuxtLink = resolveComponent('NuxtLink');
-const { user } = useAuth();
-const isTeamMember = computed(() => !!user.value?.isLfInsightsTeamMember);
 </script>
 
 <script lang="ts">

--- a/frontend/app/components/modules/leaderboards/components/row-displays/organization-row.vue
+++ b/frontend/app/components/modules/leaderboards/components/row-displays/organization-row.vue
@@ -4,7 +4,10 @@ SPDX-License-Identifier: MIT
 -->
 
 <template>
-  <div class="flex items-center w-full hover:bg-neutral-50 rounded-lg transition-all duration-300 sm:px-3 px-0 h-15">
+  <div
+    class="flex items-center w-full hover:bg-neutral-50 rounded-lg transition-all duration-300 sm:px-3 px-0 h-15"
+    :class="item.slug ? 'cursor-pointer' : ''"
+  >
     <!-- Rank -->
     <div class="w-10 shrink-0 text-neutral-900 font-secondary overflow-hidden overflow-ellipsis">
       {{ item.rank }}
@@ -12,10 +15,10 @@ SPDX-License-Identifier: MIT
 
     <!-- Organization info -->
     <component
-      :is="isTeamMember && item.slug ? nuxtLink : 'div'"
-      :to="isTeamMember && item.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
+      :is="item.slug ? nuxtLink : 'div'"
+      :to="item.slug ? { name: LfxRoutes.ORGANIZATION, params: { orgSlug: item.slug } } : undefined"
       class="flex-1 min-w-0 flex gap-3 items-center text-inherit no-underline"
-      :class="isTeamMember && item.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
+      :class="item.slug ? 'hover:text-brand-500 transition-colors cursor-pointer' : ''"
     >
       <lfx-avatar
         :src="item.logoUrl"
@@ -44,14 +47,13 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed, resolveComponent } from 'vue';
+import { resolveComponent } from 'vue';
 import type { LeaderboardConfig } from '../../config/types/leaderboard.types';
 import NumericDataDisplay from '../data-displays/numeric.vue';
 import NumericTrends from '../trends/numeric-trends.vue';
 import type { Leaderboard } from '~~/types/leaderboard/leaderboard';
 import LfxAvatar from '~/components/uikit/avatar/avatar.vue';
 import { LfxRoutes } from '~/components/shared/types/routes';
-import { useAuth } from '~~/composables/useAuth';
 
 defineProps<{
   item: Leaderboard;
@@ -59,8 +61,6 @@ defineProps<{
 }>();
 
 const nuxtLink = resolveComponent('NuxtLink');
-const { user } = useAuth();
-const isTeamMember = computed(() => !!user.value?.isLfInsightsTeamMember);
 </script>
 
 <script lang="ts">

--- a/frontend/app/components/modules/organization/components/header.vue
+++ b/frontend/app/components/modules/organization/components/header.vue
@@ -173,7 +173,7 @@ SPDX-License-Identifier: MIT
                         name="arrow-up-right-from-square"
                         :size="14"
                       />
-                      Open in LFX Self-Serve
+                      Open in LFX
                     </lfx-button>
                   </a>
                   <template #content>

--- a/frontend/app/components/modules/organization/components/overview/locked-contributors-section.vue
+++ b/frontend/app/components/modules/organization/components/overview/locked-contributors-section.vue
@@ -20,8 +20,8 @@ SPDX-License-Identifier: MIT
           button-style="pill"
           size="medium"
         >
-          <span class="sm:hidden">Open in LFX Self-Serve</span>
-          <span class="hidden sm:inline">Check your organization data in LFX Self-Serve</span>
+          <span class="sm:hidden">Open in LFX</span>
+          <span class="hidden sm:inline">Check your organization data in LFX</span>
           <lfx-icon
             name="arrow-up-right-from-square"
             :size="12"

--- a/frontend/app/components/modules/widget/components/contributors/fragments/organizations-table.vue
+++ b/frontend/app/components/modules/widget/components/contributors/fragments/organizations-table.vue
@@ -28,6 +28,7 @@ SPDX-License-Identifier: MIT
         v-for="(organization, index) in props.organizations"
         :key="`${organization.name}-${index}`"
         class="lfx-table-row"
+        :class="organization.slug ? 'cursor-pointer' : ''"
       >
         <div class="name-col">
           <div
@@ -37,9 +38,9 @@ SPDX-License-Identifier: MIT
             {{ index + 1 }}
           </div>
           <nuxt-link
-            v-if="isTeamMember && organization.slug"
+            v-if="organization.slug"
             :to="`/organization/${organization.slug}`"
-            class="flex items-center gap-2 min-w-0 overflow-hidden no-underline text-inherit"
+            class="flex items-center gap-2 min-w-0 overflow-hidden no-underline text-inherit cursor-pointer"
           >
             <lfx-avatar
               :src="organization.logo"
@@ -107,7 +108,6 @@ import { formatNumber } from '~/components/shared/utils/formatter';
 import LfxScrollableShadow from '~/components/uikit/scrollable-shadow/scrollable-shadow.vue';
 import LfxSpinner from '~/components/uikit/spinner/spinner.vue';
 import { isElementVisible } from '~/components/shared/utils/helper';
-import { useAuth } from '~~/composables/useAuth';
 
 const emit = defineEmits<{ (e: 'loadMore'): void }>();
 const loadMore = ref(null);
@@ -130,9 +130,6 @@ const props = withDefaults(
 );
 
 const showLoadMore = computed(() => props.hasNextPage && props.showFullList);
-
-const { user } = useAuth();
-const isTeamMember = computed(() => !!user.value?.isLfInsightsTeamMember);
 
 const options = {
   root: null,

--- a/frontend/docs/.vitepress/config.ts
+++ b/frontend/docs/.vitepress/config.ts
@@ -84,6 +84,7 @@ export default defineConfig({
           { text: 'LFX Data Copilot', link: '/features/lfx-data-copilot/index.md' },
           { text: 'Repository Groups', link: '/features/repository-groups/index.md' },
           { text: 'Community Collections', link: '/features/community-collections/index.md' },
+          { text: 'Organization Page', link: '/features/organization-page/index.md' },
         ],
       },
       {

--- a/frontend/docs/features/organization-page/index.md
+++ b/frontend/docs/features/organization-page/index.md
@@ -1,0 +1,35 @@
+# Organization Page
+
+Use the Organization Page to understand how your company contributes to critical open source projects — who is contributing, which projects you're involved in, and how your engagement has changed over time.
+
+## Key Metrics
+
+Three numbers at the top of the page give you an at-a-glance health check of your organization's open source activity over the **last 365 days**:
+
+- **Active contributors** — how many of your employees made at least one code contribution (commit, pull request, or issue). Shows a year-over-year trend so you can see if engagement is growing or declining.
+- **Maintainer roles** — how many maintainer or owner roles your contributors hold across all projects. A higher number signals deeper trust and influence in those communities.
+- **Critical projects** — how many distinct projects your team contributed to. Useful for gauging breadth of involvement.
+
+## Activity Over Time
+
+A bar chart showing your organization's total code contributions per year, from the earliest recorded activity to today. Use it to spot periods of growth, sustained investment, or pullback across your open source program.
+
+## Contributors Over Time
+
+A bar chart showing how many unique contributors your organization had per year. Pair it with the Activity chart to distinguish between a growing team and a shrinking one that's working harder.
+
+## Critical Projects
+
+A ranked table of the projects your contributors were involved in, ordered by **Technical influence** — your organization's share of code contributions relative to what the whole project community produced.
+
+Each project row shows:
+
+- **Technical influence** — one of four levels based on your contribution share:
+  - **Leading** — a large share; your team is a primary driver of the project.
+  - **Contributing** — a meaningful share; consistent and committed involvement.
+  - **Participating** — a small but non-zero share; actively helping.
+  - **Silent** — minimal or no code contribution activity.
+- **Contributors** — number of your employees active in that project.
+- **Activities** — total code contributions your team made.
+
+The table covers an extended rolling window of recent years and counts only code contribution activity types.

--- a/frontend/docs/features/organization-page/index.md
+++ b/frontend/docs/features/organization-page/index.md
@@ -6,7 +6,7 @@ Use the Organization Page to understand how your company contributes to critical
 
 Three numbers at the top of the page give you an at-a-glance health check of your organization's open source activity over the **last 365 days**:
 
-- **Active contributors** — how many of your employees made at least one code contribution (commit, pull request, or issue). Shows a year-over-year trend so you can see if engagement is growing or declining.
+- **Active contributors** — how many of your employees made at least one code contribution (commit, pull request, or code review). Shows a year-over-year trend so you can see if engagement is growing or declining.
 - **Maintainer roles** — how many maintainer or owner roles your contributors hold across all projects. A higher number signals deeper trust and influence in those communities.
 - **Critical projects** — how many distinct projects your team contributed to. Useful for gauging breadth of involvement.
 

--- a/frontend/types/explore/organizations.ts
+++ b/frontend/types/explore/organizations.ts
@@ -5,4 +5,5 @@ export interface ExploreOrganizations {
   logo?: string;
   displayName: string;
   activityCount: number;
+  slug?: string;
 }


### PR DESCRIPTION
This pull request updates several organization-related UI components to improve consistency and user experience. The main changes make organization rows and names consistently clickable (navigating to the organization page when a `slug` is present), simplify access logic for links, and update some LFX-related labels. Documentation for the Organization Page is also added.

**Clickable Organization Rows and Navigation Consistency**
- Made organization rows in leaderboard, explore, and widget tables consistently clickable by wrapping them in a `NuxtLink` when a `slug` is present, and applying pointer/hover styles. Removed previous logic that restricted links to team members only. [[1]](diffhunk://#diff-617300a5f712115e70dbdf5e16da83763090544a227a32412b07a698f4f89cd5R20-L21) [[2]](diffhunk://#diff-d03d785d1a7f3986ff16798a0b015fcb6b07cfaba87d6295795a6990837b326eL7-R16) [[3]](diffhunk://#diff-82bc3b2e0d58db92db8c20327e7b7a8da3212dd0d8de236a43a645999906c72bL7-R21) [[4]](diffhunk://#diff-3813a9f8b9e1dd15c2c9b67288cf191b844f8cf3aa0a003906e51aa46d4d3b22R31) [[5]](diffhunk://#diff-3813a9f8b9e1dd15c2c9b67288cf191b844f8cf3aa0a003906e51aa46d4d3b22L40-R43) [[6]](diffhunk://#diff-f22bae88004b6653455f18650818061ae9bee3482088cee0358e66e228fb694fR8)

**Code Simplification and Cleanup**
- Removed unused authentication logic and related computed properties from leaderboard and widget components, as link visibility is now based solely on the presence of a `slug`. [[1]](diffhunk://#diff-d03d785d1a7f3986ff16798a0b015fcb6b07cfaba87d6295795a6990837b326eL38-L53) [[2]](diffhunk://#diff-82bc3b2e0d58db92db8c20327e7b7a8da3212dd0d8de236a43a645999906c72bL47-L63) [[3]](diffhunk://#diff-3813a9f8b9e1dd15c2c9b67288cf191b844f8cf3aa0a003906e51aa46d4d3b22L110) [[4]](diffhunk://#diff-3813a9f8b9e1dd15c2c9b67288cf191b844f8cf3aa0a003906e51aa46d4d3b22L134-L136)

**UI/UX Copy Updates**
- Updated button and tooltip labels from "Open in LFX Self-Serve" to "Open in LFX" for clarity and consistency across organization-related components. [[1]](diffhunk://#diff-107637a7dba23dc3287fc43e115d574c6b5abdf6ae90a193f652470c5af24b0cL176-R176) [[2]](diffhunk://#diff-70c04d5309df9ab6c169129a46b08b387a23a56a3d73510974c7aa5e9c7c4973L23-R24)

**Documentation**
- Added a new documentation page describing the Organization Page, its metrics, and usage, and linked it in the VitePress navigation. [[1]](diffhunk://#diff-ef6e1d11b5f099de7b2f3d477babe3d8b939f424efebcb05feead5874c26fbedR87) [[2]](diffhunk://#diff-7fdd18047c3d57d98c9d6ccd2b894b41dc6cc66085d22569468657efa2c0fc78R1-R35)

**Type Updates**
- Added the optional `slug` property to the `ExploreOrganizations` type to support navigation logic.