### PR TITLE
docs: sync docs with recent changes

### DIFF
--- a/frontend/docs/features/community-collections/index.md
+++ b/frontend/docs/features/community-collections/index.md
@@ -27,6 +27,29 @@ My Collections is your personal hub for the collections you've created and the o
 - **My Created Collections** — a grid of your own collections. You will be able to make changes to the collection at any time.
 - **Liked Collections** — collections you've liked, separated by a labelled divider. Can include Curated, Community, or other users' collections.
 
+## Collection Detail
+
+Each collection has a detail page showing analytics data across all of its projects in one place.
+
+### Summary metrics
+
+The header shows three at-a-glance figures for the collection:
+
+- **Projects / Repositories** — total number of tracked items in the collection.
+- **Contributors** — total number of unique contributors across all projects.
+- **Avg. Health** — average [Health Score](/metrics/health-score/index.md) across onboarded projects, shown as a labelled category (Excellent, Healthy, Fair, Concerning, or Critical) alongside the numeric value.
+
+### Tabs
+
+The detail page is split into four tabs:
+
+- **Projects** — the full list of projects in the collection. Each row shows the project's Health Score category, contributor count, and badge achievements. Use the **Only Linux Foundation projects** toggle to narrow the list to LF-hosted projects only.
+- **Contributors** — contributor analytics aggregated across all projects in the collection, including active contributors, geographical distribution, and contributor leaderboard.
+- **Popularity** — popularity signals such as stars, forks, and downloads, aggregated across the collection.
+- **Development** — development activity such as commits, pull requests, and issues, aggregated across the collection.
+
+A date range selector is available on the Contributors, Popularity, and Development tabs and applies to all metrics shown on that tab.
+
 ## How to manage your own Collections
 
 You must be signed in to be able to manage Collections.


### PR DESCRIPTION
## What changed
- **Community Collections** (`frontend/docs/features/community-collections/index.md`): Added a new "Collection Detail" section documenting the metrics summary row (Projects/Repositories, Contributors, Avg. Health) and the four-tab navigation (Projects, Contributors, Popularity, Development) that was introduced in the Collections v2 UI. The Contributors, Popularity, and Development tabs now show real aggregated analytics data across all projects in the collection, and a date range selector is available on those tabs.

## Source commits
- `ac2c05e` — feat: collections v2 UI (IN-1193, IN-1194, IN-1195)
- `8b6a708` — feat: wire Collection Contributors/Popularity/Development tabs to real widgets IN-1191

## Notes
- The three other commits merged this week (`a88bcb7`, `e48b1b4`, `f3ff95a`) already included their own doc updates and were skipped.
- The health score labels (Excellent/Healthy/Fair/Concerning/Critical) and their numeric thresholds are as implemented in `collection-health-score-pill.vue` — reviewers should verify these match what's shown in production before merging.

---
_Generated by [Claude Code](https://claude.ai/code/session_014G9HxDYNkTPj2PTC5YSfPp)_