### PR TITLE
fix: prevent radix3 route collision in project security cache rule

### DIFF
--- a/frontend/setup/caching.test.ts
+++ b/frontend/setup/caching.test.ts
@@ -1,6 +1,7 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { describe, test, expect } from 'vitest';
+import { createRouter } from 'radix3';
 import cachingConfig from './caching';
 
 describe('caching configuration', () => {
@@ -11,13 +12,36 @@ describe('caching configuration', () => {
     expect(nitroRules['/api/security/**']?.headers?.['cache-control']).toBe(noCacheHeader);
   });
 
-  test('applies no-cache headers to /api/project/*/security/** endpoints', () => {
+  test('applies no-cache headers to /api/project/**/security/** endpoints', () => {
     const noCacheHeader = 'max-age=0, no-cache, no-store, must-revalidate, s-maxage=0';
     const nitroRules = cachingConfig.nitro.routeRules;
 
-    expect(nitroRules['/api/project/*/security/**']?.headers?.['cache-control']).toBe(
+    expect(nitroRules['/api/project/**/security/**']?.headers?.['cache-control']).toBe(
       noCacheHeader,
     );
+  });
+
+  test('nitro route rules do not break sibling /api/project/[slug]/** API routes', () => {
+    // A single-segment `*` in a nitro.routeRules pattern collides with the `:slug`
+    // param node that Nitro's file-based API routes register in its radix3 router,
+    // corrupting lookup for every other route under /api/project/:slug/** (health-score,
+    // insights, etc. all return 404 even though the route files exist and are registered).
+    const router = createRouter();
+    router.insert('/api/project/:slug', { name: 'index' });
+    router.insert('/api/project/:slug/overview/health-score', { name: 'health-score' });
+    router.insert('/api/project/:slug/security/assessment', { name: 'assessment' });
+
+    Object.keys(cachingConfig.nitro.routeRules).forEach((pattern) => {
+      router.insert(pattern, { name: `rule:${pattern}` });
+    });
+
+    expect(router.lookup('/api/project/k8s')).toMatchObject({ name: 'index' });
+    expect(router.lookup('/api/project/k8s/overview/health-score')).toMatchObject({
+      name: 'health-score',
+    });
+    expect(router.lookup('/api/project/k8s/security/assessment')).toMatchObject({
+      name: 'assessment',
+    });
   });
 
   test('does not apply no-cache headers to other /api/** routes', () => {

--- a/frontend/setup/caching.ts
+++ b/frontend/setup/caching.ts
@@ -103,9 +103,11 @@ export default {
         headers: { 'cache-control': 'max-age=0, no-cache, no-store, must-revalidate, s-maxage=0' },
         prerender: false,
       },
-      // `*` matches exactly one path segment — the real endpoint is
-      // /api/project/{slug}/security/assessment, two segments before `security`.
-      '/api/project/*/security/**': {
+      // A single-segment `*` here collides with the `:slug` param node that the real
+      // `/api/project/[slug]/**` API routes register in Nitro's radix3 router, corrupting
+      // route resolution for every route under `/api/project/:slug/**`.
+      // `**` matches one-or-more segments without introducing a conflicting node type.
+      '/api/project/**/security/**': {
         headers: { 'cache-control': 'max-age=0, no-cache, no-store, must-revalidate, s-maxage=0' },
         prerender: false,
       },


### PR DESCRIPTION
## Summary

- Production outage (2026-08-18): every route under `/api/project/[slug]/**` (health-score, health-score-overview, insights, associated-organization, contributor-retention, security/*) returned 404, except `/api/project/{slug}` itself.
- Root cause: IN-1211 added a Nitro `nitro.routeRules` pattern `/api/project/*/security/**` in `frontend/setup/caching.ts`. The single-segment `*` wildcard is inserted into Nitro's radix3 router at the same tree depth as the `:slug` named-param node that the real `server/api/project/[slug]/**` file-based routes register — this collides and corrupts route resolution for every sibling route under `/api/project/:slug/**`, even though the compiled route handlers exist and are registered.
- Confirmed via isolated reproduction using the actual `radix3` package: inserting the buggy pattern into a router alongside the real routes causes lookups for `health-score` etc. to return `null`; replacing it with a double-star (`**`) pattern (which does not introduce a conflicting node type) resolves correctly.
- Fix: change `/api/project/*/security/**` to `/api/project/**/security/**`.
- Added a regression test (`caching.test.ts`) that inserts every configured `nitro.routeRules` pattern into a real radix3 router alongside representative sibling API routes and asserts they all still resolve — this is the test that should have caught the original bug before it reached review/production (prior tests only asserted the config object's key/value, never exercised actual route matching).

## Test plan

- [x] `pnpm vitest run setup/caching.test.ts` — all 5 tests pass, including the new regression test
- [ ] Deploy to production and verify `/api/project/k8s/overview/health-score`, `/api/project/k8s/security/assessment`, and `/api/project/k8s/insights` all return 200