### PR TITLE
fix: add equal-weight footer line to impact breakdown

### DIFF
--- a/frontend/app/components/modules/project/components/overview/impact-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/impact-breakdown-section.vue
@@ -60,6 +60,9 @@ SPDX-License-Identifier: MIT
           :value="data.directDependents"
           :band="data.directDependentsBand"
         />
+        <p class="text-xs text-neutral-500 mt-2">
+          Impact score aggregates all signals available for this ecosystem with equal weight.
+        </p>
       </div>
 
       <div


### PR DESCRIPTION
## Summary
- Adds the missing footer line under the Impact breakdown section: "Impact score aggregates all signals available for this ecosystem with equal weight."
- This was AC #4 of IN-1235 ("Primary / Secondary pills removed. Equal-weight footer line added.") but was never implemented in any commit of the original PR (#2108) — confirmed missing from every commit on that branch, not a regression from later revert/fix commits on it.
- Caught by post-deploy QA against production after #2108 merged and deployed.

IN-1235

## Test plan
- [x] `pnpm lint` — 0 errors
- [x] `pnpm tsc-check` — clean
- [x] `pnpm test` — 202/202 passing
- [ ] Manual verification on prod after merge/deploy