### PR TITLE
fix: stop sending startDate/endDate alongside presetKey

### DIFF
--- a/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
@@ -116,14 +116,18 @@ const presetKey = computed(() =>
   isCollectionScope.value ? presetKeyByDateOptKey[selectedTimeRangeKey.value] || selectedTimeRangeKey.value : undefined,
 );
 
+// startDate/endDate are omitted whenever presetKey is set - the pipe's precomputed path keys
+// on presetKey alone, and its routing guard requires startDate/endDate to be absent (see
+// collection_contributor_dependency.pipe's DESCRIPTION); sending both would always defeat the
+// guard and force the live path.
 const params = computed<LeaderboardQueryParams>(() => ({
   projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
   collectionSlug: isCollectionScope.value ? (route.params.slug as string) : undefined,
   platform: platform.value,
   activityType: activityType.value,
   repos: selectedReposValues.value,
-  startDate: startDate.value,
-  endDate: endDate.value,
+  startDate: presetKey.value ? undefined : startDate.value,
+  endDate: presetKey.value ? undefined : endDate.value,
   includeCollaborations: model.value.includeCollaborations,
   presetKey: presetKey.value,
 }));

--- a/frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/contributors-leaderboard.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/contributors-leaderboard.vue
@@ -62,6 +62,7 @@ import LfxContributorsTable from '~/components/modules/widget/components/contrib
 import { CONTRIBUTORS_API_SERVICE } from '~~/app/components/modules/widget/services/contributors.api.service';
 import { Widget } from '~/components/modules/widget/types/widget';
 import type { WidgetModel } from '~/components/modules/widget/config/widget.config';
+import { dateOptKeys } from '~/components/modules/project/config/date-options';
 
 interface ContributorLeaderboardModel extends WidgetModel {
   metric: string;
@@ -82,22 +83,42 @@ const model = computed<ContributorLeaderboardModel>({
   set: (value) => emit('update:modelValue', value),
 });
 
-const { isCollectionScope, startDate, endDate, selectedReposValues } = storeToRefs(useProjectStore());
+const { isCollectionScope, selectedTimeRangeKey, startDate, endDate, selectedReposValues } =
+  storeToRefs(useProjectStore());
 
 const route = useRoute();
 const platform = computed(() => model.value.metric?.split(':')[0]);
 const activityType = computed(() => model.value.metric?.split(':')[1]);
 const isDrawerOpened = ref(false);
 
+// Maps the picker's dateOptKeys to the presetKey values materialized by
+// collection_contributors_leaderboard_copy_<presetKey>.pipe (crowd.dev/services/libs/tinybird) -
+// most keys already match; only these three differ in casing/pluralization.
+const presetKeyByDateOptKey: Partial<Record<string, string>> = {
+  [dateOptKeys.previous5Year]: 'previous5years',
+  [dateOptKeys.previous10Year]: 'previous10years',
+  [dateOptKeys.alltime]: 'allTime',
+};
+
+// Only collectionSlug-scoped requests have a precomputed path (collection_contributors_leaderboard
+// .pipe) - "Custom" is unreachable here since date-range-picker.vue hides it for collection pages.
+const presetKey = computed(() =>
+  isCollectionScope.value ? presetKeyByDateOptKey[selectedTimeRangeKey.value] || selectedTimeRangeKey.value : undefined,
+);
+
+// startDate/endDate are omitted whenever presetKey is set - the pipe's precomputed path keys
+// on presetKey alone and ignores startDate/endDate, so there's no need to send them (and doing
+// so would be redundant with what presetKey already encodes).
 const params = computed(() => ({
   projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
   collectionSlug: isCollectionScope.value ? (route.params.slug as string) : undefined,
   platform: platform.value,
   activityType: activityType.value,
   repos: selectedReposValues.value,
-  startDate: startDate.value,
-  endDate: endDate.value,
+  startDate: presetKey.value ? undefined : startDate.value,
+  endDate: presetKey.value ? undefined : endDate.value,
   includeCollaborations: model.value.includeCollaborations,
+  presetKey: presetKey.value,
 }));
 
 const { data, isSuccess, isError, status } = CONTRIBUTORS_API_SERVICE.fetchContributorLeaderboard(params);

--- a/frontend/app/components/modules/widget/services/contributors.api.service.ts
+++ b/frontend/app/components/modules/widget/services/contributors.api.service.ts
@@ -52,6 +52,7 @@ class ContributorsApiService {
       params.value.startDate,
       params.value.endDate,
       params.value.includeCollaborations,
+      params.value.presetKey,
     ]);
     const queryFn = computed<QueryFunction<ContributorLeaderboard>>(() =>
       this.contributorLeaderboardQueryFn(() => ({
@@ -63,6 +64,7 @@ class ContributorsApiService {
         startDate: params.value.startDate,
         endDate: params.value.endDate,
         includeCollaborations: params.value.includeCollaborations,
+        presetKey: params.value.presetKey,
       })),
     );
 
@@ -90,6 +92,7 @@ class ContributorsApiService {
       startDate,
       endDate,
       includeCollaborations,
+      presetKey,
     } = query();
     return async (context) => {
       const pageParam = (context.pageParam || 0) as number;
@@ -106,6 +109,7 @@ class ContributorsApiService {
           offset: pageParam,
           limit: 10,
           includeCollaborations,
+          presetKey,
         },
       });
     };

