### PR TITLE
feat: display all countries in geographical distribution widget

### DIFF
--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geo-distribution-view.vue
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geo-distribution-view.vue
@@ -1,0 +1,87 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<template>
+  <div class="w-full h-[330px]">
+    <client-only>
+      <lfx-chart
+        :config="getGeoMapChartConfig(chartData, chartSeries, getMaxValue(chartData))"
+        :animation="props.animation"
+      />
+    </client-only>
+  </div>
+  <div class="flex flex-col gap-5">
+    <div
+      v-for="item in listData"
+      :key="item.name"
+      class="flex flex-row justify-between items-center text-sm"
+    >
+      <div class="flex flex-row gap-4 items-center">
+        <span class="text-base">
+          {{ item.flag }}
+        </span>
+        <span class="font-medium">
+          {{ item.name }}
+        </span>
+      </div>
+      <span>
+        {{ formatNumber(item.count) }} {{ pluralize(props.label.toLowerCase(), item.count) }} ・ {{ item.percentage }}%
+      </span>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import pluralize from 'pluralize';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import { convertToChartData, getMaxValue } from '~/components/uikit/chart/helpers/chart-helpers';
+import type { ChartData, RawChartData, ChartSeries } from '~/components/uikit/chart/types/ChartTypes';
+import { getGeoMapChartConfig } from '~/components/uikit/chart/configs/geo-map.chart';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type { GeoMapData } from '~/components/modules/widget/components/contributors/types/geo-map.types';
+
+const props = withDefaults(
+  defineProps<{
+    geoMapData?: GeoMapData[];
+    label: string;
+    limit?: number;
+    animation?: boolean;
+  }>(),
+  {
+    geoMapData: () => [],
+    limit: undefined,
+    animation: true,
+  },
+);
+
+// "Unknown" location is intentionally hidden from the list and chart (see IN-1225 / #2062).
+const knownGeoMapData = computed(() => props.geoMapData.filter((item) => item.name !== 'Unknown'));
+
+const listData = computed(() => (props.limit ? knownGeoMapData.value.slice(0, props.limit) : knownGeoMapData.value));
+
+const chartData = computed<ChartData[]>(() =>
+  convertToChartData(knownGeoMapData.value as unknown as RawChartData[], 'name', ['count', 'percentage']).map(
+    (item) => ({
+      ...item,
+      key: item.key === 'United States' ? 'United States of America' : item.key,
+    }),
+  ),
+);
+
+const chartSeries = computed<ChartSeries[]>(() => [
+  {
+    name: props.label,
+    type: 'map',
+    yAxisIndex: 0,
+    dataIndex: 0,
+  },
+]);
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxGeoDistributionView',
+};
+</script>

--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geo-distribution-view.vue
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geo-distribution-view.vue
@@ -26,7 +26,8 @@ SPDX-License-Identifier: MIT
         </span>
       </div>
       <span>
-        {{ formatNumber(item.count) }} {{ pluralize(props.label.toLowerCase(), item.count) }} ・ {{ item.percentage }}%
+        {{ formatNumber(item.count) }} {{ pluralize(props.label.toLowerCase(), item.count) }} ・
+        {{ formatNumber(item.percentage, item.percentage < 1 ? 2 : 0) }}%
       </span>
     </div>
   </div>
@@ -35,6 +36,7 @@ SPDX-License-Identifier: MIT
 <script setup lang="ts">
 import { computed } from 'vue';
 import pluralize from 'pluralize';
+import { filterKnownCountries } from '../geo-map.helper';
 import LfxChart from '~/components/uikit/chart/chart.vue';
 import { convertToChartData, getMaxValue } from '~/components/uikit/chart/helpers/chart-helpers';
 import type { ChartData, RawChartData, ChartSeries } from '~/components/uikit/chart/types/ChartTypes';
@@ -56,8 +58,7 @@ const props = withDefaults(
   },
 );
 
