### PR TITLE
feat: route collection-scoped tinybird requests to single bucket

### DIFF
--- a/frontend/server/data/tinybird/bucket-cache.test.ts
+++ b/frontend/server/data/tinybird/bucket-cache.test.ts
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import type { TinybirdResponse } from './tinybird';
+
+function mockResponse<T>(data: T): TinybirdResponse<T> {
+  return {
+    data,
+    meta: [],
+    rows: Array.isArray(data) ? data.length : 1,
+    rows_before_limit_at_least: 0,
+    statistics: { elapsed: 0, rows_read: 0, bytes_read: 0 },
+  };
+}
+
+describe('getBucketIdForCollection', () => {
+  afterEach(() => {
+    delete process.env.NUXT_REDIS_URL;
+    vi.clearAllMocks();
+  });
+
+  it('returns null for an empty collection slug without calling the fetcher', async () => {
+    const { getBucketIdForCollection } = await import('./bucket-cache');
+    const fetcher = vi.fn();
+
+    const result = await getBucketIdForCollection('', fetcher);
+
+    expect(result).toBeNull();
+    expect(fetcher).not.toHaveBeenCalled();
+  });
+
+  it('resolves the bucketId from Tinybird for a valid collection slug', async () => {
+    const { getBucketIdForCollection } = await import('./bucket-cache');
+    const fetcher = vi.fn().mockResolvedValue(mockResponse([{ bucketId: 7 }]));
+
+    const result = await getBucketIdForCollection('cncf', fetcher);
+
+    expect(result).toBe(7);
+    expect(fetcher).toHaveBeenCalledWith('/v0/pipes/collection_buckets.json', {
+      collectionSlug: 'cncf',
+    });
+  });
+
+  it('falls back to null (not fatal) when no bucket is found for the collection', async () => {
+    const { getBucketIdForCollection } = await import('./bucket-cache');
+    const fetcher = vi.fn().mockResolvedValue(mockResponse([]));
+
+    const result = await getBucketIdForCollection('unknown-collection', fetcher);
+
+    expect(result).toBeNull();
+  });
+
+  it('propagates rate limit errors instead of masking them as a cache miss', async () => {
+    const { getBucketIdForCollection } = await import('./bucket-cache');
+    const fetcher = vi.fn().mockRejectedValue({ statusCode: 429 });
+
+    await expect(getBucketIdForCollection('cncf', fetcher)).rejects.toEqual({ statusCode: 429 });
+  });
+
+  it('propagates server errors instead of masking them as a cache miss', async () => {
+    const { getBucketIdForCollection } = await import('./bucket-cache');
+    const fetcher = vi.fn().mockRejectedValue({ statusCode: 503 });
+
+    await expect(getBucketIdForCollection('cncf', fetcher)).rejects.toEqual({ statusCode: 503 });
+  });
+
+  it('returns null (fallback) for other fetch errors when Redis is enabled', async () => {
+    process.env.NUXT_REDIS_URL = 'redis://localhost:6379';
+    const { getBucketIdForCollection } = await import('./bucket-cache');
+    const fetcher = vi.fn().mockRejectedValue(new Error('network error'));
+
+    const result = await getBucketIdForCollection('cncf', fetcher);
+
+    expect(result).toBeNull();
+  });
+});

--- a/frontend/server/data/tinybird/bucket-cache.ts
+++ b/frontend/server/data/tinybird/bucket-cache.ts
@@ -9,12 +9,6 @@ import type { TinybirdResponse } from './tinybird';
  * Only used when Redis is available.
  */
 const inFlightRequests = new Map<string, Promise<number | null>>();
-
-/**
- * In-memory cache to prevent cache stampede (multiple concurrent requests for same collection).
- * Maps collection slug to a Promise that resolves to bucketId.
- * Only used when Redis is available.
- */
 const collectionInFlightRequests = new Map<string, Promise<number | null>>();
 
 /**
@@ -31,9 +25,6 @@ interface CollectionBucketResponse {
   bucketId: number;
 }
 
-/**
- * Check if Redis caching is enabled
- */
 function isRedisEnabled(): boolean {
   return !!process.env.NUXT_REDIS_URL && process.env.NUXT_REDIS_URL.length > 0;
 }