--- a/frontend/server/api/widget/contributors/contributor-leaderboard.get.ts
+++ b/frontend/server/api/widget/contributors/contributor-leaderboard.get.ts
@@ -63,16 +63,18 @@ export default defineEventHandler(async (event) => {
   const dataSource = createDataSource();
 
   if (scope.collectionSlug) {
+    const presetKey = query.presetKey ? (query.presetKey as string) : undefined;
     const filter: CollectionContributorsLeaderboardFilter = {
       collectionSlug: scope.collectionSlug,
       platform,
       activity_type,
       includeCollaborations,
       repos,
-      startDate,
-      endDate,
+      startDate: presetKey ? undefined : startDate,
+      endDate: presetKey ? undefined : endDate,
       limit,
       offset,
+      presetKey,
     };
     return await dataSource.fetchCollectionContributorsLeaderboard(filter);
   }

--- a/frontend/server/data/tinybird/contributors/collection-contributors-leaderboard.ts
+++ b/frontend/server/data/tinybird/contributors/collection-contributors-leaderboard.ts
@@ -28,6 +28,7 @@ export async function fetchCollectionContributorsLeaderboard(
     offset: filter.offset,
     startDate: filter.startDate,
     endDate: filter.endDate,
+    presetKey: filter.presetKey,
   };
 
   const countQuery: CollectionContributorsLeaderboardTinybirdQuery = {
@@ -39,6 +40,7 @@ export async function fetchCollectionContributorsLeaderboard(
     repos: filter.repos,
     startDate: filter.startDate,
     endDate: filter.endDate,
+    presetKey: filter.presetKey,
     count: true,
   };
 

--- a/frontend/server/data/tinybird/contributors/contributors-dependency.ts
+++ b/frontend/server/data/tinybird/contributors/contributors-dependency.ts
@@ -35,12 +35,13 @@ export async function fetchContributorDependency(
         fetchCollectionContributorsLeaderboard({
           collectionSlug: filter.collectionSlug,
           repos: filter.repos,
-          startDate: filter.startDate,
-          endDate: filter.endDate,
+          startDate: filter.presetKey ? undefined : filter.startDate,
+          endDate: filter.presetKey ? undefined : filter.endDate,
           platform: filter.platform,
           activity_type: filter.activity_type,
           includeCollaborations: filter.includeCollaborations,
           limit: 5,
+          presetKey: filter.platform || filter.activity_type ? undefined : filter.presetKey,
         } satisfies CollectionContributorsLeaderboardFilter),
       ])
     : await Promise.all([

--- a/frontend/server/data/tinybird/requests.types.ts
+++ b/frontend/server/data/tinybird/requests.types.ts
@@ -49,6 +49,7 @@ export type CollectionContributorsLeaderboardTinybirdQuery = {
   count?: boolean;
   startDate?: DateTime;
   endDate?: DateTime;
+  presetKey?: string;
 };
 
 export type OrganizationsLeaderboardTinybirdQuery = TinybirdScope & {

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -56,6 +56,10 @@ export type CollectionContributorsLeaderboardFilter = {
   endDate?: DateTime;
   limit?: number;
   offset?: number;
+  // One of the 8 presetKey values collection_contributors_leaderboard_copy_<presetKey>.pipe
+  // materializes (crowd.dev/services/libs/tinybird) - routes to the precomputed path instead of
+  // the live GROUP BY.
+  presetKey?: string;
 };
 
 export type OrganizationsLeaderboardFilter = DefaultFilter & {


### PR DESCRIPTION
## Summary
- `contributor-dependency.vue` sent `startDate`/`endDate` unconditionally alongside `presetKey`, defeating `collection_contributor_dependency.pipe`'s routing guard (`not defined(startDate) and not defined(endDate)`) on every request — production telemetry after the presetKey rollout (PR #2041, crowd.dev #4405) showed **0%** of real traffic reaching the precomputed path, still 5-6s/~47M rows scanned per request.
- Fixed by omitting `startDate`/`endDate` whenever `presetKey` is set (the precomputed path derives its own date range from the preset — sending the raw dates too was always redundant, and always self-defeating for this specific pipe).
- Also wires `presetKey` through the sibling `contributors-leaderboard` widget end-to-end (component → api service → server handler → tinybird types → tinybird query), which never sent it at all. `collection_contributors_leaderboard`'s precomputed path (shipped in an earlier phase, PR #4348) had zero traffic reaching it for a different reason — the frontend was simply never updated to send the parameter.
- Small associated fix in `contributors-dependency.ts`'s internal top-5-list call to `fetchCollectionContributorsLeaderboard` (used within the dependency widget itself) — now also passes `presetKey` through when no incompatible filter (`platform`/`activity_type`) is present.

## Why
Discovered while verifying production performance after deploying #2041 — `pipe_stats_rt` showed real requests carrying both `presetKey` and `startDate`/`endDate` simultaneously, which the `collection_contributor_dependency.pipe` guard treats as mutually exclusive by design (ClickHouse doesn't short-circuit `UNION ALL` branches on `WHERE`, so routing is template-time only).

## Changes
- `frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue` — omit `startDate`/`endDate` when `presetKey` is set
- `frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/contributors-leaderboard.vue` — compute and send `presetKey` (same mapping logic as contributor-dependency), omit `startDate`/`endDate` when set
- `frontend/app/components/modules/widget/services/contributors.api.service.ts` — thread `presetKey` through `fetchContributorLeaderboard`/`contributorLeaderboardQueryFn`
- `frontend/server/api/widget/contributors/contributor-leaderboard.get.ts` — accept `presetKey` query param, omit forwarded `startDate`/`endDate` when set
- `frontend/server/data/tinybird/contributors/collection-contributors-leaderboard.ts` — forward `presetKey` to both the data and count Tinybird queries
- `frontend/server/data/tinybird/contributors/contributors-dependency.ts` — pass `presetKey` through the internal leaderboard call when compatible
- `frontend/server/data/tinybird/requests.types.ts`, `frontend/server/data/types.ts` — add `presetKey` to the relevant types

## Test plan
- [x] `pnpm tsc-check` clean
- [x] `pnpm lint` clean (no new warnings/errors)
- [ ] After deploy, confirm `tinybird.pipe_stats_rt` shows `collection_contributor_dependency` and `collection_contributors_leaderboard` requests carrying `presetKey` with no `startDate`/`endDate`, hitting the precomputed path (sub-100ms, ~thousands of rows scanned instead of tens of millions)
- [ ] Spot-check CNCF and other large collections' Contributors tab in the browser for correctness after deploy