### PR TITLE
docs: rewrite health score page for v2 methodology

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -3,18 +3,22 @@ if git diff --name-only --cached | grep 'frontend/';
   then
     echo "FRONTEND FOLDER CHANGED --> starting husky..."
     cd frontend && \
-    pnpm exec eslint --fix $(git diff --name-only --diff-filter=d --cached --relative) && \
+    ESLINT_FILES=$(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|ts|vue)$' | tr '\n' ' ') && \
+    ([ -z "$ESLINT_FILES" ] || (pnpm exec eslint --fix $ESLINT_FILES && git add -u $(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|ts|vue)$'))) && \
     pnpm tsc-check
-    git add -u $(git diff --name-only --diff-filter=d --cached --relative)
 fi
 
 #run lint-staged to add copyright license on top of all new files
 #
-# --no-stash: the hook already force-stages every touched file via `git add -u`
-# above, so there's nothing partially-staged left for lint-staged's stash-based
-# backup/restore to protect. That stash mechanism has been observed to race with
-# git's own index handling during a real `git commit -S` (GPG-signed) transaction,
-# silently turning the commit into a pure deletion of every touched file while
-# leaving disk content correct (reproduced twice; not reproducible when running
-# this script standalone outside of `git commit`).
-npx lint-staged --no-stash
+# Guard: only run when JS/TS/Vue files are staged. When only non-lintable
+# files (e.g. .md) are staged, `npx lint-staged --no-stash` races with the
+# GPG signing transaction and silently turns commits into pure deletions of
+# every staged file (disk content intact). Skipping it when there is no
+# matching work eliminates that race.
+#
+# Similarly, `git add -u` (which re-stages eslint --fix output) is now
+# inside the eslint guard above, so it also only runs when lintable files
+# are present — removing the other vector for the same GPG index race.
+if git diff --name-only --cached | grep -qE '\.(js|ts|vue)$'; then
+  npx lint-staged --no-stash
+fi

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -20,5 +20,5 @@ fi
 # inside the eslint guard above, so it also only runs when lintable files
 # are present — removing the other vector for the same GPG index race.
 if git diff --name-only --cached | grep -qE '\.(js|ts|vue)$'; then
-  npx lint-staged --no-stash
+  pnpm exec lint-staged --no-stash
 fi

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -3,8 +3,8 @@ if git diff --name-only --cached | grep 'frontend/';
   then
     echo "FRONTEND FOLDER CHANGED --> starting husky..."
     cd frontend && \
-    ESLINT_FILES=$(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|ts|vue)$' | tr '\n' ' ') && \
-    ([ -z "$ESLINT_FILES" ] || (pnpm exec eslint --fix $ESLINT_FILES && git add -u $(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|ts|vue)$'))) && \
+    ESLINT_FILES=$(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|cjs|mjs|ts|cts|mts|tsx|jsx|vue)$' | tr '\n' ' ') && \
+    ([ -z "$ESLINT_FILES" ] || (pnpm exec eslint --fix $ESLINT_FILES && git add -u $(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|cjs|mjs|ts|cts|mts|tsx|jsx|vue)$'))) && \
     pnpm tsc-check
 fi
 
@@ -19,6 +19,6 @@ fi
 # Similarly, `git add -u` (which re-stages eslint --fix output) is now
 # inside the eslint guard above, so it also only runs when lintable files
 # are present — removing the other vector for the same GPG index race.
-if git diff --name-only --cached | grep -qE '\.(js|ts|vue)$'; then
+if git diff --name-only --cached | grep -qE '\.(js|cjs|mjs|ts|cts|mts|tsx|jsx|vue)$'; then
   pnpm exec lint-staged --no-stash
 fi

--- a/frontend/docs/features/community-collections/index.md
+++ b/frontend/docs/features/community-collections/index.md
@@ -33,7 +33,7 @@ Every collection detail page opens on the **Projects** tab. The header displays 
 
 - **Projects / Repositories** — the total number of projects and individual repositories included in the collection.
 - **Contributors** — the total number of unique contributors across all projects in the collection.
-- **Avg. Health** — the average LFX Health Score across all projects, labelled Excellent (80+), Healthy (60–79), Fair (40–59), Concerning (20–39), or Critical (below 20).
+- **Avg. Health** — the average LFX Health Score across all projects, labelled Excellent (85–100), Healthy (70–84), Fair (50–69), Concerning (30–49), or Critical (below 30).
 
 ### Projects tab
 

--- a/frontend/docs/index.md
+++ b/frontend/docs/index.md
@@ -23,7 +23,7 @@ features:
   link: /introduction/what-is-insights/index
   linkText: Learn more
 - title: Health Score
-  details: A single, unified metric that reflects the overall health of an open source project, from activity to security.
+  details: Three independent assessments — Lifecycle state, Health Score, and Impact Score — that together answer whether a project is well-maintained, healthy, and critical to the ecosystem.
   link: /metrics/health-score/index
   linkText: Learn more
 - title: FAQ

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -1,6 +1,6 @@
 # Health Score Explained
 
-LFX Insights now surfaces **three independent assessments** for every project: a **Lifecycle state**, a **Health Score**, and an **Impact Score**. Together, these replace the previous single composite score and answer three distinct questions:
+LFX Insights surfaces **three independent assessments** for open source projects: a **Lifecycle state**, a **Health Score**, and an **Impact Score**. Together, these replace the previous single composite score and answer three distinct questions:
 
 - **Lifecycle:** what state is this project in?
 - **Health Score:** how well-maintained is it?
@@ -32,7 +32,7 @@ Look at the Lifecycle state before the numeric scores. It is derived from mainta
 
 | State | What it means |
 |---|---|
-| **Active** | Regular commits in the last 6 months, responsive maintainers, healthy release cadence |
+| **Active** | Does not meet criteria for any other state. Typically has recent commits and responsive maintainers, but no specific thresholds are required. |
 | **Stable** | Low activity by design. The project is mature and does not need frequent changes. Maintainers are still reachable. |
 | **Declining** | Activity dropped more than 50% in the last 6 months while issue volume increased; a sign the project is under pressure |
 | **Inert** | No commits in 18+ months, but no open issues or pull requests either. Nothing to judge responsiveness by. A quiet project, not a neglected one. |
@@ -83,7 +83,7 @@ Measures the median time for a non-author to respond to newly opened issues and 
 - **15 pts:** Median response time under 7 days
 - **10 pts:** Median response time under 30 days
 - **5 pts:** Median response time under 90 days
-- **0 pts:** Median response time over 90 days, or no response data available
+- **0 pts:** Median response time 90 days or more, or no response data available
 
 #### 1.2 Bus Factor (max 18 pts)
 
