### PR TITLE
fix: remove placeholder tooltip and fix mobile health breakdown stacking

### DIFF
--- a/frontend/app/components/modules/collection/components/details/collection-health-score-pill.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-health-score-pill.vue
@@ -10,30 +10,24 @@ SPDX-License-Identifier: MIT
   >
     <span class="text-xs font-medium text-neutral-500">Unavailable</span>
   </lfx-chip>
-  <lfx-tooltip
+  <lfx-chip
     v-else
-    placement="top"
-    content="Tooltip copy pending"
+    type="bordered"
+    size="small"
+    class="flex items-center gap-1"
   >
-    <lfx-chip
-      type="bordered"
-      size="small"
-      class="flex items-center gap-1"
-    >
-      <span
-        class="size-1.5 rounded-full shrink-0"
-        :class="healthScoreDotClass"
-      />
-      <span class="text-xs font-medium text-neutral-900">{{ healthScoreLabel }}</span>
-      <span class="text-xs font-medium text-neutral-500">({{ props.score }})</span>
-    </lfx-chip>
-  </lfx-tooltip>
+    <span
+      class="size-1.5 rounded-full shrink-0"
+      :class="healthScoreDotClass"
+    />
+    <span class="text-xs font-medium text-neutral-900">{{ healthScoreLabel }}</span>
+    <span class="text-xs font-medium text-neutral-500">({{ props.score }})</span>
+  </lfx-chip>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import LfxChip from '~/components/uikit/chip/chip.vue';
-import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
 
 const props = defineProps<{
   score: number;

--- a/frontend/app/components/modules/collection/components/details/collection-impact-score-pill.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-impact-score-pill.vue
@@ -10,30 +10,24 @@ SPDX-License-Identifier: MIT
   >
     <span class="text-xs font-medium text-neutral-500">N/A</span>
   </lfx-chip>
-  <lfx-tooltip
+  <lfx-chip
     v-else
-    placement="top"
-    content="Tooltip copy pending"
+    type="bordered"
+    size="small"
+    class="flex items-center gap-1"
   >
-    <lfx-chip
-      type="bordered"
-      size="small"
-      class="flex items-center gap-1"
-    >
-      <span
-        class="size-1.5 rounded-full shrink-0"
-        :class="impactScoreDotClass"
-      />
-      <span class="text-xs font-medium text-neutral-900">{{ impactScoreLabel }}</span>
-      <span class="text-xs font-medium text-neutral-500">({{ props.score }})</span>
-    </lfx-chip>
-  </lfx-tooltip>
+    <span
+      class="size-1.5 rounded-full shrink-0"
+      :class="impactScoreDotClass"
+    />
+    <span class="text-xs font-medium text-neutral-900">{{ impactScoreLabel }}</span>
+    <span class="text-xs font-medium text-neutral-500">({{ props.score }})</span>
+  </lfx-chip>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import LfxChip from '~/components/uikit/chip/chip.vue';
-import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
 
 const props = defineProps<{
   score: number | null;

--- a/frontend/app/components/modules/collection/components/details/collection-lifecycle-badge.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-lifecycle-badge.vue
@@ -10,27 +10,21 @@ SPDX-License-Identifier: MIT
   >
     <span class="text-xs font-medium text-neutral-500">Unavailable</span>
   </lfx-chip>
-  <lfx-tooltip
+  <lfx-tag
     v-else
-    placement="top"
-    content="Tooltip copy pending"
+    :variation="variation"
+    type="transparent"
+    size="small"
+    class="capitalize"
   >
-    <lfx-tag
-      :variation="variation"
-      type="transparent"
-      size="small"
-      class="capitalize"
-    >
-      {{ props.lifecycleLabel }}
-    </lfx-tag>
-  </lfx-tooltip>
+    {{ props.lifecycleLabel }}
+  </lfx-tag>
 </template>
 
 <script setup lang="ts">
 import { computed } from 'vue';
 import LfxTag from '~/components/uikit/tag/tag.vue';
 import LfxChip from '~/components/uikit/chip/chip.vue';
-import LfxTooltip from '~/components/uikit/tooltip/tooltip.vue';
 import type { TagStyle } from '~/components/uikit/tag/types/tag.types';
 
 const props = defineProps<{

--- a/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
@@ -37,7 +37,7 @@ SPDX-License-Identifier: MIT
       <span>Health Score unavailable. All three categories have less than 40% signal coverage for this project.</span>
     </div>
 
-    <div class="flex items-stretch gap-1 p-1 bg-neutral-50 rounded-lg mb-4">
+    <div class="flex flex-col sm:flex-row sm:items-stretch gap-1 p-1 bg-neutral-50 rounded-lg mb-4">
       <lfx-health-breakdown-category-card
         v-for="category in categories"
         :key="category.key"


### PR DESCRIPTION
## Summary
- Remove the placeholder "Tooltip copy pending" tooltip from the collection lifecycle, health score, and impact pills on the collection details page
- Stack the health breakdown category cards (Maintainer Health, Security & Supply Chain, Development Activity) vertically on mobile instead of squeezing them into a row

## Test plan
- [x] `tsc-check` passes
- [x] `eslint` passes on changed files
- [ ] Verify collection details page (e.g. `/collection/details/cncf`) no longer shows the placeholder tooltip
- [ ] Verify `/project/k8s` health breakdown cards stack on mobile viewport widths