### PR TITLE
chore: update LFX org page links to app.lfx.dev

### DIFF
--- a/frontend/app/components/modules/organization/components/header.vue
+++ b/frontend/app/components/modules/organization/components/header.vue
@@ -158,7 +158,7 @@ SPDX-License-Identifier: MIT
                   :allow-pass-through="true"
                 >
                   <a
-                    href="https://myorg.lfx.dev"
+                    href="https://app.lfx.dev/org/projects"
                     target="_blank"
                     rel="noopener noreferrer"
                     class="no-underline"

--- a/frontend/app/components/modules/organization/components/overview/locked-contributors-section.vue
+++ b/frontend/app/components/modules/organization/components/overview/locked-contributors-section.vue
@@ -10,7 +10,7 @@ SPDX-License-Identifier: MIT
       <p class="font-semibold text-neutral-900">Working at {{ orgDisplayName }}?</p>
       <p class="text-sm text-neutral-500">Get person-level insights about your open source contributions.</p>
       <a
-        href="https://myorg.lfx.dev"
+        href="https://app.lfx.dev/org/projects"
         target="_blank"
         rel="noopener noreferrer"
         class="no-underline mt-1"


### PR DESCRIPTION
## Summary
- Update "Open in LFX" button link in organization header
- Update "Check your organization data in LFX" button link in locked contributors section
- Both now point to `https://app.lfx.dev/org/projects` instead of `https://myorg.lfx.dev`

## Test plan
- [ ] Visit an organization page and verify "Open in LFX" button links to `https://app.lfx.dev/org/projects`
- [ ] Verify the locked contributors section button links to the same URL