-// "Unknown" location is intentionally hidden from the list and chart (see IN-1225 / #2062).
-const knownGeoMapData = computed(() => props.geoMapData.filter((item) => item.name !== 'Unknown'));
+const knownGeoMapData = computed(() => filterKnownCountries(props.geoMapData));
 
 const listData = computed(() => (props.limit ? knownGeoMapData.value.slice(0, props.limit) : knownGeoMapData.value));
 

--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geographical-distribution-drawer.vue
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geographical-distribution-drawer.vue
@@ -1,0 +1,159 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<template>
+  <lfx-drawer
+    v-model="isDrawerOpen"
+    position="right"
+  >
+    <div class="relative flex flex-col justify-start h-full">
+      <div class="pt-4 sm:pt-6 px-4 sm:px-6">
+        <h3 class="text-heading-3 font-semibold font-secondary pb-3">
+          {{ geographicalDistribution.name }}
+        </h3>
+        <p class="text-body-2 text-neutral-500 mb-6">
+          {{ geographicalDistribution.description(project!, props.model) }}
+          <a
+            :href="geographicalDistribution.learnMoreLink"
+            class="text-brand-500"
+            target="_blank"
+            >Learn more</a
+          >
+        </p>
+
+        <hr />
+      </div>
+      <section class="mt-5 flex flex-col flex-grow overflow-auto">
+        <div class="flex flex-wrap gap-4 items-center justify-between mb-6 px-4 sm:px-6 pt-[1px]">
+          <lfx-tabs
+            :tabs="tabs"
+            :model-value="activeTab"
+            width-type="inline"
+            @update:model-value="activeTab = $event"
+          />
+          <div class="max-w-max">
+            <lfx-activities-dropdown
+              v-model="metric"
+              placement="bottom-end"
+              :full-width="false"
+              :match-width="false"
+              width="25rem"
+              :include-collaborations="props.model.includeCollaborations"
+            />
+          </div>
+        </div>
+
+        <div class="px-4 sm:px-6">
+          <lfx-project-load-state
+            :status="status"
+            :error="error"
+            error-message="Error fetching geographical distribution"
+            :is-empty="isEmpty"
+          >
+            <lfx-geo-distribution-view
+              :geo-map-data="geoMapData"
+              :label="label"
+            />
+          </lfx-project-load-state>
+        </div>
+      </section>
+    </div>
+  </lfx-drawer>
+</template>
+
+<script setup lang="ts">
+import { useRoute } from 'nuxt/app';
+import { ref, computed, watch } from 'vue';
+import { storeToRefs } from 'pinia';
+import LfxGeoDistributionView from './geo-distribution-view.vue';
+import LfxDrawer from '~/components/uikit/drawer/drawer.vue';
+import LfxTabs from '~/components/uikit/tabs/tabs.vue';
+import { useProjectStore } from '~/components/modules/project/store/project.store';
+import { isEmptyData } from '~/components/shared/utils/helper';
+import LfxActivitiesDropdown from '~/components/modules/widget/components/contributors/fragments/activities-dropdown.vue';
+import LfxProjectLoadState from '~/components/modules/project/components/shared/load-state.vue';
+import geographicalDistribution from '~/components/modules/widget/config/contributor/geographical-distribution/geographical-distribution.config';
+import type {
+  GeoMapData,
+  GeoMapResponse,
+} from '~/components/modules/widget/components/contributors/types/geo-map.types';
+import {
+  CONTRIBUTORS_API_SERVICE,
+  type GeographicalDistributionQueryParams,
+} from '~~/app/components/modules/widget/services/contributors.api.service';
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: boolean;
+    selectedTab?: string;
+    selectedMetric?: string;
+    model: { includeCollaborations?: boolean };
+  }>(),
+  {
+    modelValue: false,
+    selectedTab: 'organizations',
+    selectedMetric: 'all:all',
+    model: () => ({ includeCollaborations: false }),
+  },
+);
+
+const emit = defineEmits<{ (e: 'update:modelValue', value: boolean): void }>();
+
+const isDrawerOpen = computed({
+  get: () => props.modelValue,
+  set: (value: boolean) => emit('update:modelValue', value),
+});
+
+const route = useRoute();
+const activeTab = ref(props.selectedTab);
+const metric = ref(props.selectedMetric);
+const platform = computed(() => metric.value.split(':')[0]);
+const activityType = computed(() => metric.value.split(':')[1]);
+
+const { isCollectionScope, startDate, endDate, selectedReposValues, project } = storeToRefs(useProjectStore());
+
+const params = computed<GeographicalDistributionQueryParams>(() => ({
+  projectSlug: isCollectionScope.value ? undefined : (route.params.slug as string),
+  collectionSlug: isCollectionScope.value ? (route.params.slug as string) : undefined,
+  type: activeTab.value,
+  platform: platform.value,
+  activityType: activityType.value,
+  repos: selectedReposValues.value,
+  startDate: startDate.value,
+  endDate: endDate.value,
+  includeCollaborations: props.model.includeCollaborations,
+}));
+
+const { data, status, error } = CONTRIBUTORS_API_SERVICE.fetchGeographicalDistribution(params);
+
+const geoMapData = computed<GeoMapData[] | undefined>(() => (data.value as GeoMapResponse)?.data);
+
+const isEmpty = computed(() => isEmptyData(geoMapData.value as unknown as Record<string, unknown>[]));
+
+const tabs = [
+  {
+    label: 'Organizations',
+    value: 'organizations',
+  },
+  {
+    label: 'Contributors',
+    value: 'contributors',
+  },
+];
+
+const label = computed(() => (activeTab.value === 'contributors' ? 'Contributor' : 'Organization'));
+
+watch(isDrawerOpen, (isOpen) => {
+  if (isOpen) {
+    activeTab.value = props.selectedTab;
+    metric.value = props.selectedMetric;
+  }
+});
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxGeographicalDistributionDrawer',
+};
+</script>

