### PR TITLE
docs: sync docs with recent changes

### DIFF
--- a/frontend/docs/features/community-collections/index.md
+++ b/frontend/docs/features/community-collections/index.md
@@ -53,6 +53,25 @@ Click the **Share** button on the Collection Detail page to open the share flow.
 
 Click the duplicate icon on a collection card or on the Collection Detail page to create a copy under your My Collections.
 
+## Collection Detail Page
+
+Every collection detail page shows a header with three aggregate metrics that summarise the collection's combined projects:
+
+- **Projects / Repositories** — the total number of projects and repositories included in the collection.
+- **Contributors** — the total number of unique contributors across all projects in the collection.
+- **Avg. Health** — the average Health Score across all projects, labelled as **Excellent** (80+), **Healthy** (60–79), **Fair** (40–59), **Concerning** (20–39), or **Critical** (below 20).
+
+### Tabs (Curated Collections only)
+
+Linux Foundation–curated collections offer four tabs for deeper analysis across the collection as a whole:
+
+- **Projects** — the default view: a sortable table of all projects in the collection, with their Health Score, contributor count, contributor/organization dependency, and achievements.
+- **Contributors** — contributor-focused widgets aggregated across every project: active contributors, active organizations, contributor and organization leaderboards, geographical distribution, and dependency metrics.
+- **Popularity** — popularity widgets aggregated across every project, including stars and forks over time.
+- **Development** — development-focused widgets aggregated across every project, including active contributors and active organizations over time.
+
+A date range picker is available on the Contributors, Popularity, and Development tabs to scope all widgets to a specific time window. Community collections and personal collections show only the Projects view.
+
 ## Collection Visibility
 
 User-created collections support two visibility states, private and public.


### PR DESCRIPTION
## What changed
- **Community Collections** (`frontend/docs/features/community-collections/index.md`): Added a new "Collection Detail Page" section describing the aggregate metrics row (Projects/Repositories, Contributors, Avg. Health) visible on every collection, and the four-tab layout (Projects, Contributors, Popularity, Development) available exclusively on Linux Foundation–curated collections. Also documents that the date range picker is present on the three widget tabs and that community/personal collections show only the Projects view.

## Source commits
- `ac2c05e` — feat: collections v2 UI (IN-1193, IN-1194, IN-1195) — introduced the metrics row, the four-tab layout, and the new routes
- `8b6a7082` — feat: wire Collection Contributors/Popularity/Development tabs to real widgets IN-1191 — connected the tabs to live widget data

## Notes
- The tabs (Contributors, Popularity, Development) are confirmed in source to appear **only** on curated collections (`CollectionTypeEnum.CURATED`); community and personal collections are explicitly guarded and redirected to the Projects tab.
- Avg. Health labels (Excellent/Healthy/Fair/Concerning/Critical) and thresholds are taken directly from `collection-metrics-row.vue`.
- The date range picker condition is confirmed in `[slug].vue` (`isAggregateWidgetTab` checks for the three widget-driven routes).


---
_Generated by [Claude Code](https://claude.ai/code/session_01YHEgciDoqxUyq1Xf9MbgrA)_