@@ -185,17 +176,6 @@ async function fetchBucketIdFromTinybird(
   return bucketId;
 }
 
-/**
- * Fetches the bucketId for a given collection from Tinybird.
- *
- * Caching strategy depends on environment:
- * - Local (no NUXT_REDIS_URL): Always fetches fresh from Tinybird (no caching)
- * - Production (with NUXT_REDIS_URL): Uses Redis cache (24hr TTL)
- *
- * @param {string} collectionSlug - The collection slug to fetch bucketId for
- * @param {Function} fetcher - The fetchFromTinybird function (injected to avoid circular dependency)
- * @return {Promise<number | null>} The bucketId for the collection, or null if not found/error occurred
- */
 export async function getBucketIdForCollection(
   collectionSlug: string,
   fetcher: <T>(
@@ -276,9 +256,6 @@ export async function getBucketIdForCollection(
   return fetchPromise;
 }
 
-/**
- * Internal function to fetch bucketId from Tinybird API for a collection
- */
 async function fetchBucketIdForCollectionFromTinybird(
   slugValue: string,
   fetcher: <T>(
@@ -366,12 +343,14 @@ export async function clearAllBucketCaches(): Promise<void> {
   try {
     const storage = useStorage('redis');
     const keys = await storage.getKeys('project_bucket:');
+    const collectionKeys = await storage.getKeys('collection_bucket:');
 
-    await Promise.all(keys.map((key) => storage.removeItem(key)));
+    await Promise.all([...keys, ...collectionKeys].map((key) => storage.removeItem(key)));
   } catch (error) {
     console.error('Failed to clear all bucket caches:', error);
   }
 
   // Clear in-flight requests
   inFlightRequests.clear();
+  collectionInFlightRequests.clear();
 }

--- a/frontend/server/data/tinybird/bucket-cache.ts
+++ b/frontend/server/data/tinybird/bucket-cache.ts
@@ -11,9 +11,23 @@ import type { TinybirdResponse } from './tinybird';
 const inFlightRequests = new Map<string, Promise<number | null>>();
 
 /**
+ * In-memory cache to prevent cache stampede (multiple concurrent requests for same collection).
+ * Maps collection slug to a Promise that resolves to bucketId.
+ * Only used when Redis is available.
+ */
+const collectionInFlightRequests = new Map<string, Promise<number | null>>();
+
+/**
  * Response type from the project_buckets Tinybird pipe
  */
 interface ProjectBucketResponse {
+  bucketId: number;
+}
+
+/**
+ * Response type from the collection_buckets Tinybird pipe
+ */
+interface CollectionBucketResponse {
   bucketId: number;
 }
 
@@ -161,6 +175,139 @@ async function fetchBucketIdFromTinybird(
       JSON.stringify({
         message: 'tinybird_bucket_invalid_type',
         project: projectValue,
+        bucketIdType: typeof bucketId,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+    return null;
+  }
+
+  return bucketId;
+}
+
+/**
+ * Fetches the bucketId for a given collection from Tinybird.
+ *
+ * Caching strategy depends on environment:
+ * - Local (no NUXT_REDIS_URL): Always fetches fresh from Tinybird (no caching)
+ * - Production (with NUXT_REDIS_URL): Uses Redis cache (24hr TTL)
+ *
+ * @param {string} collectionSlug - The collection slug to fetch bucketId for
+ * @param {Function} fetcher - The fetchFromTinybird function (injected to avoid circular dependency)
+ * @return {Promise<number | null>} The bucketId for the collection, or null if not found/error occurred
+ */
+export async function getBucketIdForCollection(
+  collectionSlug: string,
+  fetcher: <T>(
+    path: string,
+    query: Record<string, string | number | boolean | string[] | undefined | null>,
+  ) => Promise<TinybirdResponse<T>>,
+): Promise<number | null> {
+  const slugValue = collectionSlug?.toString().trim();
+  if (!slugValue || slugValue.length === 0) {
+    console.warn(
+      JSON.stringify({
+        message: 'tinybird_bucket_invalid_collection',
+        timestamp: new Date().toISOString(),
+      }),
+    );
+    return null;
+  }
+
+  const redisEnabled = isRedisEnabled();
+
+  if (!redisEnabled) {
+    return await fetchBucketIdForCollectionFromTinybird(slugValue, fetcher);
+  }
+
+  if (collectionInFlightRequests.has(slugValue)) {
+    try {
+      return await collectionInFlightRequests.get(slugValue)!;
+    } catch {
+      collectionInFlightRequests.delete(slugValue);
+    }
+  }
+
+  const cacheKey = `collection_bucket:${slugValue}`;
+
+  const fetchPromise = (async () => {
+    try {
+      const storage = useStorage('redis');
+      const cachedBucketId = await storage.getItem<number>(cacheKey);
+
+      if (cachedBucketId !== null && cachedBucketId !== undefined) {
+        return cachedBucketId;
+      }
+    } catch (cacheError) {
+      console.error(`Failed to read from Redis cache for collection ${slugValue}:`, cacheError);
+    }
+
+    try {
+      const bucketId = await fetchBucketIdForCollectionFromTinybird(slugValue, fetcher);
+
+      if (bucketId === null) {
+        return null;
+      }
+
+      try {
+        const storage = useStorage('redis');
+        await storage.setItem(cacheKey, bucketId, { ttl: 86400 });
+      } catch (cacheError) {
+        console.error(`Failed to cache bucketId for collection ${slugValue}:`, cacheError);
+      }
+
+      return bucketId;
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        const status = (error as { statusCode: number }).statusCode;
+        if (status === 429 || status >= 500) {
+          throw error;
+        }
+      }
+      console.warn(`Failed to fetch bucketId for collection ${slugValue}:`, error);
+      return null;
+    } finally {
+      collectionInFlightRequests.delete(slugValue);
+    }
+  })();
+
+  collectionInFlightRequests.set(slugValue, fetchPromise);
+
+  return fetchPromise;
+}
+
+/**
+ * Internal function to fetch bucketId from Tinybird API for a collection
+ */
+async function fetchBucketIdForCollectionFromTinybird(
+  slugValue: string,
+  fetcher: <T>(
+    path: string,
+    query: Record<string, string | number | boolean | string[] | undefined | null>,
+  ) => Promise<TinybirdResponse<T>>,
+): Promise<number | null> {
+  const response = await fetcher<CollectionBucketResponse[]>('/v0/pipes/collection_buckets.json', {
+    collectionSlug: slugValue,
+  });
+
+  if (!response?.data || !Array.isArray(response.data) || response.data.length === 0) {
+    console.warn(
+      JSON.stringify({
+        message: 'tinybird_bucket_not_found',
+        collectionSlug: slugValue,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+    return null;
+  }
+
+  const bucketId = response.data[0]?.bucketId;
+
+  if (typeof bucketId !== 'number') {
+    console.warn(
+      JSON.stringify({
+        message: 'tinybird_bucket_invalid_type',
+        collectionSlug: slugValue,
         bucketIdType: typeof bucketId,
         timestamp: new Date().toISOString(),
       }),

--- a/frontend/server/data/tinybird/tinybird.ts
+++ b/frontend/server/data/tinybird/tinybird.ts
@@ -3,7 +3,7 @@
 import { DateTime } from 'luxon';
 import { ofetch } from 'ofetch';
 import { AdaptiveSemaphore } from './adaptive-semaphore';
-import { getBucketIdForProject } from './bucket-cache';
+import { getBucketIdForCollection, getBucketIdForProject } from './bucket-cache';
 
 const MAX_CONCURRENT = parseInt(process.env.NUXT_TINYBIRD_MAX_CONCURRENT || '35', 10);
 const MAX_QUEUE_SIZE = parseInt(process.env.NUXT_TINYBIRD_MAX_QUEUE_SIZE || '500', 10);
@@ -109,6 +109,33 @@ export async function fetchFromTinybird<T>(
     }
   }
 
+  // Fetch and add bucketId if query contains a collectionSlug parameter
+  // Tinybird will route the request to the single bucket that contains the collection's data
+  // instead of scanning the 10-way union
+  if (
+    query.collectionSlug &&
+    typeof query.collectionSlug === 'string' &&
+    !query.bucketId &&
+    path !== '/v0/pipes/collection_buckets.json'
+  ) {
+    try {
+      const bucketId = await getBucketIdForCollection(query.collectionSlug, fetchFromTinybird);
+      if (bucketId !== null) {
+        query.bucketId = bucketId;
+      }
+      // No bucketId found is not fatal for collections (unlike projects) - fall back to the union pipe
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        const status = (error as { statusCode: number }).statusCode;
+        if (status === 429 || status >= 500) {
+          throw error;
+        }
+      }
+      console.warn(`Failed to fetch bucketId for collection ${query.collectionSlug}:`, error);
+      // Continue without bucketId - falls back to the union pipe
+    }
+  }
+
   // We don't want to send undefined, null, or empty values to TinyBird, so we remove those from the query.
   // We also format DateTime objects so that TinyBird understands them.
   const processedQuery = Object.fromEntries(
@@ -140,7 +167,10 @@ export async function fetchFromTinybird<T>(
   // Health-check pings and bucket lookups bypass the semaphore so they don't
   // compete for slots with real data queries (each query already needs a bucket
   // lookup first, which would double the slot pressure).
-  const skipThrottle = path === '/v0/pipes/ping.json' || path === '/v0/pipes/project_buckets.json';
+  const skipThrottle =
+    path === '/v0/pipes/ping.json' ||
+    path === '/v0/pipes/project_buckets.json' ||
+    path === '/v0/pipes/collection_buckets.json';
 
   let acquired = false;
   let wasQueued = false;


### PR DESCRIPTION
## Summary

- Adds collection bucket resolution to pre-route collection-scoped queries to a single bucket instead of scanning the 10-way union, matching the existing project-bucket optimization pattern
- Implements `getBucketIdForCollection()` with Redis 24h TTL caching, in-flight request stampede prevention, and graceful fallback to union queries (unlike project buckets which throw on not-found)
- Wires collection bucket routing into `fetchFromTinybird()` so any request carrying `collectionSlug` pre-resolves `bucketId` before hitting Tinybird; added `collection_buckets.json` to the throttle skip-list to avoid semaphore deadlock during bucket lookups

## Changes

| File | What changed |
|------|-------------|
| `frontend/server/data/tinybird/bucket-cache.ts` | Added `getBucketIdForCollection()` export (mirrors `getBucketIdForProject` pattern) with Redis cache + stampede prevention; added `fetchBucketIdForCollectionFromTinybird()` internal helper; updated `clearAllBucketCaches()` to also clear collection cache keys |
| `frontend/server/data/tinybird/bucket-cache.test.ts` | New test file: 6 Vitest cases covering empty-slug rejection, successful resolution, not-found graceful fallback, 429/5xx error propagation, and generic-error fallback |
| `frontend/server/data/tinybird/tinybird.ts` | Imported `getBucketIdForCollection`; added collection-slug detection and bucket resolution in `fetchFromTinybird()` before query execution; added `collection_buckets.json` to throttle skip-list alongside `project_buckets.json` |

## JIRA

IN-1231 — Route collection-scoped activity queries to a single bucket instead of the 10-way union

## Deploy order

The companion crowd.dev PR (branch `feat/IN-1231-collection-bucket-routing`) added the Tinybird single-bucket routing pipe and wired `activities_filtered.pipe` to use it when `bucketId` is present — **this change is already deployed to production.** This insights PR is self-contained (gracefully falls back if the pipe is unavailable); no ordering risk remains.

## DB migrations

No DB migrations.

## Test plan

- 6 new unit tests in `bucket-cache.test.ts`, all passing
- Browser QA pass: `crowd-insights-qa` validated across 3 real collections (CNCF, cloud-management-platforms, asyncapi) — no cross-collection data leakage, all widget requests 200 OK, full report at `LFX/qa/IN-1231-bucket-routing-qa.md`
- No regressions in collection page widget rendering or data accuracy

## Checklist

- [x] `git commit --signoff -S` on every commit
- [x] MIT license header on every new source file
- [x] PR diff < 1000 lines (236 additions)
- [x] No unrelated changes bundled
- [x] Companion crowd.dev Tinybird pipes already deployed to production