--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geographical-distribution-drawer.vue
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/fragments/geographical-distribution-drawer.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: MIT
 
         <hr />
       </div>
-      <section class="mt-5 flex flex-col flex-grow overflow-auto">
+      <section class="mt-5 flex flex-col flex-grow overflow-auto pb-5">
         <div class="flex flex-wrap gap-4 items-center justify-between mb-6 px-4 sm:px-6 pt-[1px]">
           <lfx-tabs
             :tabs="tabs"
@@ -66,6 +66,7 @@ SPDX-License-Identifier: MIT
 import { useRoute } from 'nuxt/app';
 import { ref, computed, watch } from 'vue';
 import { storeToRefs } from 'pinia';
+import { filterKnownCountries } from '../geo-map.helper';
 import LfxGeoDistributionView from './geo-distribution-view.vue';
 import LfxDrawer from '~/components/uikit/drawer/drawer.vue';
 import LfxTabs from '~/components/uikit/tabs/tabs.vue';
@@ -129,7 +130,9 @@ const { data, status, error } = CONTRIBUTORS_API_SERVICE.fetchGeographicalDistri
 
 const geoMapData = computed<GeoMapData[] | undefined>(() => (data.value as GeoMapResponse)?.data);
 
-const isEmpty = computed(() => isEmptyData(geoMapData.value as unknown as Record<string, unknown>[]));
+const isEmpty = computed(() =>
+  isEmptyData(filterKnownCountries(geoMapData.value) as unknown as Record<string, unknown>[]),
+);
 
 const tabs = [
   {

--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/geo-map.helper.ts
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/geo-map.helper.ts
@@ -1,0 +1,7 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import type { GeoMapData } from '~/components/modules/widget/components/contributors/types/geo-map.types';
+
+// "Unknown" location is intentionally hidden from the list and chart (see IN-1225 / #2062).
+export const filterKnownCountries = (data?: GeoMapData[]): GeoMapData[] =>
+  data?.filter((item) => item.name !== 'Unknown') ?? [];

--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/geographical-distribution.vue
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/geographical-distribution.vue
@@ -36,53 +36,44 @@ SPDX-License-Identifier: MIT
       error-message="Error fetching geographical distribution"
       :is-empty="isEmpty"
     >
-      <div class="w-full h-[330px]">
-        <client-only>
-          <lfx-chart
-            :config="getGeoMapChartConfig(chartData, chartSeries, getMaxValue(chartData))"
-            :animation="!props.snapshot"
-          />
-        </client-only>
-      </div>
-      <div>
-        <div
-          v-if="status !== 'pending'"
-          class="flex flex-col gap-5"
+      <lfx-geo-distribution-view
+        v-if="status !== 'pending'"
+        :geo-map-data="geoMapData"
+        :label="label"
+        :limit="5"
+        :animation="!props.snapshot"
+      />
+      <div
+        v-if="!props.snapshot && showAllCountriesButton"
+        class="mt-5 flex flex-row justify-center"
+      >
+        <lfx-button
+          type="transparent"
+          @click="isDrawerOpened = true"
         >
-          <div
-            v-for="item in geoMapDataCountries"
-            :key="item.name"
-            class="flex flex-row justify-between items-center text-sm"
-          >
-            <div class="flex flex-row gap-4 items-center">
-              <span class="text-base">
-                {{ item.flag }}
-              </span>
-              <span class="font-medium">
-                {{ item.name }}
-              </span>
-            </div>
-            <span>
-              {{ formatNumber(item.count) }} {{ pluralize(label.toLowerCase(), item.count) }} ・ {{ item.percentage }}%
-            </span>
-          </div>
-        </div>
+          All countries
+        </lfx-button>
       </div>
     </lfx-project-load-state>
   </section>
+  <client-only>
+    <lfx-geographical-distribution-drawer
+      v-model="isDrawerOpened"
+      :selected-tab="model.activeTab"
+      :selected-metric="model.metric"
+      :model="model"
+    />
+  </client-only>
 </template>
 
 <script setup lang="ts">
-import { computed, watch } from 'vue';
+import { computed, ref, watch } from 'vue';
 import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
-import pluralize from 'pluralize';
+import LfxGeoDistributionView from './fragments/geo-distribution-view.vue';
+import LfxGeographicalDistributionDrawer from './fragments/geographical-distribution-drawer.vue';
 import LfxTabs from '~/components/uikit/tabs/tabs.vue';
-import LfxChart from '~/components/uikit/chart/chart.vue';
-import { convertToChartData, getMaxValue } from '~/components/uikit/chart/helpers/chart-helpers';
-import type { ChartData, RawChartData, ChartSeries } from '~/components/uikit/chart/types/ChartTypes';
-import { getGeoMapChartConfig } from '~/components/uikit/chart/configs/geo-map.chart';
-import { formatNumber } from '~/components/shared/utils/formatter';
+import LfxButton from '~/components/uikit/button/button.vue';
 import { useProjectStore } from '~/components/modules/project/store/project.store';
 import { isEmptyData } from '~/components/shared/utils/helper';
 import type {
@@ -137,22 +128,13 @@ const params = computed<GeographicalDistributionQueryParams>(() => ({
 }));
 
 const { data, status, error } = CONTRIBUTORS_API_SERVICE.fetchGeographicalDistribution(params);
+const isDrawerOpened = ref(false);
 
 const geoMapData = computed<GeoMapData[] | undefined>(() => (data.value as GeoMapResponse)?.data);
-const geoMapDataCountries = computed<GeoMapData[] | undefined>(() =>
-  geoMapData.value ? geoMapData.value.filter((item) => item.name !== 'Unknown').slice(0, 5) : undefined,
-);
+const knownGeoMapData = computed(() => geoMapData.value?.filter((item) => item.name !== 'Unknown') ?? []);
+const showAllCountriesButton = computed(() => knownGeoMapData.value.length > 5);
 
-const chartData = computed<ChartData[]>(
-  // convert the data to chart data
-  () =>
-    convertToChartData(geoMapData.value as unknown as RawChartData[], 'name', ['count', 'percentage']).map((item) => ({
-      ...item,
-      key: item.key === 'United States' ? 'United States of America' : item.key,
-    })),
-);
-
-const isEmpty = computed(() => isEmptyData(chartData.value as unknown as Record<string, unknown>[]));
+const isEmpty = computed(() => isEmptyData(knownGeoMapData.value as unknown as Record<string, unknown>[]));
 
 const tabs = [
   {
@@ -166,15 +148,6 @@ const tabs = [
 ];
 
 const label = computed(() => (model.value.activeTab === 'contributors' ? 'Contributor' : 'Organization'));
-
-const chartSeries = computed<ChartSeries[]>(() => [
-  {
-    name: label.value,
-    type: 'map',
-    yAxisIndex: 0,
-    dataIndex: 0,
-  },
-]);
 
 watch(
   status,

--- a/frontend/app/components/modules/widget/config/contributor/geographical-distribution/geographical-distribution.vue
+++ b/frontend/app/components/modules/widget/config/contributor/geographical-distribution/geographical-distribution.vue
@@ -56,14 +56,13 @@ SPDX-License-Identifier: MIT
       </div>
     </lfx-project-load-state>
   </section>
-  <client-only>
-    <lfx-geographical-distribution-drawer
-      v-model="isDrawerOpened"
-      :selected-tab="model.activeTab"
-      :selected-metric="model.metric"
-      :model="model"
-    />
-  </client-only>
+  <lfx-geographical-distribution-drawer
+    v-if="isDrawerOpened"
+    v-model="isDrawerOpened"
+    :selected-tab="model.activeTab"
+    :selected-metric="model.metric"
+    :model="model"
+  />
 </template>
 
 <script setup lang="ts">
@@ -72,6 +71,7 @@ import { useRoute } from 'vue-router';
 import { storeToRefs } from 'pinia';
 import LfxGeoDistributionView from './fragments/geo-distribution-view.vue';
 import LfxGeographicalDistributionDrawer from './fragments/geographical-distribution-drawer.vue';
+import { filterKnownCountries } from './geo-map.helper';
 import LfxTabs from '~/components/uikit/tabs/tabs.vue';
 import LfxButton from '~/components/uikit/button/button.vue';
 import { useProjectStore } from '~/components/modules/project/store/project.store';
@@ -131,7 +131,7 @@ const { data, status, error } = CONTRIBUTORS_API_SERVICE.fetchGeographicalDistri
 const isDrawerOpened = ref(false);
 
 const geoMapData = computed<GeoMapData[] | undefined>(() => (data.value as GeoMapResponse)?.data);
-const knownGeoMapData = computed(() => geoMapData.value?.filter((item) => item.name !== 'Unknown') ?? []);
+const knownGeoMapData = computed(() => filterKnownCountries(geoMapData.value));
 const showAllCountriesButton = computed(() => knownGeoMapData.value.length > 5);
 
 const isEmpty = computed(() => isEmptyData(knownGeoMapData.value as unknown as Record<string, unknown>[]));


### PR DESCRIPTION
## Summary
- Show all countries (not just top N) in the geographical distribution widget's "All countries" drawer

## Related
- Depends on the percentage-precision fix in the Tinybird pipes to avoid a wall of `0%` rows for the long tail: linuxfoundation/crowd.dev#4464 (must be deployed to Tinybird for correct display)

## Test plan
- [ ] Open a project's Contributors → geographical distribution widget → "All countries" and confirm all countries are listed
- [ ] After the crowd.dev PR is deployed, confirm long-tail countries show fractional percentages instead of `0%`