### PR TITLE
fix: disable lint-staged stash to prevent GPG-signed commit corruption

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -9,4 +9,12 @@ if git diff --diff-filter=d --name-only --cached | grep 'frontend/';
 fi
 
 #run lint-staged to add copyright license on top of all new files
-npx lint-staged
+#
+# --no-stash: the hook already force-stages every touched file via `git add -u`
+# above, so there's nothing partially-staged left for lint-staged's stash-based
+# backup/restore to protect. That stash mechanism has been observed to race with
+# git's own index handling during a real `git commit -S` (GPG-signed) transaction,
+# silently turning the commit into a pure deletion of every touched file while
+# leaving disk content correct (reproduced twice; not reproducible when running
+# this script standalone outside of `git commit`).
+npx lint-staged --no-stash


### PR DESCRIPTION
## Summary
- The pre-commit hook's `npx lint-staged` step was silently turning GPG-signed commits (`git commit -S`) into pure deletions of every touched file — disk content stayed correct, but the recorded commit tree only contained deletions. Reproduced twice, deterministic under a real `git commit -S`, not reproducible running the hook script standalone.
- Root cause: lint-staged's stash-based backup/restore mechanism was racing with git's own index handling during the commit transaction. The hook already force-stages every touched file via `git add -u` right before this step runs, so there's nothing partially-staged left for the stash to protect.
- Fix: pass `--no-stash` to `npx lint-staged`, removing the race entirely.

## Test plan
- [x] Reproduced the corruption on `main` with a real `git commit -S` touching `frontend/`, confirmed via `git show --stat` (pure deletions)
- [x] Applied `--no-stash`, repeated the same commit — confirmed correct tree via `git show --stat` (real insertions/deletions, no data loss)
- [x] Confirmed GPG signature still verifies (`git log --format='%G? %h %s'` → `G`)