### PR TITLE
revert: fix: stop sending startDate/endDate alongside presetKey

### DIFF
--- a/frontend/app/components/modules/project/components/shared/header/date-range-picker.vue
+++ b/frontend/app/components/modules/project/components/shared/header/date-range-picker.vue
@@ -100,7 +100,6 @@ SPDX-License-Identifier: MIT
       </lfx-dropdown-item>
 
       <lfx-dropdown-item
-        v-if="!isCollectionScope"
         value="custom"
         label="Custom"
         :checkmark-before="true"
@@ -141,7 +140,7 @@ import { useQueryParam } from '~/components/shared/utils/query-param';
 import { processProjectParams, projectParamsSetter } from '~/components/modules/project/services/project.query.service';
 import useResponsive from '~/components/shared/utils/responsive';
 
-const { isCollectionScope, selectedTimeRangeKey, startDate, endDate } = storeToRefs(useProjectStore());
+const { selectedTimeRangeKey, startDate, endDate } = storeToRefs(useProjectStore());
 const { queryParams } = useQueryParam(processProjectParams, projectParamsSetter);
 const isOpen = ref(false);
 const isCustomSelectorOpen = ref(false);

--- a/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
@@ -116,18 +116,14 @@ const presetKey = computed(() =>
   isCollectionScope.value ? presetKeyByDateOptKey[selectedTimeRangeKey.value] || selectedTimeRangeKey.value : undefined,
 );
 
-// startDate/endDate are omitted whenever presetKey is set - the pipe's precomputed path keys
-// on presetKey alone, and its routing guard requires startDate/endDate to be absent (see
-// collection_contributor_dependency.pipe's DESCRIPTION); sending both would always defeat the
-// guard and force the live path.
 const params = computed<LeaderboardQueryParams>(() => ({
   projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
   collectionSlug: isCollectionScope.value ? (route.params.slug as string) : undefined,
   platform: platform.value,
   activityType: activityType.value,
   repos: selectedReposValues.value,
-  startDate: presetKey.value ? undefined : startDate.value,
-  endDate: presetKey.value ? undefined : endDate.value,
+  startDate: startDate.value,
+  endDate: endDate.value,
   includeCollaborations: model.value.includeCollaborations,
   presetKey: presetKey.value,
 }));

--- a/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributor-dependency/contributor-dependency.vue
@@ -4,10 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <template>
   <section :class="props.snapshot ? 'mt-2' : 'mt-5'">
-    <div
-      v-if="!isCollectionScope"
-      :class="props.snapshot ? 'mb-5' : 'mb-6'"
-    >
+    <div :class="props.snapshot ? 'mb-5' : 'mb-6'">
       <lfx-activities-dropdown
         v-model="model.metric"
         full-width
@@ -61,7 +58,6 @@ import type { ContributorDependency } from '~~/types/contributors/responses.type
 import LfxAvatarGroup from '~/components/uikit/avatar-group/avatar-group.vue';
 import LfxAvatar from '~/components/uikit/avatar/avatar.vue';
 import { useProjectStore } from '~/components/modules/project/store/project.store';
-import { dateOptKeys } from '~/components/modules/project/config/date-options';
 import { isEmptyData } from '~/components/shared/utils/helper';
 import LfxActivitiesDropdown from '~/components/modules/widget/components/contributors/fragments/activities-dropdown.vue';
 import LfxProjectLoadState from '~/components/modules/project/components/shared/load-state.vue';
@@ -94,27 +90,11 @@ const model = computed<ContributorDependencyModel>({
   set: (value) => emit('update:modelValue', value),
 });
 
-const { isCollectionScope, selectedTimeRangeKey, startDate, endDate, selectedReposValues } =
-  storeToRefs(useProjectStore());
+const { isCollectionScope, startDate, endDate, selectedReposValues } = storeToRefs(useProjectStore());
 
 const route = useRoute();
 const platform = computed(() => model.value.metric.split(':')[0]);
 const activityType = computed(() => model.value.metric.split(':')[1]);
