### PR TITLE
feat: wire presetKey and gate custom date/activity filters on collection pages IN-1196

### DIFF
--- a/frontend/app/components/modules/project/components/shared/header/date-range-picker.vue
+++ b/frontend/app/components/modules/project/components/shared/header/date-range-picker.vue
@@ -100,6 +100,7 @@ SPDX-License-Identifier: MIT
       </lfx-dropdown-item>
 
       <lfx-dropdown-item
+        v-if="!isCollectionScope"
         value="custom"
         label="Custom"
         :checkmark-before="true"
@@ -140,7 +141,7 @@ import { useQueryParam } from '~/components/shared/utils/query-param';
 import { processProjectParams, projectParamsSetter } from '~/components/modules/project/services/project.query.service';
 import useResponsive from '~/components/shared/utils/responsive';
 
-const { selectedTimeRangeKey, startDate, endDate } = storeToRefs(useProjectStore());
+const { isCollectionScope, selectedTimeRangeKey, startDate, endDate } = storeToRefs(useProjectStore());
 const { queryParams } = useQueryParam(processProjectParams, projectParamsSetter);
 const isOpen = ref(false);
 const isCustomSelectorOpen = ref(false);

--- a/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
@@ -4,7 +4,10 @@ SPDX-License-Identifier: MIT
 -->
 <template>
   <section :class="props.snapshot ? 'mt-2' : 'mt-5'">
-    <div :class="props.snapshot ? 'mb-5' : 'mb-6'">
+    <div
+      v-if="!isCollectionScope"
+      :class="props.snapshot ? 'mb-5' : 'mb-6'"
+    >
       <lfx-activities-dropdown
         v-model="model.metric"
         full-width
@@ -58,6 +61,7 @@ import type { ContributorDependency } from '~~/types/contributors/responses.type
 import LfxAvatarGroup from '~/components/uikit/avatar-group/avatar-group.vue';
 import LfxAvatar from '~/components/uikit/avatar/avatar.vue';
 import { useProjectStore } from '~/components/modules/project/store/project.store';
+import { dateOptKeys } from '~/components/modules/project/config/date-options';
 import { isEmptyData } from '~/components/shared/utils/helper';
 import LfxActivitiesDropdown from '~/components/modules/widget/components/contributors/fragments/activities-dropdown.vue';
 import LfxProjectLoadState from '~/components/modules/project/components/shared/load-state.vue';
@@ -90,11 +94,27 @@ const model = computed<ContributorDependencyModel>({
   set: (value) => emit('update:modelValue', value),
 });
 
-const { isCollectionScope, startDate, endDate, selectedReposValues } = storeToRefs(useProjectStore());
+const { isCollectionScope, selectedTimeRangeKey, startDate, endDate, selectedReposValues } =
+  storeToRefs(useProjectStore());
 
 const route = useRoute();
 const platform = computed(() => model.value.metric.split(':')[0]);
 const activityType = computed(() => model.value.metric.split(':')[1]);