@@ -177,24 +177,37 @@ Counts commits authored in the last 6 months on the cleaned activity stream (bot
 
 #### 3.3 Issue Resolution (max 7 pts)
 
-Measures the median time from issue opened to issue closed over the last 12 months. Only non-bot activity is included. Lower median time means a higher score.
+Combines two independent measures over the last 12 months: how many issues were resolved, and how quickly. Only non-bot activity is included. Points from each component are added together.
 
-- **7 pts:** Median resolution time under 7 days
-- **5 pts:** Median resolution time under 14 days
-- **3 pts:** Median resolution time under 30 days
-- **1 pt:** Median resolution time under 90 days
-- **0 pts:** Median resolution time over 90 days, or no closed issues in the period
+**Close ratio** (max 4 pts) — issues closed relative to issues opened:
+
+- **4 pts:** 80% or more of opened issues were closed
+- **2 pts:** 50% or more of opened issues were closed
+- **0 pts:** Fewer than 50% closed, or no issues in the period
+
+**Median time to close** (max 3 pts):
+
+- **3 pts:** Median close time under 7 days
+- **2 pts:** Median close time under 30 days
+- **0 pts:** 30 days or more, or no closed issues in the period
 
 Gerrit repositories do not ingest issue data. This sub-signal is blocked for Gerrit-only projects and its weight redistributes within Development Activity.
 
 #### 3.4 PR Merge Health (max 5 pts)
 
-Evaluates the ratio of merged pull requests to closed-unmerged pull requests over the last 12 months, combined with median time to merge. A high abandonment rate or slow merge cadence signals a backlog problem.
+Combines two independent measures over the last 12 months: what fraction of pull requests were merged rather than abandoned, and how quickly. Points from each component are added together.
 
-- **5 pts:** High merge rate (80% or more of closed PRs merged) and median merge time under 7 days
-- **3 pts:** Good merge rate (60% or more) or fast merge time under 14 days
-- **1 pt:** Moderate merge rate (40% or more) or merge time under 30 days
-- **0 pts:** Low merge rate or median merge time over 30 days
+**Merge ratio** (max 3 pts) — merged pull requests relative to all closed pull requests:
+
+- **3 pts:** 70% or more of closed pull requests were merged
+- **1 pt:** 40% or more of closed pull requests were merged
+- **0 pts:** Fewer than 40% merged, or no closed pull requests in the period
+
+**Median time to merge** (max 2 pts):
+
+- **2 pts:** Median merge time under 7 days
+- **1 pt:** Median merge time under 30 days
+- **0 pts:** 30 days or more, or no merged pull requests in the period
 
 Gerrit repositories do not ingest pull request data. This sub-signal is blocked for Gerrit-only projects and its weight redistributes within Development Activity.
 
@@ -239,7 +252,7 @@ Projects that do not publish any tracked packages do not receive an Impact Score
 Impact is computed in three steps:
 
 1. **Log-transform raw inputs:** downloads, direct dependents, and transitive dependents are log-transformed to compress the power-law distributions typical of open source package ecosystems.
-2. **Normalize within each ecosystem** using percentile rank, so packages are comparable across ecosystems despite different raw magnitudes (npm and Maven packages live in very different distribution ranges).
+2. **Normalize within each ecosystem**, so packages are comparable across ecosystems despite different raw magnitudes (npm and Maven packages live in very different distribution ranges).
 3. **Weighted blend** of the four signals, biased toward blast-radius signals (transitive dependents and graph centrality), then scaled to 0–100.
 
 ## Multi-Repo Projects
@@ -292,7 +305,7 @@ The original Insights Health Score was a single 0–100 value, computed as an eq
 | **Health categories** | 4 equal categories at 25 pts each | 3 weighted categories: Maintainer (40), Security and Supply Chain (35), Development Activity (25) |
 | **Popularity** | Baked into Health Score as 25% of the total | Separate Impact Score; does not affect Health |
 | **Lifecycle** | Not modeled | Six states: Active, Stable, Declining, Inert, Abandoned, Archived |
-| **Stable "done" libraries** | Penalized: low commits meant a low score | Not penalized: the Stable state and development floor recognize intentionally low-activity projects |
+| **Stable "done" libraries** | Penalized: low commits meant a low score | Not penalized: the Stable state recognizes intentionally low-activity projects |
 | **Maintainer signal** | Contributor count only | Responsiveness, bus factor (curated plus observed), organizational diversity |
 | **Security** | OpenSSF Baseline pass/fail ratio | Open CVEs with severity weighting, security practices, OpenSSF Scorecard, dependency health, supply chain integrity |
 | **Missing data** | Returned unavailable if any sub-score was absent | Two-layer redistribution: blocked sub-signals rescale within their category; scores are only marked unavailable when signal floor is too low to be defensible |

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -20,39 +20,24 @@ No score captures all the nuance of an open source project. Different projects s
 | **Health Score** | How well-maintained is it? | 0–100, independent of popularity |
 | **Impact Score** | How much does it matter if this breaks? | 0–100, based on dependency graph reach |
 
-All three are shown together in the UI. When prioritizing stewardship, low Health combined with high Impact is the most urgent combination.
-
 This methodology was developed with community input. You can read the full discussion and the feedback that shaped these decisions in [GitHub Discussion #1939](https://github.com/linuxfoundation/insights/discussions/1939).
 
 ## Lifecycle State
-
-Look at the Lifecycle state before the numeric scores. It is derived from maintainer signals using a decision tree, not from the composite score itself.
 
 ### States
 
 | State | What it means |
 |---|---|
-| **Active** | Does not meet criteria for any other state. Any project not classified as Archived, Abandoned, Inert, Declining, or Stable falls here. No specific activity thresholds are required. |
-| **Stable** | Low activity by design. The project is mature and does not need frequent changes. Maintainers are still reachable. |
-| **Declining** | Activity dropped more than 50% in the last 6 months while issue volume increased; a sign the project is under pressure |
-| **Inert** | No commits in 18+ months, but no open issues or pull requests either. Nothing to judge responsiveness by. A quiet project, not a neglected one. |
-| **Abandoned** | No maintainer activity in 12+ months, with open issues or pull requests that have gone unanswered for an extended period |
-| **Archived** | Explicitly archived in the repository host or marked deprecated in the package registry |
+| **Active** | Regular commits in the last 6 months and maintainer is responsive to issues and pull requests. |
+| **Stable** | Commit activity has dropped more than 50% compared to the prior period, but a release was published within the last 12 months, fewer than 50 issues are open, and no critical vulnerabilities are unresolved. |
+| **Declining** | Commits in the last 6 months are less than half the prior 6 months, and the number of newly opened issues has increased. A sign the project is under pressure. |
+| **Inert** | No commits in 18 or more months, and no open issues or pull requests. Nothing to judge responsiveness by — a quiet project, not a neglected one. |
+| **Abandoned** | Open issues or pull requests have gone unanswered for 90 to 180 days, and no maintainer activity in the last 18 months. |
+| **Archived** | Explicitly archived in the repository host or marked deprecated or yanked in the package registry. |
 
 ::: tip
 "Silence alone is not abandonment — ignoring people is." A finished utility with no open issues, no CVEs, and no need for further development gets `Inert`, not `Abandoned`. The `Abandoned` state requires evidence of neglect: open items piling up while maintainers are absent. This distinction came directly from community feedback on the methodology.
 :::
-
-### Classification Rules
-
-The lifecycle state is assigned by evaluating the following conditions in order. The first match wins:
-
-1. **Archived:** the repository's archived flag is set, or the package registry marks the package as deprecated or yanked.
-2. **Abandoned:** open issues or pull requests have received no non-author response for an extended period (90 to 180 days), and maintainers have had no activity in the last 18 months.
-3. **Inert:** no commits in the last 18 months, and no open issues or pull requests in that window (nothing to judge responsiveness by).
-4. **Declining:** commits in the last 6 months are less than 50% of the prior 6 months, and the volume of newly opened issues is higher than the prior period.
-5. **Stable:** the latest release is within the last 12 months, fewer than 50 issues are open, no critical vulnerabilities are open, and commits have dropped more than 50% vs. the prior period.
-6. **Active:** all other projects.
 
 For multi-repo projects, the project takes the best state across all its repositories: Active beats Stable, Stable beats Declining, and so on down to Archived.
 
@@ -199,7 +184,7 @@ Gerrit repositories do not ingest issue data. This sub-signal is blocked for Ger
 
 #### 3.4 PR Merge Health (max 5 pts)
 
-Combines two independent measures over the last 12 months: what fraction of pull requests were merged rather than abandoned, and how quickly. Points from each component are added together.
+Combines two independent measures over the last 12 months: what fraction of pull requests were merged rather than abandoned, and how quickly. Points from each component are added together. For Gerrit projects, changesets and patchsets are mapped to the same metrics.
 
 **Merge ratio** (max 3 pts) — merged pull requests relative to all closed pull requests:
 
@@ -212,8 +197,6 @@ Combines two independent measures over the last 12 months: what fraction of pull
 - **2 pts:** Median merge time under 7 days
 - **1 pt:** Median merge time under 30 days
 - **0 pts:** 30 days or more, or no merged pull requests in the period
-
-Gerrit repositories do not ingest pull request data. This sub-signal is blocked for Gerrit-only projects and its weight redistributes within Development Activity.
 
 ### Handling Missing Data
 
@@ -277,7 +260,7 @@ Security practices and OpenSSF Scorecard are currently GitHub-only. GitLab proje
 
 **Gerrit projects:**
 
-Gerrit does not ingest issue or PR data in the same format as GitHub and GitLab. Issue Resolution, PR Merge Health, and Security Practices are typically blocked. Commit Activity and Bus Factor remain available. Development Activity may compute from a reduced set of sub-signals.
+Gerrit does not ingest issue data in the same format as GitHub and GitLab. Issue Resolution and Security Practices are typically blocked. PR Merge Health is available — Gerrit changesets and patchsets are mapped to the same merge metrics. Commit Activity and Bus Factor also remain available.
 
 **Projects without published packages:**
 
@@ -290,10 +273,6 @@ For multi-repo projects, sub-signals in a `partial` coverage state are computed 
 ::: info
 Health Score comparisons across projects with different platform or data coverage are not directly comparable. A project with full GitHub and package data is scored on more signals than one on Gerrit with no published packages. Coverage details are always shown alongside the score.
 :::
-
-## Bot and Non-Human Activity
-
-All time-based and activity-count signals (responsiveness, commit counts, issue metrics, PR metrics, bus factor recency) are computed from the cleaned activity stream, which excludes bots, team accounts, and organization accounts identified through contributor enrichment. This prevents automated issue floods or bot-authored PRs from distorting responsiveness or resolution metrics.
 
 ## How This Differs from the Previous Health Score
 

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -1,6 +1,6 @@
 # Health Score Explained
 
-LFX Insights surfaces **three independent assessments** for open source projects: a **Lifecycle state**, a **Health Score**, and an **Impact Score**. Together, these replace the previous single composite score and answer three distinct questions:
+LFX Insights surfaces up to **three independent assessments** for open source projects: a **Lifecycle state**, a **Health Score**, and when applicable an **Impact Score**. Together, these replace the previous single composite score and answer three distinct questions:
 
 - **Lifecycle:** what state is this project in?
 - **Health Score:** how well-maintained is it?
@@ -32,7 +32,7 @@ Look at the Lifecycle state before the numeric scores. It is derived from mainta
 
 | State | What it means |
 |---|---|
-| **Active** | Does not meet criteria for any other state. Typically has recent commits and responsive maintainers, but no specific thresholds are required. |
+| **Active** | Does not meet criteria for any other state. Any project not classified as Archived, Abandoned, Inert, Declining, or Stable falls here. No specific activity thresholds are required. |
 | **Stable** | Low activity by design. The project is mature and does not need frequent changes. Maintainers are still reachable. |
 | **Declining** | Activity dropped more than 50% in the last 6 months while issue volume increased; a sign the project is under pressure |
 | **Inert** | No commits in 18+ months, but no open issues or pull requests either. Nothing to judge responsiveness by. A quiet project, not a neglected one. |
@@ -48,7 +48,7 @@ Look at the Lifecycle state before the numeric scores. It is derived from mainta
 The lifecycle state is assigned by evaluating the following conditions in order. The first match wins:
 
 1. **Archived:** the repository's archived flag is set, or the package registry marks the package as deprecated or yanked.
-2. **Abandoned:** open issues or pull requests have received no non-author response for an extended period (90 to 180 days), and maintainers have had no activity in the last 12 months.
+2. **Abandoned:** open issues or pull requests have received no non-author response for an extended period (90 to 180 days), and maintainers have had no activity in the last 18 months.
 3. **Inert:** no commits in the last 18 months, and no open issues or pull requests in that window (nothing to judge responsiveness by).
 4. **Declining:** commits in the last 6 months are less than 50% of the prior 6 months, and the volume of newly opened issues is higher than the prior period.
 5. **Stable:** the latest release is within the last 12 months, fewer than 50 issues are open, no critical vulnerabilities are open, and commits have dropped more than 50% vs. the prior period.
@@ -78,14 +78,16 @@ A project with responsive maintainers will fix CVEs, clear backlogs, and ship fi
 
 #### 1.1 Maintainer Responsiveness (max 15 pts)
 
-Measures the median time for a non-author to respond to newly opened issues and pull requests. Bot and automation activity is excluded so only genuine human responses count.
+Measures the median time for a non-author to respond to newly opened issues and pull requests. The score uses the average of the issue and PR response medians. Bot and automation activity is excluded so only genuine human responses count.
 
-- **15 pts:** Median response time under 7 days
-- **10 pts:** Median response time under 30 days
-- **5 pts:** Median response time under 90 days
-- **0 pts:** Median response time 90 days or more, or no response data available
+- **15 pts:** Median response time under 24 hours
+- **12 pts:** Median response time under 3 days
+- **9 pts:** Median response time under 1 week
+- **5 pts:** Median response time under 1 month
+- **2 pts:** Median response time under 3 months
+- **0 pts:** Median response time 3 months or more, or no response data available
 
-Projects with no open issues or pull requests in the measurement window have no response data. This sub-signal is scored as 0 pts (not redistributed), because the signal is available — there is simply no activity to measure.
+Projects with no open issues or pull requests in the measurement window have no response data. This sub-signal scores 0 pts (not redistributed) because the signal is `available` — there is simply no activity to measure. Only `blocked` sub-signals redistribute their weight.
 
 #### 1.2 Bus Factor (max 18 pts)
 
@@ -102,7 +104,7 @@ Counts the number of people who are actively maintaining the project, taking the
 Measures how many distinct organizations the active maintainers are affiliated with, using contributor affiliation data. Projects maintained by contributors from multiple independent organizations are more resilient to any single organization withdrawing support.
 
 - **7 pts:** Maintainers from 3 or more organizations
-- **4 pts:** Maintainers from 2 organizations
+- **5 pts:** Maintainers from 2 organizations
 - **2 pts:** All maintainers from 1 organization
 - **0 pts:** Affiliation unknown
 
@@ -117,7 +119,11 @@ Counts unresolved security advisories scoped to the repository, sourced from OSV
 - **10 pts:** No open vulnerabilities
 - Points deducted per open advisory: 6 per Critical, 3 per High, 1 per Moderate (minimum 0)
 
-If no vulnerability scan has been completed for the repository, this sub-signal is unavailable and its weight redistributes to other Security sub-signals.
+If no vulnerability scan has been completed for the repository, this sub-signal is `blocked` and its weight redistributes to other available Security sub-signals.
+
+::: info
+The UI currently shows "No open vulnerabilities" when scan data is absent rather than marking the sub-signal as unavailable. This is a known display issue (IN-1241) and does not affect the underlying score calculation.
+:::
 
 #### 2.2 Security Practices (max 8 pts)
 
@@ -153,7 +159,7 @@ Assesses build provenance attestation, artifact-to-repository consistency, and p
 
 ### 3. Development Activity (0–25 pts)
 
-A finished library with no open issues, no CVEs, and a recent release can score well here without recent commits. Intentionally low-activity projects are not penalized.
+Development Activity rewards recent releases, commits, resolved issues, and merged pull requests. Projects with no activity across these signals score low here. The Lifecycle state provides additional context — a `Stable` classification signals to users that low activity is intentional — but it does not change the underlying point formula.
 
 #### 3.1 Release Cadence (max 8 pts)
 
@@ -202,7 +208,7 @@ Combines two independent measures over the last 12 months: what fraction of pull
 **Merge ratio** (max 3 pts) — merged pull requests relative to all closed pull requests:
 
 - **3 pts:** 70% or more of closed pull requests were merged
-- **1 pt:** 40% or more of closed pull requests were merged
+- **1 pt:** 40–69% of closed pull requests were merged
 - **0 pts:** Fewer than 40% merged, or no closed pull requests in the period
 
 **Median time to merge** (max 2 pts):
@@ -283,7 +289,7 @@ Release Cadence, Dependency Health, and Supply Chain Integrity are all package-m
 
 **Projects with partial data across repos:**
 
-For multi-repo projects, sub-signals in a `partial` coverage state are computed over the subset of repositories where data is available. The score reflects what can be observed, and the coverage detail is available in the UI for transparency.
+For multi-repo projects, sub-signals in a `partial` coverage state are computed over the subset of repositories where data is available. The score reflects what can be observed.
 
 ::: info
 Health Score comparisons across projects with different platform or data coverage are not directly comparable. A project with full GitHub and package data is scored on more signals than one on Gerrit with no published packages. Coverage details are always shown alongside the score.

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -240,20 +240,18 @@ Projects that do not publish any tracked packages do not receive an Impact Score
 
 ### Signals
 
-| Signal | Role | What it captures |
-|---|---|---|
-| **Transitive dependents** | Primary | All packages that depend on this project directly or indirectly. The core blast-radius measure. |
-| **Graph centrality** | Primary | PageRank-style score over the dependency graph, weighting a package by the importance of what depends on it. A package depended on by major runtimes or frameworks scores higher than one with the same count of less-important dependents. |
-| **Downloads** | Secondary | Per-registry download counts. A proxy for real-world usage, complementary to graph signals. |
-| **Direct dependents** | Secondary | First-degree dependent count. Weighted lower than transitive reach because it under-ranks load-bearing packages with few direct dependents but large indirect reach. |
+| Signal | What it captures |
+|---|---|
+| **Transitive dependents** | All packages that depend on this project directly or indirectly. The core blast-radius measure. |
+| **Direct dependents** | First-degree dependent count. Included alongside transitive reach to capture direct adoption. |
+| **Downloads** | Per-registry download counts. A proxy for real-world usage. Where raw counts are unavailable (for example, Maven), an ecosystem-provided popularity score is used instead. |
 
 ### Methodology
 
-Impact is computed in three steps:
+Impact is computed in two steps:
 
-1. **Log-transform raw inputs:** downloads, direct dependents, and transitive dependents are log-transformed to compress the power-law distributions typical of open source package ecosystems.
-2. **Normalize within each ecosystem**, so packages are comparable across ecosystems despite different raw magnitudes (npm and Maven packages live in very different distribution ranges).
-3. **Weighted blend** of the four signals, biased toward blast-radius signals (transitive dependents and graph centrality), then scaled to 0–100.
+1. **Score each signal relative to the ecosystem:** for each signal, a package's contribution is measured as its cumulative share of the total ecosystem signal. Packages at the top of each distribution score near 1; the long tail scores near 0. Signals with no data for a given ecosystem are excluded.
+2. **Average across available signals**, then scaled to 0–100. Packages are not penalized when a specific signal is unavailable for their ecosystem.
 
 ## Multi-Repo Projects
 

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -35,8 +35,8 @@ Look at the Lifecycle state before the numeric scores. It is derived from mainta
 | **Active** | Regular commits in the last 6 months, responsive maintainers, healthy release cadence |
 | **Stable** | Low activity by design. The project is mature and does not need frequent changes. Maintainers are still reachable. |
 | **Declining** | Activity dropped more than 50% in the last 6 months while issue volume increased; a sign the project is under pressure |
-| **Inert** | No commits in 18+ months, but no open issues or PRs either. Nothing to judge responsiveness by. A quiet project, not a neglected one. |
-| **Abandoned** | No maintainer activity in 12+ months, with open issues or PRs that have gone unanswered for an extended period |
+| **Inert** | No commits in 18+ months, but no open issues or pull requests either. Nothing to judge responsiveness by. A quiet project, not a neglected one. |
+| **Abandoned** | No maintainer activity in 12+ months, with open issues or pull requests that have gone unanswered for an extended period |
 | **Archived** | Explicitly archived in the repository host or marked deprecated in the package registry |
 
 ::: tip
@@ -48,8 +48,8 @@ Look at the Lifecycle state before the numeric scores. It is derived from mainta
 The lifecycle state is assigned by evaluating the following conditions in order. The first match wins:
 
 1. **Archived:** the repository's archived flag is set, or the package registry marks the package as deprecated or yanked.
-2. **Abandoned:** open issues or PRs have received no non-author response for an extended period (90 to 180 days), and maintainers have had no activity in the trailing 12 months.
-3. **Inert:** no commits in the last 18 months, and no open issues or PRs in that window (nothing to judge responsiveness by).
+2. **Abandoned:** open issues or pull requests have received no non-author response for an extended period (90 to 180 days), and maintainers have had no activity in the last 12 months.
+3. **Inert:** no commits in the last 18 months, and no open issues or pull requests in that window (nothing to judge responsiveness by).
 4. **Declining:** commits in the last 6 months are less than 50% of the prior 6 months, and the volume of newly opened issues is higher than the prior period.
 5. **Stable:** the latest release is within the last 12 months, fewer than 50 issues are open, no critical vulnerabilities are open, and commits have dropped more than 50% vs. the prior period.
 6. **Active:** all other projects.
@@ -87,7 +87,7 @@ Measures the median time for a non-author to respond to newly opened issues and 
 
 #### 1.2 Bus Factor (max 18 pts)
 
-Counts the number of people who are actively maintaining the project, taking the higher of two sources: the official maintainer roster and the set of people observably performing review and merge actions in the last 12 months. This fallback corrects for curated rosters that undercount large, community-maintained projects.
+Counts the number of people who are actively maintaining the project, taking the higher of two sources: the official maintainer roster and the set of people observably performing review and merge actions in the last 12 months. This corrects for curated rosters that undercount large, community-maintained projects.
 
 - **18 pts:** 5 or more active maintainers
 - **15 pts:** 3 or 4 active maintainers
@@ -105,6 +105,8 @@ Measures how many distinct organizations the active maintainers are affiliated w
 - **0 pts:** Affiliation unknown
 
 ### 2. Security and Supply Chain (0–35 pts)
+
+A project's security posture depends on both what it ships and how it is built. This category measures known vulnerabilities, documented security practices, supply chain integrity, and the health of the project's own dependencies.
 
 #### 2.1 Open Vulnerabilities (max 10 pts)
 
@@ -175,7 +177,7 @@ Counts commits authored in the last 6 months on the cleaned activity stream (bot
 
 #### 3.3 Issue Resolution (max 7 pts)
 
-Measures the median time from issue opened to issue closed over the trailing 12 months. Only non-bot activity is included. Lower median time means a higher score.
+Measures the median time from issue opened to issue closed over the last 12 months. Only non-bot activity is included. Lower median time means a higher score.
 
 - **7 pts:** Median resolution time under 7 days
 - **5 pts:** Median resolution time under 14 days
@@ -187,12 +189,14 @@ Gerrit repositories do not ingest issue data. This sub-signal is blocked for Ger
 
 #### 3.4 PR Merge Health (max 5 pts)
 
-Evaluates the ratio of merged pull requests to closed-unmerged pull requests over the trailing 12 months, combined with median time to merge. A high abandonment rate or slow merge cadence signals a backlog problem.
+Evaluates the ratio of merged pull requests to closed-unmerged pull requests over the last 12 months, combined with median time to merge. A high abandonment rate or slow merge cadence signals a backlog problem.
 
 - **5 pts:** High merge rate (80% or more of closed PRs merged) and median merge time under 7 days
 - **3 pts:** Good merge rate (60% or more) or fast merge time under 14 days
 - **1 pt:** Moderate merge rate (40% or more) or merge time under 30 days
 - **0 pts:** Low merge rate or median merge time over 30 days
+
+Gerrit repositories do not ingest pull request data. This sub-signal is blocked for Gerrit-only projects and its weight redistributes within Development Activity.
 
 ### Handling Missing Data
 

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -6,7 +6,7 @@ LFX Insights surfaces up to **three independent assessments** for open source pr
 - **Health Score:** how well-maintained is it?
 - **Impact Score:** how much does it matter if something goes wrong?
 
-Separating health from impact means a popular but poorly maintained project can't score well, and a mature "done" library won't score poorly just for having few recent commits.
+Separating health from impact means a popular but poorly maintained project can't score well on the Health Score, while its high reach is still captured in the Impact Score.
 
 ::: warning ⚠️ Please note
 No score captures all the nuance of an open source project. Different projects serve different goals: some are mature and stable by design, others are experimental or niche. These assessments are meant to highlight signals and risks, not to make final judgments. Always consider context alongside the numbers.
@@ -119,11 +119,7 @@ Counts unresolved security advisories scoped to the repository, sourced from OSV
 - **10 pts:** No open vulnerabilities
 - Points deducted per open advisory: 6 per Critical, 3 per High, 1 per Moderate (minimum 0)
 
-If no vulnerability scan has been completed for the repository, this sub-signal is `blocked` and its weight redistributes to other available Security sub-signals.
-
-::: info
-The UI currently shows "No open vulnerabilities" when scan data is absent rather than marking the sub-signal as unavailable. This is a known display issue (IN-1241) and does not affect the underlying score calculation.
-:::
+If no vulnerability scan data is available for the repository, missing advisory counts are treated as zero. The project is scored as having no open vulnerabilities and receives the full 10 points. Absent scan data cannot currently be distinguished from a clean scan in the score calculation.
 
 #### 2.2 Security Practices (max 8 pts)
 
@@ -311,7 +307,7 @@ The original Insights Health Score was a single 0–100 value, computed as an eq
 | **Health categories** | 4 equal categories at 25 pts each | 3 weighted categories: Maintainer (40), Security and Supply Chain (35), Development Activity (25) |
 | **Popularity** | Baked into Health Score as 25% of the total | Separate Impact Score; does not affect Health |
 | **Lifecycle** | Not modeled | Six states: Active, Stable, Declining, Inert, Abandoned, Archived |
-| **Stable "done" libraries** | Penalized: low commits meant a low score | Not penalized: the Stable state recognizes intentionally low-activity projects |
+| **Stable "done" libraries** | Penalized: low commits meant a low score | Lifecycle context added: a `Stable` classification signals low activity is intentional, but the Health Score formula still scores low-activity signals as low |
 | **Maintainer signal** | Contributor count only | Responsiveness, bus factor (curated plus observed), organizational diversity |
 | **Security** | OpenSSF Baseline pass/fail ratio | Open CVEs with severity weighting, security practices, OpenSSF Scorecard, dependency health, supply chain integrity |
 | **Missing data** | Returned unavailable if any sub-score was absent | Two-layer redistribution: blocked sub-signals rescale within their category; scores are only marked unavailable when signal floor is too low to be defensible |

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -85,6 +85,8 @@ Measures the median time for a non-author to respond to newly opened issues and 
 - **5 pts:** Median response time under 90 days
 - **0 pts:** Median response time 90 days or more, or no response data available
 
+Projects with no open issues or pull requests in the measurement window have no response data. This sub-signal is scored as 0 pts (not redistributed), because the signal is available — there is simply no activity to measure.
+
 #### 1.2 Bus Factor (max 18 pts)
 
 Counts the number of people who are actively maintaining the project, taking the higher of two sources: the official maintainer roster and the set of people observably performing review and merge actions in the last 12 months. This corrects for curated rosters that undercount large, community-maintained projects.
@@ -122,12 +124,12 @@ If no vulnerability scan has been completed for the repository, this sub-signal 
 Checks whether the repository has adopted documented security practices:
 
 - **2 pts:** `SECURITY.md` file present
-- **2 pts:** Vulnerability disclosure process documented
 - **2 pts:** Branch protection enabled on the default branch
-- **2 pts:** Releases are cryptographically signed
+- **2 pts:** Required code reviews on pull requests
+- **2 pts:** Required status checks before merging
 
 ::: info
-`SECURITY.md` presence and branch protection are currently evaluated for GitHub repositories. Vulnerability disclosure process detection and signed release verification are in development. GitLab and Gerrit repositories have this sub-signal blocked; its weight redistributes to other available Security sub-signals.
+Security practices are currently evaluated for GitHub repositories only. GitLab and Gerrit repositories have this sub-signal blocked; its weight redistributes to other available Security sub-signals.
 :::
 
 #### 2.3 OpenSSF Scorecard (max 7 pts)

--- a/frontend/docs/metrics/health-score/index.md
+++ b/frontend/docs/metrics/health-score/index.md
@@ -1,175 +1,305 @@
 # Health Score Explained
 
-The Health Score in LFX Insights is **a single, unified metric (0–100) that reflects the overall health of an open source project**. It's designed to give developers a quick, high-confidence signal about whether a project is actively maintained, widely used, secure, and well-governed.
+LFX Insights now surfaces **three independent assessments** for every project: a **Lifecycle state**, a **Health Score**, and an **Impact Score**. Together, these replace the previous single composite score and answer three distinct questions:
+
+- **Lifecycle:** what state is this project in?
+- **Health Score:** how well-maintained is it?
+- **Impact Score:** how much does it matter if something goes wrong?
+
+Separating health from impact means a popular but poorly maintained project can't score well, and a mature "done" library won't score poorly just for having few recent commits.
 
 ::: warning ⚠️ Please note
-While the Health Score provides a useful, data-driven snapshot of a project's overall state, no single score can capture all the nuance of an open source project. Different projects serve different goals—some are mature and stable, others are experimental or niche by design. This scoring model is meant to highlight potential signals and risks, not to make final judgments. Always consider context and use your own judgment alongside the score.
+No score captures all the nuance of an open source project. Different projects serve different goals: some are mature and stable by design, others are experimental or niche. These assessments are meant to highlight signals and risks, not to make final judgments. Always consider context alongside the numbers.
 :::
 
-## Insights Health Score Formula
+## The Three Assessments
 
-The Insights Health Score is calculated as the sum of four equally weighted categories:
+| Assessment | Question answered | Output |
+|---|---|---|
+| **Lifecycle** | What state is this project in? | One of six states: Active, Stable, Declining, Inert, Abandoned, Archived |
+| **Health Score** | How well-maintained is it? | 0–100, independent of popularity |
+| **Impact Score** | How much does it matter if this breaks? | 0–100, based on dependency graph reach |
 
-**Health Score (0-100 pts) = Contributors (0–25 pts) + Popularity (0–25 pts) + Development (0–25 pts) + Security & Best Practices (0–25 pts)**
+All three are shown together in the UI. When prioritizing stewardship, low Health combined with high Impact is the most urgent combination.
 
-The aggregated score is evaluated as follows:
+This methodology was developed with community input. You can read the full discussion and the feedback that shaped these decisions in [GitHub Discussion #1939](https://github.com/linuxfoundation/insights/discussions/1939).
 
-- **> 80 pts**: Excellent
-- **60 - 79 pts**: Healthy
-- **40 - 59 pts**: Stable
-- **20 - 39 pts**: Unsteady
-- **< 20 pts**: Critical
+## Lifecycle State
 
-## Scoring Criteria
+Look at the Lifecycle state before the numeric scores. It is derived from maintainer signals using a decision tree, not from the composite score itself.
 
-Each of the following metrics is scored on a 0–5 point scale, and grouped into four categories: Contributors, Popularity, Development, and Security & Best Practices. Each category can reach up to 25 points.
+### States
 
-### 1. Contributors (0–25 pts)
+| State | What it means |
+|---|---|
+| **Active** | Regular commits in the last 6 months, responsive maintainers, healthy release cadence |
+| **Stable** | Low activity by design. The project is mature and does not need frequent changes. Maintainers are still reachable. |
+| **Declining** | Activity dropped more than 50% in the last 6 months while issue volume increased; a sign the project is under pressure |
+| **Inert** | No commits in 18+ months, but no open issues or PRs either. Nothing to judge responsiveness by. A quiet project, not a neglected one. |
+| **Abandoned** | No maintainer activity in 12+ months, with open issues or PRs that have gone unanswered for an extended period |
+| **Archived** | Explicitly archived in the repository host or marked deprecated in the package registry |
 
-#### 1.1 Contributor Dependency
-
-- **0 pts:** 1 contributor accounts for 51%+ of contributions
-- **1 pt:** 2 contributors account for 51%+ of contributions
-- **2 pts:** 3–4 contributors account for 51%+ of contributions
-- **3 pts:** 5–6 contributors account for 51%+ of contributions
-- **4 pts:** 7–9 contributors account for 51%+ of contributions
-- **5 pts:** 10 or more contributors account for 51%+ of contributions
-
-#### 1.2 Organization Dependency
-
-- **0 pts:** 1 organization accounts for 51%+ of contributions
-- **1 pt:** 2 organizations account for 51%+ of contributions
-- **2 pts:** 3 organizations account for 51%+ of contributions
-- **3 pts:** 4–5 organizations account for 51%+ of contributions
-- **4 pts:** 6–7 organizations account for 51%+ of contributions
-- **5 pts:** 8 or more organizations account for 51%+ of contributions
-
-#### 1.3 Quarterly Active Contributors
-
-- **0 pts:** 0–1 active contributors in the last quarter
-- **1 pt:** 2–3 active contributors in the last quarter
-- **2 pts:** 4–6 active contributors in the last quarter
-- **3 pts:** 7–10 active contributors in the last quarter
-- **4 pts:** 11–20 active contributors in the last quarter
-- **5 pts:** 21 or more active contributors in the last quarter
-
-#### 1.4 Quarterly Contributor Retention Rate
-
-- **0 pts:** Less than 2% of contributors are contributing quarter over quarter
-- **1 pt:** 3–5% of contributors are contributing quarter over quarter
-- **2 pts:** 6–9% of contributors are contributing quarter over quarter
-- **3 pts:** 10–14% of contributors are contributing quarter over quarter
-- **4 pts:** 15–19% of contributors are contributing quarter over quarter
-- **5 pts:** 20% or more of contributors are contributing quarter over quarter
-
-### 2. Popularity (0–25 pts)
-
-::: warning ⚠️ If a project does not have data for all popularity metrics, Insights will calculate the popularity score using only the available metrics.
+::: tip
+"Silence alone is not abandonment — ignoring people is." A finished utility with no open issues, no CVEs, and no need for further development gets `Inert`, not `Abandoned`. The `Abandoned` state requires evidence of neglect: open items piling up while maintainers are absent. This distinction came directly from community feedback on the methodology.
 :::
 
-#### 2.1 GitHub Stars
+### Classification Rules
 
-- **0 pts:** 0–9 GitHub stars
-- **1 pt:** 10–49 GitHub stars
-- **2 pts:** 50–199 GitHub stars
-- **3 pts:** 200–499 GitHub stars
-- **4 pts:** 500–999 GitHub stars
-- **5 pts:** 1,000+ GitHub stars
+The lifecycle state is assigned by evaluating the following conditions in order. The first match wins:
 
-#### 2.2 GitHub Forks
+1. **Archived:** the repository's archived flag is set, or the package registry marks the package as deprecated or yanked.
+2. **Abandoned:** open issues or PRs have received no non-author response for an extended period (90 to 180 days), and maintainers have had no activity in the trailing 12 months.
+3. **Inert:** no commits in the last 18 months, and no open issues or PRs in that window (nothing to judge responsiveness by).
+4. **Declining:** commits in the last 6 months are less than 50% of the prior 6 months, and the volume of newly opened issues is higher than the prior period.
+5. **Stable:** the latest release is within the last 12 months, fewer than 50 issues are open, no critical vulnerabilities are open, and commits have dropped more than 50% vs. the prior period.
+6. **Active:** all other projects.
 
-- **0 pts:** 0–4 forks
-- **1 pt:** 5–9 forks
-- **2 pts:** 10–19 forks
-- **3 pts:** 20–39 forks
-- **4 pts:** 40–79 forks
-- **5 pts:** 80+ forks
+For multi-repo projects, the project takes the best state across all its repositories: Active beats Stable, Stable beats Declining, and so on down to Archived.
 
-#### 2.3 Google Search Queries per Month
+## Health Score (0–100)
 
-- **0 pts:** <10 queries
-- **1 pt:** 10–49 queries
-- **2 pts:** 50–199 queries
-- **3 pts:** 200–499 queries
-- **4 pts:** 500–999 queries
-- **5 pts:** 1,000+ queries
+The Health Score measures how well-maintained a project is, independent of how popular or critical it is. A widely-used project with poor maintainer responsiveness will score low here, even if its Impact Score is high.
 
-#### 2.4 Social Mentions per Month (Coming Soon)
+**Health Score (0–100) = Maintainer Health (0–40 pts) + Security and Supply Chain (0–35 pts) + Development Activity (0–25 pts)**
 
-- **0 pts:** 0–4 social mentions
-- **1 pt:** 5–9 social mentions
-- **2 pts:** 10–24 social mentions
-- **3 pts:** 25–49 social mentions
-- **4 pts:** 50–99 social mentions
-- **5 pts:** 100+ social mentions
+### Rating Bands
 
-#### 2.5 GitHub Mentions (Coming Soon)
+| Score | Label | What it signals |
+|---|---|---|
+| 85–100 | **Excellent** | Well-maintained, secure, active or intentionally stable |
+| 70–84 | **Healthy** | In good shape with minor gaps |
+| 50–69 | **Fair** | Some concerning signals; may need attention |
+| 30–49 | **Concerning** | Multiple risk signals; stewardship candidate |
+| 0–29 | **Critical** | Serious gaps; likely needs intervention |
 
-- **0 pts:** 0–9 GitHub mentions
-- **1 pt:** 10–29 GitHub mentions
-- **2 pts:** 30–99 GitHub mentions
-- **3 pts:** 100–249 GitHub mentions
-- **4 pts:** 250–499 GitHub mentions
-- **5 pts:** 500+ GitHub mentions
+### 1. Maintainer Health (0–40 pts)
 
-### 3. Development (0-25 pts)
+A project with responsive maintainers will fix CVEs, clear backlogs, and ship fixes. Without them, the other signals are just a timer.
 
-#### 3.1 New Pull Requests per Month
+#### 1.1 Maintainer Responsiveness (max 15 pts)
 
-- **0 pts:** 0–1 new pull requests
-- **1 pt:** 2–3 new pull requests
-- **2 pts:** 4–7 new pull requests
-- **3 pts:** 8–15 new pull requests
-- **4 pts:** 16–30 new pull requests
-- **5 pts:** 31+ new pull requests
+Measures the median time for a non-author to respond to newly opened issues and pull requests. Bot and automation activity is excluded so only genuine human responses count.
 
-#### 3.2 Issue Resolution Time
+- **15 pts:** Median response time under 7 days
+- **10 pts:** Median response time under 30 days
+- **5 pts:** Median response time under 90 days
+- **0 pts:** Median response time over 90 days, or no response data available
 
-- **0 pts:** Average resolution time > 60 days
-- **1 pt:** 51–60 days
-- **2 pts:** 36–50 days
-- **3 pts:** 22–35 days
-- **4 pts:** 8–21 days
-- **5 pts:** < 8 days
+#### 1.2 Bus Factor (max 18 pts)
 
-#### 3.3 Merge Lead Time
+Counts the number of people who are actively maintaining the project, taking the higher of two sources: the official maintainer roster and the set of people observably performing review and merge actions in the last 12 months. This fallback corrects for curated rosters that undercount large, community-maintained projects.
 
-- **0 pts:** > 30 days
-- **1 pt:** 21–30 days
-- **2 pts:** 15–20 days
-- **3 pts:** 7–14 days
-- **4 pts:** 3–6 days
-- **5 pts:** < 3 days
+- **18 pts:** 5 or more active maintainers
+- **15 pts:** 3 or 4 active maintainers
+- **6 pts:** 2 active maintainers
+- **3 pts:** 1 active maintainer
+- **0 pts:** No active maintainers
 
-#### 3.4 Active Days (Last 30 Days)
+#### 1.3 Organizational Diversity (max 7 pts)
 
-- **0 pts:** Active on 0–5 days
-- **1 pt:** Active on 6–10 days
-- **2 pts:** Active on 11–15 days
-- **3 pts:** Active on 16–20 days
-- **4 pts:** Active on 21–26 days
-- **5 pts:** Active on 27–30 days
+Measures how many distinct organizations the active maintainers are affiliated with, using contributor affiliation data. Projects maintained by contributors from multiple independent organizations are more resilient to any single organization withdrawing support.
 
-#### 3.5 Contributions Outside Work Hours
+- **7 pts:** Maintainers from 3 or more organizations
+- **4 pts:** Maintainers from 2 organizations
+- **2 pts:** All maintainers from 1 organization
+- **0 pts:** Affiliation unknown
 
-- **0 pts:** 75%+ outside work hours
-- **1 pt:** 50–74% outside work hours
-- **2 pts:** 40–49% outside work hours
-- **3 pts:** 30–39% outside work hours
-- **4 pts:** 20–29% outside work hours
-- **5 pts:** <20% outside work hours
+### 2. Security and Supply Chain (0–35 pts)
 
-### 4. Security & Best Practices (0-25 pts)
+#### 2.1 Open Vulnerabilities (max 10 pts)
 
-We run a set of control assessments for all available repositories of a project, powered by the [Open Source Project Security Baseline](https://baseline.openssf.org) by OpenSSF.
+Counts unresolved security advisories scoped to the repository, sourced from OSV and GHSA. Points are deducted by severity:
 
-The Security & Best Practices dimension is evaluated with an equally weighted score from all applicable control assessments. We only consider control assessments that worked without privileged access to the project's codebase and ignore those that are not applicable (e.g., controls that cannot be evaluated due to repository limitations or project structure).
+- **10 pts:** No open vulnerabilities
+- Points deducted per open advisory: 6 per Critical, 3 per High, 1 per Moderate (minimum 0)
 
-Where supported (currently, only GitHub and Gitlab), we also ignore repositories that are archived, meaning they won't affect the final score.
+If no vulnerability scan has been completed for the repository, this sub-signal is unavailable and its weight redistributes to other Security sub-signals.
 
-Additionally, some repositories may be marked as excluded, even if they are not archived. One example of this are `.github` repositories, which are automatically marked as excluded, but not archived. Repositories marked as excluded are also ignored in the health score calculations.
+#### 2.2 Security Practices (max 8 pts)
 
-The formula used is:
-**Security & Best Practices Score = Passed Control Assessments / (Passed + Failed Control Assessments)**
+Checks whether the repository has adopted documented security practices:
 
-This percentage is then converted to a 0-25 point scale for the final Health Score.
+- **2 pts:** `SECURITY.md` file present
+- **2 pts:** Vulnerability disclosure process documented
+- **2 pts:** Branch protection enabled on the default branch
+- **2 pts:** Releases are cryptographically signed
+
+::: info
+`SECURITY.md` presence and branch protection are currently evaluated for GitHub repositories. Vulnerability disclosure process detection and signed release verification are in development. GitLab and Gerrit repositories have this sub-signal blocked; its weight redistributes to other available Security sub-signals.
+:::
+
+#### 2.3 OpenSSF Scorecard (max 7 pts)
+
+Normalized from the OpenSSF Scorecard's 0–10 scale. Currently available for GitHub-hosted repositories only. GitLab and Gerrit repositories have this sub-signal blocked, and its weight redistributes within the Security category.
+
+#### 2.4 Dependency Health (max 5 pts)
+
+Evaluates the security posture of the project's direct dependencies:
+
+- **5 pts:** No direct dependencies with known high or critical vulnerabilities
+- **3 pts:** 1 or 2 vulnerable dependencies
+- **1 pt:** 3 to 5 vulnerable dependencies
+- **0 pts:** More than 5 vulnerable dependencies
+
+Available only for repositories that publish tracked packages. Repositories without published packages have this sub-signal blocked.
+
+#### 2.5 Supply Chain Integrity (max 5 pts)
+
+Assesses build provenance attestation, artifact-to-repository consistency, and publisher account security. This sub-signal is in development and is currently blocked for all projects. Its weight redistributes to available Security sub-signals; projects are not penalized.
+
+### 3. Development Activity (0–25 pts)
+
+A finished library with no open issues, no CVEs, and a recent release can score well here without recent commits. Intentionally low-activity projects are not penalized.
+
+#### 3.1 Release Cadence (max 8 pts)
+
+Measures how recently and regularly the project has published releases. Counted over distinct release days to prevent burst-publishing in monorepos from inflating the score.
+
+- **8 pts:** Latest release within 90 days and consistent cadence (releases at least every 90 days)
+- **6 pts:** Latest release within 180 days
+- **4 pts:** Latest release within 1 year
+- **2 pts:** Latest release within 2 years
+- **0 pts:** No release in over 2 years, or no releases tracked
+
+Available only for repositories that publish tracked packages. Repositories without published packages have this sub-signal blocked.
+
+#### 3.2 Commit Activity (max 5 pts)
+
+Counts commits authored in the last 6 months on the cleaned activity stream (bots and automation excluded).
+
+- **5 pts:** 50 or more commits
+- **4 pts:** 20 to 49 commits
+- **3 pts:** 5 to 19 commits
+- **1 pt:** 1 to 4 commits
+- **0 pts:** No commits
+
+#### 3.3 Issue Resolution (max 7 pts)
+
+Measures the median time from issue opened to issue closed over the trailing 12 months. Only non-bot activity is included. Lower median time means a higher score.
+
+- **7 pts:** Median resolution time under 7 days
+- **5 pts:** Median resolution time under 14 days
+- **3 pts:** Median resolution time under 30 days
+- **1 pt:** Median resolution time under 90 days
+- **0 pts:** Median resolution time over 90 days, or no closed issues in the period
+
+Gerrit repositories do not ingest issue data. This sub-signal is blocked for Gerrit-only projects and its weight redistributes within Development Activity.
+
+#### 3.4 PR Merge Health (max 5 pts)
+
+Evaluates the ratio of merged pull requests to closed-unmerged pull requests over the trailing 12 months, combined with median time to merge. A high abandonment rate or slow merge cadence signals a backlog problem.
+
+- **5 pts:** High merge rate (80% or more of closed PRs merged) and median merge time under 7 days
+- **3 pts:** Good merge rate (60% or more) or fast merge time under 14 days
+- **1 pt:** Moderate merge rate (40% or more) or merge time under 30 days
+- **0 pts:** Low merge rate or median merge time over 30 days
+
+### Handling Missing Data
+
+Not every signal is available for every project. Insights uses two layers of redistribution so projects aren't penalized for gaps in data coverage.
+
+**Layer 1, sub-signal blocked:** if a specific sub-signal cannot be computed (for example, OpenSSF Scorecard is unavailable for a GitLab repository), the missing points are redistributed proportionally to the other available sub-signals in the same category. The category's maximum is preserved.
+
+**Layer 2, category unavailable:** if fewer than 40% of a category's maximum points are covered by available sub-signals, the entire category is marked unavailable and dropped from the composite. The remaining available categories rescale to fill 100 points.
+
+If all three categories fall below the 40% coverage threshold, the Health Score itself is emitted as `unavailable`, never as a zero or blank. This way you can always distinguish "we could not measure this" from "this project scored poorly."
+
+## Impact Score (0–100)
+
+The Impact Score answers: how bad is it if this breaks? It is independent of the Health Score. A healthy project can have low impact; an unhealthy project can have high impact.
+
+The score is package-mediated. A project's Impact Score is the highest impact score across all packages it publishes. This reflects blast radius: a project's potential for damage if it fails equals its most widely depended-upon package.
+
+Projects that do not publish any tracked packages do not receive an Impact Score. This includes documentation sites, community landing pages, and projects that ship binaries rather than registry packages.
+
+### Impact Bands
+
+| Score | Label | What it signals |
+|---|---|---|
+| 85–100 | **Foundational** | Extremely broad transitive reach; failure would affect a significant portion of the ecosystem |
+| 60–84 | **Major** | High dependency graph presence; widely used directly or indirectly |
+| 30–59 | **Moderate** | Significant reach within a narrower part of the ecosystem |
+| 0–29 | **Minor** | Limited dependency footprint |
+
+### Signals
+
+| Signal | Role | What it captures |
+|---|---|---|
+| **Transitive dependents** | Primary | All packages that depend on this project directly or indirectly. The core blast-radius measure. |
+| **Graph centrality** | Primary | PageRank-style score over the dependency graph, weighting a package by the importance of what depends on it. A package depended on by major runtimes or frameworks scores higher than one with the same count of less-important dependents. |
+| **Downloads** | Secondary | Per-registry download counts. A proxy for real-world usage, complementary to graph signals. |
+| **Direct dependents** | Secondary | First-degree dependent count. Weighted lower than transitive reach because it under-ranks load-bearing packages with few direct dependents but large indirect reach. |
+
+### Methodology
+
+Impact is computed in three steps:
+
+1. **Log-transform raw inputs:** downloads, direct dependents, and transitive dependents are log-transformed to compress the power-law distributions typical of open source package ecosystems.
+2. **Normalize within each ecosystem** using percentile rank, so packages are comparable across ecosystems despite different raw magnitudes (npm and Maven packages live in very different distribution ranges).
+3. **Weighted blend** of the four signals, biased toward blast-radius signals (transitive dependents and graph centrality), then scaled to 0–100.
+
+## Multi-Repo Projects
+
+An Insights project can span multiple repositories. Sub-signals are computed per repository, then rolled up to the project level:
+
+- **Health Score and sub-scores:** straight mean across all active, non-excluded repositories.
+- **Lifecycle state:** best-state-wins. One active repository makes the project active, regardless of the state of other repositories.
+- **Impact Score:** the highest impact score across all packages published by any repository in the project.
+
+Repositories marked as excluded (for example, experimental sandbox repos) are not included in scoring. This prevents an inactive experimental repository from dragging down a project's Health Score.
+
+## Platform and Data Coverage
+
+Insights collects data from GitHub, GitLab, and Gerrit. Not all signals are available on every platform, and not all projects publish tracked packages.
+
+**GitLab projects:**
+
+Security practices and OpenSSF Scorecard are currently GitHub-only. GitLab projects will typically have these sub-signals blocked and absorbed by Layer-1 redistribution or, if Security coverage falls below 40%, the entire Security category may be marked unavailable. Health Score still computes from Maintainer Health and Development Activity. Broader security signal coverage for GitLab is in development.
+
+**Gerrit projects:**
+
+Gerrit does not ingest issue or PR data in the same format as GitHub and GitLab. Issue Resolution, PR Merge Health, and Security Practices are typically blocked. Commit Activity and Bus Factor remain available. Development Activity may compute from a reduced set of sub-signals.
+
+**Projects without published packages:**
+
+Release Cadence, Dependency Health, and Supply Chain Integrity are all package-mediated signals. Projects that do not publish to a tracked registry (npm, PyPI, Maven, and others) will have these sub-signals blocked. Their weight redistributes to the signals that are available. Impact Score will not be shown for these projects.
+
+**Projects with partial data across repos:**
+
+For multi-repo projects, sub-signals in a `partial` coverage state are computed over the subset of repositories where data is available. The score reflects what can be observed, and the coverage detail is available in the UI for transparency.
+
+::: info
+Health Score comparisons across projects with different platform or data coverage are not directly comparable. A project with full GitHub and package data is scored on more signals than one on Gerrit with no published packages. Coverage details are always shown alongside the score.
+:::
+
+## Bot and Non-Human Activity
+
+All time-based and activity-count signals (responsiveness, commit counts, issue metrics, PR metrics, bus factor recency) are computed from the cleaned activity stream, which excludes bots, team accounts, and organization accounts identified through contributor enrichment. This prevents automated issue floods or bot-authored PRs from distorting responsiveness or resolution metrics.
+
+## How This Differs from the Previous Health Score
+
+::: info
+The original Insights Health Score was a single 0–100 value, computed as an equal-weight mean of four sub-scores: Contributors (25 pts), Popularity (25 pts), Development (25 pts), and Security and Best Practices (25 pts). The current methodology replaces that with three independent assessments and re-weighted health categories.
+:::
+
+| Aspect | Original Health Score | Current methodology |
+|---|---|---|
+| **Output** | Single score (0–100) | Three assessments: Lifecycle (state), Health Score (0–100), Impact Score (0–100) |
+| **Health categories** | 4 equal categories at 25 pts each | 3 weighted categories: Maintainer (40), Security and Supply Chain (35), Development Activity (25) |
+| **Popularity** | Baked into Health Score as 25% of the total | Separate Impact Score; does not affect Health |
+| **Lifecycle** | Not modeled | Six states: Active, Stable, Declining, Inert, Abandoned, Archived |
+| **Stable "done" libraries** | Penalized: low commits meant a low score | Not penalized: the Stable state and development floor recognize intentionally low-activity projects |
+| **Maintainer signal** | Contributor count only | Responsiveness, bus factor (curated plus observed), organizational diversity |
+| **Security** | OpenSSF Baseline pass/fail ratio | Open CVEs with severity weighting, security practices, OpenSSF Scorecard, dependency health, supply chain integrity |
+| **Missing data** | Returned unavailable if any sub-score was absent | Two-layer redistribution: blocked sub-signals rescale within their category; scores are only marked unavailable when signal floor is too low to be defensible |
+| **Rating bands** | Excellent / Healthy / Stable / Unsteady / Critical | Excellent / Healthy / Fair / Concerning / Critical |
+
+### Why the original approach had gaps
+
+The previous model had several structural problems:
+
+- **Equal weighting ignored blast radius.** A project with a single maintainer and a critical open CVE could score the same as a project with ten maintainers and a clean security record, if their activity levels were similar.
+- **Popularity baked into health.** A massively downloaded project with a compromised or absent maintainer appeared healthy because download counts inflated the score.
+- **Stable libraries were penalized.** A mature utility with no bugs, no CVEs, and no need for active development scored near Critical simply because it had few recent commits.
+- **No lifecycle signal.** The model could not distinguish "abandoned with a high score" from "active with a high score," a critical difference for stewardship and dependency risk.
+- **Any missing sub-score returned unavailable.** Projects on GitLab or Gerrit, or projects without package data, often could not be scored at all.

--- a/frontend/docs/more/faq/index.md
+++ b/frontend/docs/more/faq/index.md
@@ -17,10 +17,10 @@ You can suggest changes or flag issues via the Insights dashboard ("report issue
 ## Understanding Metrics
 
 **What do the different scores mean?**  
-We documentented detailed explanations for each metric. You can find them grouped by the four different dimensions: [Contributors](../../metrics/contributors/index.md), [Development](../../metrics/development/index.md), [Health Score](../../metrics/health-score/index.md), [Popularity](../../metrics/popularity/index.md), and [Security & Best Practices](../../metrics/security/index.md).
+We have documented detailed explanations for each metric. You can explore project data across several views: [Contributors](../../metrics/contributors/index.md), [Development](../../metrics/development/index.md), [Popularity](../../metrics/popularity/index.md), and [Security & Best Practices](../../metrics/security/index.md). The [Health Score](../../metrics/health-score/index.md) page explains all three assessments in detail.
 
-**How is the overall project healthscore calculated?**  
-The total score is a weighted sum of the four dimensions. Each dimension is scored on a fixed scale and based on transparent benchmarks. You can read more details in the [Health Score](../../metrics/health-score/index.md) section.
+**How is the overall project health score calculated?**  
+The Health Score is one of three independent assessments. It measures maintainer health, security and supply chain, and development activity — each weighted and combined into a 0–100 score. A separate Lifecycle state and Impact Score are also shown. You can read more details in the [Health Score](../../metrics/health-score/index.md) section.
 
 **What does “criticality” mean in this context?**  
 “Criticality” reflects how essential a project is to the broader ecosystem. It includes factors like usage, dependency footprint, contributor activity, and update frequency. We determine criticality based on the [OpenSSF Criticality Score](https://openssf.org/projects/criticality-score/).

--- a/frontend/docs/more/faq/index.md
+++ b/frontend/docs/more/faq/index.md
@@ -20,7 +20,7 @@ You can suggest changes or flag issues via the Insights dashboard ("report issue
 We have documented detailed explanations for each metric. You can explore project data across several views: [Contributors](../../metrics/contributors/index.md), [Development](../../metrics/development/index.md), [Popularity](../../metrics/popularity/index.md), and [Security & Best Practices](../../metrics/security/index.md). The [Health Score](../../metrics/health-score/index.md) page explains all three assessments in detail.
 
 **How is the overall project health score calculated?**  
-The Health Score is one of three independent assessments. It measures maintainer health, security and supply chain, and development activity — each weighted and combined into a 0–100 score. A separate Lifecycle state and Impact Score are also shown. You can read more details in the [Health Score](../../metrics/health-score/index.md) section.
+The Health Score is one of three independent assessments. It measures maintainer health, security and supply chain, and development activity — each weighted and combined into a 0–100 score. A Lifecycle state is always shown. An Impact Score (0–100) is shown for projects that publish tracked packages; projects without published packages do not receive one. You can read more details in the [Health Score](../../metrics/health-score/index.md) section.
 
 **What does “criticality” mean in this context?**  
 “Criticality” reflects how essential a project is to the broader ecosystem. It includes factors like usage, dependency footprint, contributor activity, and update frequency. We determine criticality based on the [OpenSSF Criticality Score](https://openssf.org/projects/criticality-score/).

--- a/frontend/docs/more/glossary/index.md
+++ b/frontend/docs/more/glossary/index.md
@@ -40,7 +40,7 @@ Criticality reflects how essential an open source project is to the broader soft
 
 ## Health Score
 
-LFX Insights surfaces three independent assessments for each project: a **Lifecycle state** (one of six categorical states indicating the project's current phase), a **Health Score** (0–100, measuring maintainer health, security and supply chain, and development activity), and an **Impact Score** (0–100, measuring dependency graph reach — only shown for projects with tracked published packages). The Health Score and Impact Score use standardized scoring logic across all projects to enable fair comparisons. See the [Health Score](../../metrics/health-score/index.md) page for full methodology details.
+LFX Insights surfaces three independent assessments for each project: a **Lifecycle state** (one of six categorical states indicating the project's current phase), a **Health Score** (0–100, measuring maintainer health, security and supply chain, and development activity), and an **Impact Score** (0–100, measuring dependency graph reach — only shown for projects with tracked published packages). The Health Score uses standardized scoring logic, but scores are not directly comparable across projects with different platform or data coverage — a project with full GitHub and package data is scored on more signals than one on Gerrit with no published packages. See the [Health Score](../../metrics/health-score/index.md) page for full methodology details.
 
 ## Issues
 

--- a/frontend/docs/more/glossary/index.md
+++ b/frontend/docs/more/glossary/index.md
@@ -40,7 +40,7 @@ Criticality reflects how essential an open source project is to the broader soft
 
 ## Health Score
 
-The Health Score in LFX Insights summarizes the overall condition of an open source project across four key dimensions: contributor activity, development velocity, adoption signals, and security practices. Each dimension is scored individually, then combined into a single score from 0 to 100 to help identify projects that are actively maintained, widely used, and following best practices. The scoring logic is standardized across all projects to enable fair comparisons.
+LFX Insights surfaces three independent assessments for each project: a **Lifecycle state** (one of six categorical states indicating the project's current phase), a **Health Score** (0–100, measuring maintainer health, security and supply chain, and development activity), and an **Impact Score** (0–100, measuring dependency graph reach — only shown for projects with tracked published packages). The Health Score and Impact Score use standardized scoring logic across all projects to enable fair comparisons. See the [Health Score](../../metrics/health-score/index.md) page for full methodology details.
 
 ## Issues
 


### PR DESCRIPTION
## Summary

- Rewrites `docs/metrics/health-score/index.md` for the v2 methodology, which replaces the original four-category equal-weight model with three independent assessments: Lifecycle state, Health Score (Maintainer 40 + Security & Supply Chain 35 + Development Activity 25), and Impact Score (package-mediated, 0–100)
- Adds per-signal rubric tables with point tiers and thresholds for all 12 sub-signals across the three Health Score categories
- Documents two-layer missing-data redistribution so projects on GitLab, Gerrit, or without published packages are not penalized for unavailable signals
- Adds platform coverage section explicitly addressing GitLab, Gerrit, no-package projects, and partial multi-repo scenarios
- Adds migration comparison table (original vs current methodology) with explanation of why the original approach had structural gaps
- Links to community discussion #1939 where the methodology changes were shaped
- Fixes a pre-commit hook race condition in `frontend/.husky/pre-commit` where `git add -u` and `npx lint-staged --no-stash` wrote to the git index while GPG held a lock during `git commit -S`, silently turning docs-only commits into pure deletions of staged files. Fix: guard both `eslint --fix`/`git add -u` and `lint-staged` to only run when JS/TS/Vue files are staged. Also replaces `npx lint-staged` with `pnpm exec lint-staged` per workspace conventions (`.claude/rules/pnpm-workspace-commands.md`).

> **Note on hook fix scope:** Copilot flagged this as an unrelated change. The hook fix was discovered while authoring this PR (docs-only commits reproducibly deleted staged files). A separate fix PR would have been blocked by the same bug. The fix is contained to one file with no logic changes beyond the file-type guards and the npx→pnpm exec swap.

## Test plan

- [ ] `cd frontend && pnpm docs:dev` — open `/docs/metrics/health-score/` and verify all three assessment sections render
- [ ] VitePress callouts (`warning`/`info`/`tip`) render as styled panels
- [ ] Sidebar entry still reads "Health Score"
- [ ] All internal links resolve (no 404s in the docs nav)
- [ ] Make a docs-only commit on a branch to verify the pre-commit hook no longer deletes staged files

Closes IN-1236