-
-// Maps the picker's dateOptKeys to the presetKey values materialized by
-// collection_contributor_dependency_copy_<presetKey>.pipe (crowd.dev/services/libs/tinybird) -
-// most keys already match; only these three differ in casing/pluralization.
-const presetKeyByDateOptKey: Partial<Record<string, string>> = {
-  [dateOptKeys.previous5Year]: 'previous5years',
-  [dateOptKeys.previous10Year]: 'previous10years',
-  [dateOptKeys.alltime]: 'allTime',
-};
-
-// Only collectionSlug-scoped requests have a precomputed path (collection_contributor_dependency
-// .pipe) - "Custom" is unreachable here since date-range-picker.vue hides it for collection pages.
-const presetKey = computed(() =>
-  isCollectionScope.value ? presetKeyByDateOptKey[selectedTimeRangeKey.value] || selectedTimeRangeKey.value : undefined,
-);
 
 const params = computed<LeaderboardQueryParams>(() => ({
   projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
@@ -125,7 +105,6 @@ const params = computed<LeaderboardQueryParams>(() => ({
   startDate: startDate.value,
   endDate: endDate.value,
   includeCollaborations: model.value.includeCollaborations,
-  presetKey: presetKey.value,
 }));
 
 const { data, status, error } = CONTRIBUTORS_API_SERVICE.fetchContributorDependency(params);

--- a/frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/contributors-leaderboard.vue
+++ b/frontend/app/components/modules/widget/config/contributor/contributors-leaderboard/contributors-leaderboard.vue
@@ -62,7 +62,6 @@ import LfxContributorsTable from '~/components/modules/widget/components/contrib
 import { CONTRIBUTORS_API_SERVICE } from '~~/app/components/modules/widget/services/contributors.api.service';
 import { Widget } from '~/components/modules/widget/types/widget';
 import type { WidgetModel } from '~/components/modules/widget/config/widget.config';
-import { dateOptKeys } from '~/components/modules/project/config/date-options';
 
 interface ContributorLeaderboardModel extends WidgetModel {
   metric: string;
@@ -83,42 +82,22 @@ const model = computed<ContributorLeaderboardModel>({
   set: (value) => emit('update:modelValue', value),
 });
 
-const { isCollectionScope, selectedTimeRangeKey, startDate, endDate, selectedReposValues } =
-  storeToRefs(useProjectStore());
+const { isCollectionScope, startDate, endDate, selectedReposValues } = storeToRefs(useProjectStore());
 
 const route = useRoute();
 const platform = computed(() => model.value.metric?.split(':')[0]);
 const activityType = computed(() => model.value.metric?.split(':')[1]);
 const isDrawerOpened = ref(false);
 
-// Maps the picker's dateOptKeys to the presetKey values materialized by
-// collection_contributors_leaderboard_copy_<presetKey>.pipe (crowd.dev/services/libs/tinybird) -
-// most keys already match; only these three differ in casing/pluralization.
-const presetKeyByDateOptKey: Partial<Record<string, string>> = {
-  [dateOptKeys.previous5Year]: 'previous5years',
-  [dateOptKeys.previous10Year]: 'previous10years',
-  [dateOptKeys.alltime]: 'allTime',
-};
-
-// Only collectionSlug-scoped requests have a precomputed path (collection_contributors_leaderboard
-// .pipe) - "Custom" is unreachable here since date-range-picker.vue hides it for collection pages.
-const presetKey = computed(() =>
-  isCollectionScope.value ? presetKeyByDateOptKey[selectedTimeRangeKey.value] || selectedTimeRangeKey.value : undefined,
-);
-
-// startDate/endDate are omitted whenever presetKey is set - the pipe's precomputed path keys
-// on presetKey alone and ignores startDate/endDate, so there's no need to send them (and doing
-// so would be redundant with what presetKey already encodes).
 const params = computed(() => ({
   projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
   collectionSlug: isCollectionScope.value ? (route.params.slug as string) : undefined,
   platform: platform.value,
   activityType: activityType.value,
   repos: selectedReposValues.value,
-  startDate: presetKey.value ? undefined : startDate.value,
-  endDate: presetKey.value ? undefined : endDate.value,
+  startDate: startDate.value,
+  endDate: endDate.value,
   includeCollaborations: model.value.includeCollaborations,
-  presetKey: presetKey.value,
 }));
 
 const { data, isSuccess, isError, status } = CONTRIBUTORS_API_SERVICE.fetchContributorLeaderboard(params);

--- a/frontend/app/components/modules/widget/services/contributors.api.service.ts
+++ b/frontend/app/components/modules/widget/services/contributors.api.service.ts
@@ -52,7 +52,6 @@ class ContributorsApiService {
       params.value.startDate,
       params.value.endDate,
       params.value.includeCollaborations,
-      params.value.presetKey,
     ]);
     const queryFn = computed<QueryFunction<ContributorLeaderboard>>(() =>
       this.contributorLeaderboardQueryFn(() => ({
@@ -64,7 +63,6 @@ class ContributorsApiService {
         startDate: params.value.startDate,
         endDate: params.value.endDate,
         includeCollaborations: params.value.includeCollaborations,
-        presetKey: params.value.presetKey,
       })),
     );
 
@@ -92,7 +90,6 @@ class ContributorsApiService {
       startDate,
       endDate,
       includeCollaborations,
-      presetKey,
     } = query();
     return async (context) => {
       const pageParam = (context.pageParam || 0) as number;
@@ -109,7 +106,6 @@ class ContributorsApiService {
           offset: pageParam,
           limit: 10,
           includeCollaborations,
-          presetKey,
         },
       });
     };

--- a/frontend/app/components/modules/widget/services/contributors.api.service.ts
+++ b/frontend/app/components/modules/widget/services/contributors.api.service.ts
@@ -23,7 +23,6 @@ export interface ContributorQueryParams {
   endDate?: string | null;
   granularity?: string;
   includeCollaborations?: boolean;
-  presetKey?: string;
 }
 
 export interface LeaderboardQueryParams extends ContributorQueryParams {
@@ -304,7 +303,6 @@ class ContributorsApiService {
       params.value.startDate,
       params.value.endDate,
       params.value.includeCollaborations,
-      params.value.presetKey,
     ]);
     const queryFn = computed<QueryFunction<ContributorDependency>>(() =>
       this.contributorDependencyQueryFn(() => ({
@@ -316,7 +314,6 @@ class ContributorsApiService {
         startDate: params.value.startDate,
         endDate: params.value.endDate,
         includeCollaborations: params.value.includeCollaborations,
-        presetKey: params.value.presetKey,
       })),
     );
 
@@ -338,7 +335,6 @@ class ContributorsApiService {
       startDate,
       endDate,
       includeCollaborations,
-      presetKey,
     } = query();
     return async () => {
       return await $fetch(`/api/widget/contributors/contributor-dependency`, {
@@ -351,7 +347,6 @@ class ContributorsApiService {
           startDate,
           endDate,
           includeCollaborations,
-          presetKey,
         },
       });
     };

--- a/frontend/server/api/widget/contributors/contributor-dependency.get.ts
+++ b/frontend/server/api/widget/contributors/contributor-dependency.get.ts
@@ -56,7 +56,6 @@ export default defineEventHandler(async (event) => {
     repos,
     startDate: query.startDate ? DateTime.fromISO(query.startDate as string) : undefined,
     endDate: query.endDate ? DateTime.fromISO(query.endDate as string) : undefined,
-    presetKey: query.presetKey ? (query.presetKey as string) : undefined,
   };
 
   const dataSource = createDataSource();

--- a/frontend/server/api/widget/contributors/contributor-leaderboard.get.ts
+++ b/frontend/server/api/widget/contributors/contributor-leaderboard.get.ts
@@ -63,18 +63,16 @@ export default defineEventHandler(async (event) => {
   const dataSource = createDataSource();
 
   if (scope.collectionSlug) {
-    const presetKey = query.presetKey ? (query.presetKey as string) : undefined;
     const filter: CollectionContributorsLeaderboardFilter = {
       collectionSlug: scope.collectionSlug,
       platform,
       activity_type,
       includeCollaborations,
       repos,
-      startDate: presetKey ? undefined : startDate,
-      endDate: presetKey ? undefined : endDate,
+      startDate,
+      endDate,
       limit,
       offset,
-      presetKey,
     };
     return await dataSource.fetchCollectionContributorsLeaderboard(filter);
   }

--- a/frontend/server/data/tinybird/contributors/collection-contributors-leaderboard.ts
+++ b/frontend/server/data/tinybird/contributors/collection-contributors-leaderboard.ts
@@ -28,7 +28,6 @@ export async function fetchCollectionContributorsLeaderboard(
     offset: filter.offset,
     startDate: filter.startDate,
     endDate: filter.endDate,
-    presetKey: filter.presetKey,
   };
 
   const countQuery: CollectionContributorsLeaderboardTinybirdQuery = {
@@ -40,7 +39,6 @@ export async function fetchCollectionContributorsLeaderboard(
     repos: filter.repos,
     startDate: filter.startDate,
     endDate: filter.endDate,
-    presetKey: filter.presetKey,
     count: true,
   };
 

--- a/frontend/server/data/tinybird/contributors/contributors-dependency.ts
+++ b/frontend/server/data/tinybird/contributors/contributors-dependency.ts
@@ -35,13 +35,12 @@ export async function fetchContributorDependency(
         fetchCollectionContributorsLeaderboard({
           collectionSlug: filter.collectionSlug,
           repos: filter.repos,
-          startDate: filter.presetKey ? undefined : filter.startDate,
-          endDate: filter.presetKey ? undefined : filter.endDate,
+          startDate: filter.startDate,
+          endDate: filter.endDate,
           platform: filter.platform,
           activity_type: filter.activity_type,
           includeCollaborations: filter.includeCollaborations,
           limit: 5,
-          presetKey: filter.platform || filter.activity_type ? undefined : filter.presetKey,
         } satisfies CollectionContributorsLeaderboardFilter),
       ])
     : await Promise.all([

--- a/frontend/server/data/tinybird/requests.types.ts
+++ b/frontend/server/data/tinybird/requests.types.ts
@@ -49,7 +49,6 @@ export type CollectionContributorsLeaderboardTinybirdQuery = {
   count?: boolean;
   startDate?: DateTime;
   endDate?: DateTime;
-  presetKey?: string;
 };
 
 export type OrganizationsLeaderboardTinybirdQuery = TinybirdScope & {

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -56,10 +56,6 @@ export type CollectionContributorsLeaderboardFilter = {
   endDate?: DateTime;
   limit?: number;
   offset?: number;
-  // One of the 8 presetKey values collection_contributors_leaderboard_copy_<presetKey>.pipe
-  // materializes (crowd.dev/services/libs/tinybird) - routes to the precomputed path instead of
-  // the live GROUP BY.
-  presetKey?: string;
 };
 
 export type OrganizationsLeaderboardFilter = DefaultFilter & {

--- a/frontend/server/data/types.ts
+++ b/frontend/server/data/types.ts
@@ -74,11 +74,6 @@ export type ContributorDependencyFilter = DefaultFilter & {
   platform?: ActivityPlatforms;
   activity_type?: ActivityTypes;
   limit?: number;
-  // One of the 8 presetKey values collection_contributor_dependency_copy_<presetKey>.pipe
-  // materializes (crowd.dev/services/libs/tinybird) - routes collectionSlug-scoped requests to
-  // the precomputed path instead of the live GROUP BY. Project-scoped requests ignore this field
-  // (contributor_dependency.pipe has no precomputed path).
-  presetKey?: string;
 };
 
 export type OrganizationDependencyFilter = DefaultFilter & {


### PR DESCRIPTION
## Summary
- Reverts #2041 (feat: wire presetKey and gate custom date/activity filters on collection pages IN-1196) and #2042 (fix: stop sending startDate/endDate alongside presetKey)
- These commits wired the frontend to route contributor-dependency and contributors-leaderboard widget requests to precomputed/presetKey-split Tinybird pipes as part of a multi-phase Tinybird performance-optimization effort
- That optimization effort has been fully abandoned — the corresponding Tinybird pipes/datasources (crowd.dev, never merged to crowd.dev main) are being deleted from production Tinybird in a parallel effort, and this repo needs to stop referencing them
- After this merges, both widgets go back to their pre-optimization behavior: live-path queries with startDate/endDate, no presetKey routing, Custom date range and activity/platform filters restored

## Test plan
- [ ] Verify Contributors tab on a Collection detail page loads contributor-dependency and contributors-leaderboard widgets without errors
- [ ] Verify Custom date range option is available again on Collection pages
- [ ] Verify activity/platform dropdown is available again on the contributor-dependency widget
- [ ] Confirm no requests reference presetKey-suffixed pipe variants after deploy