+
+// Maps the picker's dateOptKeys to the presetKey values materialized by
+// collection_contributor_dependency_copy_<presetKey>.pipe (crowd.dev/services/libs/tinybird) -
+// most keys already match; only these three differ in casing/pluralization.
+const presetKeyByDateOptKey: Partial<Record<string, string>> = {
+  [dateOptKeys.previous5Year]: 'previous5years',
+  [dateOptKeys.previous10Year]: 'previous10years',
+  [dateOptKeys.alltime]: 'allTime',
+};
+
+// Only collectionSlug-scoped requests have a precomputed path (collection_contributor_dependency
+// .pipe) - "Custom" is unreachable here since date-range-picker.vue hides it for collection pages.
+const presetKey = computed(() =>
+  isCollectionScope.value ? presetKeyByDateOptKey[selectedTimeRangeKey.value] || selectedTimeRangeKey.value : undefined,
+);
 
 const params = computed<LeaderboardQueryParams>(() => ({
   projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
@@ -105,6 +125,7 @@ const params = computed<LeaderboardQueryParams>(() => ({
   startDate: startDate.value,
   endDate: endDate.value,
   includeCollaborations: model.value.includeCollaborations,
+  presetKey: presetKey.value,
 }));
 
 const { data, status, error } = CONTRIBUTORS_API_SERVICE.fetchContributorDependency(params);

--- a/frontend/app/components/modules/widget/services/contributors.api.service.ts
+++ b/frontend/app/components/modules/widget/services/contributors.api.service.ts
@@ -23,6 +23,7 @@ export interface ContributorQueryParams {
   endDate?: string | null;
   granularity?: string;
   includeCollaborations?: boolean;
+  presetKey?: string;
 }
 
 export interface LeaderboardQueryParams extends ContributorQueryParams {
@@ -303,6 +304,7 @@ class ContributorsApiService {
       params.value.startDate,
       params.value.endDate,
       params.value.includeCollaborations,
+      params.value.presetKey,
     ]);
     const queryFn = computed<QueryFunction<ContributorDependency>>(() =>
       this.contributorDependencyQueryFn(() => ({
@@ -314,6 +316,7 @@ class ContributorsApiService {
         startDate: params.value.startDate,
         endDate: params.value.endDate,
         includeCollaborations: params.value.includeCollaborations,
+        presetKey: params.value.presetKey,
       })),
     );
 
@@ -335,6 +338,7 @@ class ContributorsApiService {
       startDate,
       endDate,
       includeCollaborations,
+      presetKey,
     } = query();
     return async () => {
       return await $fetch(`/api/widget/contributors/contributor-dependency`, {
@@ -347,6 +351,7 @@ class ContributorsApiService {
           startDate,
           endDate,
           includeCollaborations,
+          presetKey,
         },
       });
     };

--- a/frontend/server/api/widget/contributors/contributor-dependency.get.ts
+++ b/frontend/server/api/widget/contributors/contributor-dependency.get.ts
@@ -56,6 +56,7 @@ export default defineEventHandler(async (event) => {
     repos,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,
+    presetKey: query.presetKey ? (query.presetKey as string) : undefined,
   };
 
   const dataSource = createDataSource();

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -74,6 +74,11 @@ export type ContributorDependencyFilter = DefaultFilter & {
   platform?: ActivityPlatforms;
   activity_type?: ActivityTypes;
   limit?: number;
+  // One of the 8 presetKey values collection_contributor_dependency_copy_<presetKey>.pipe
+  // materializes (crowd.dev/services/libs/tinybird) - routes collectionSlug-scoped requests to
+  // the precomputed path instead of the live GROUP BY. Project-scoped requests ignore this field
+  // (contributor_dependency.pipe has no precomputed path).
+  presetKey?: string;
 };
 
 export type OrganizationDependencyFilter = DefaultFilter & {


### PR DESCRIPTION
## Summary
- Wires an explicit `presetKey` query parameter end-to-end (Vue widget → API service → server route → Tinybird filter) so collection-page requests to the `contributor-dependency` widget can reach the backend's precomputed fast path (`collection_contributor_dependency.pipe`), which only activates when `presetKey` is present and no other filters are set.
- Hides the "Custom" date-range option in the shared page-header date picker on collection pages (`isCollectionScope`), since the precomputed backend has no path for arbitrary date ranges.
- Hides the activities/platform filter dropdown on the `contributor-dependency` widget on collection pages, for the same reason.
- Both gates are collection-scoped only — project pages are unaffected and retain both controls.

## Why
The backend precompute (crowd.dev companion PR) branches to its fast path only when the request carries a `presetKey` matching one of 8 fixed values and omits repos/date-range/platform/activity_type filters. Without this change, the frontend never sent `presetKey` at all, so every request silently fell back to the expensive live GROUP BY path regardless of backend readiness.

## Changes
- `contributor-dependency.vue` — computes `presetKey` from the store's `selectedTimeRangeKey`, only when `isCollectionScope`; includes a small local translation map for 3 keys whose casing/pluralization differs from Tinybird's naming (`previous5Year`→`previous5years`, `previous10Year`→`previous10years`, `alltime`→`allTime`); hides the activities dropdown on collection pages.
- `date-range-picker.vue` — hides the "Custom" option when `isCollectionScope`.
- `contributors.api.service.ts` — threads `presetKey` through `ContributorQueryParams`, the query key, and the fetch params.
- `contributor-dependency.get.ts` — reads `presetKey` off the query string into the filter object.
- `server/data/types.ts` — adds `presetKey?: string` to `ContributorDependencyFilter`.

## Deploy order
The companion crowd.dev PR (Tinybird pipe/datasource changes) must be deployed **before** this PR merges — the `presetKey` values sent here must match pipe names that already exist live. Already deployed and verified against production Tinybird.

## Test plan
- [x] `pnpm tsc-check`, `pnpm lint`, `pnpm test` all pass
- [x] Verified via curl against local dev server + direct Tinybird queries that `presetKey` values (including `past365days`) return correct, non-empty data for a real collection
- [x] Browser QA: confirmed on a collection page the "Custom" option is absent from the date picker (8 fixed presets only) and the activities dropdown is absent from the contributor-dependency widget, which renders real data
- [ ] Project-page non-regression (Custom option / activities dropdown still shown) verified via code review of the `v-if` conditions, not yet visually re-confirmed in browser

JIRA: IN-1196