### PR TITLE
docs: sync docs with recent changes

### DIFF
--- a/frontend/docs/features/community-collections/index.md
+++ b/frontend/docs/features/community-collections/index.md
@@ -27,6 +27,34 @@ My Collections is your personal hub for the collections you've created and the o
 - **My Created Collections** — a grid of your own collections. You will be able to make changes to the collection at any time.
 - **Liked Collections** — collections you've liked, separated by a labelled divider. Can include Curated, Community, or other users' collections.
 
+## Collection detail page
+
+Opening any collection takes you to its detail page. The header shows the collection name, logo, owner, last-updated date, and description, followed by a row of summary chips:
+
+- **Projects / Repositories** — total count of projects and repositories in the collection.
+- **Contributors** — unique contributor count across the collection.
+- **Avg. Health** — the collection's average health score, shown with a status label (Excellent, Healthy, Fair, Concerning, or Critical) alongside the numeric score.
+
+### Tabs on Curated Collections
+
+Curated Collections show a tab bar below the header with four views:
+
+- **Projects** — the list of every project in the collection. A **Only Linux Foundation projects** toggle limits the list to LF-hosted projects.
+- **Contributors** — aggregate contributor widgets across every project in the collection.
+- **Popularity** — aggregate popularity widgets across every project in the collection.
+- **Development** — aggregate development-activity widgets across every project in the collection.
+
+The Contributors, Popularity, and Development tabs include a date range picker that scopes every widget on the tab to the selected range. The picker and the aggregate tabs are exclusive to Curated Collections — Community Collections and My Collections detail pages show only the Projects list.
+
+### Actions on the detail page
+
+The action buttons shown in the header depend on the collection type:
+
+- **Curated** and **Community** collections show **Duplicate**, **Like**, and **Share**.
+- **My Collections** show **Edit**, **Delete**, and **Share**.
+
+Duplicate and Like require you to be signed in.
+
 ## How to manage your own Collections
 
 You must be signed in to be able to manage Collections.


### PR DESCRIPTION
## What changed

- **Community Collections** (`frontend/docs/features/community-collections/index.md`): added a "Collection detail page" section documenting the collection detail page as it appears after the Collections v2 UI work — header summary chips (Projects/Repositories, Contributors, Avg. Health), the four-tab navigation and date range picker exclusive to Curated Collections, the "Only Linux Foundation projects" toggle on the Projects tab, and the per-type action buttons (Duplicate/Like/Share for Curated & Community, Edit/Delete/Share for My Collections).

## Source commits

- [`ac2c05e`](https://github.com/linuxfoundation/insights/commit/ac2c05e8762903ad905576a2f706ec3db3f4d272) — feat: collections v2 UI (IN-1193, IN-1194, IN-1195) (#2007)
- [`8b6a708`](https://github.com/linuxfoundation/insights/commit/8b6a7082abc7ceae0bc8c5af9610d02c44865366) — feat: wire Collection Contributors/Popularity/Development tabs to real widgets IN-1191 (#2013)

## Notes

- The aggregate tabs (Contributors / Popularity / Development) and the date range picker are only rendered on Curated Collections — source: `showsAggregateTabs = collectionType === CollectionTypeEnum.CURATED` in `frontend/app/pages/collection/details/[slug].vue`. Please double-check the wording that spells this out.
- The Avg. Health chip status labels (Excellent / Healthy / Fair / Concerning / Critical) come from `collection-metrics-row.vue`. The doc lists them as the possible labels the user may see but deliberately does not spell out the score thresholds, to avoid duplicating health-score logic that lives in the Health Score doc.
- Held back this week:
  - `feat: add organization results to global search bar` (#2023) — the global search bar is not documented anywhere today, so a one-liner about organizations being added would require a new page from scratch. Deferred until there is a home for it.
  - `chore: update LFX org page links to app.lfx.dev` (#2024) — internal URL swap only, not visible content the docs describe.

---
_Generated by [Claude Code](https://claude.ai/code/session_018dLk3GHCxH3FjZq7EZ7Tjr)_