### PR TITLE
fix: handle inert lifecycle state in ui

### DIFF
--- a/frontend/app/components/modules/collection/components/details/collection-lifecycle-badge.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-lifecycle-badge.vue
@@ -31,13 +31,13 @@ const props = defineProps<{
   lifecycleLabel?: string | null;
 }>();
 
-// active -> green, stable -> blue, declining -> amber, abandoned -> red, archived -> neutral grey.
 const variation = computed<TagStyle>(() => {
   const variations: Record<string, TagStyle> = {
     active: 'positive',
     stable: 'info',
     declining: 'warning',
     abandoned: 'negative',
+    inert: 'warning',
     archived: 'default',
   };
   return variations[props.lifecycleLabel?.toLowerCase() ?? ''] ?? 'default';

--- a/frontend/config/health-breakdown-templates.test.ts
+++ b/frontend/config/health-breakdown-templates.test.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect } from 'vitest';
+import { getLifecycleDescription } from './health-breakdown-templates';
+
+describe('getLifecycleDescription', () => {
+  test('should return the inert description when lifecycle state is "inert"', () => {
+    const result = getLifecycleDescription('inert', null);
+    expect(result).toBe(
+      'No commits or activity recorded in the past 18 months. The project appears inactive and may require maintenance attention.',
+    );
+  });
+
+  test('should return the active description for active state', () => {
+    const result = getLifecycleDescription('active', null);
+    expect(result).toBe(
+      'Consistent commits, responsive maintainers, regular releases, and healthy issue triage.',
+    );
+  });
+
+  test('should return the default description for null or unrecognized state', () => {
+    const result1 = getLifecycleDescription(null, null);
+    const result2 = getLifecycleDescription('unknown-state', null);
+    const defaultDescription =
+      'No repository activity has been indexed for this project. Lifecycle state cannot be determined until a supported source platform is connected.';
+    expect(result1).toBe(defaultDescription);
+    expect(result2).toBe(defaultDescription);
+  });
+
+  test('should return the stable description for stable state', () => {
+    const result = getLifecycleDescription('stable', null);
+    expect(result).toBe(
+      'Mature and deliberately low-activity. The maintainer is reachable and there are no open issues or vulnerabilities that require attention.',
+    );
+  });
+
+  test('should return the archived description for archived state', () => {
+    const result = getLifecycleDescription('archived', null);
+    expect(result).toBe(
+      'The repository has been explicitly archived. No further updates are expected and the project is no longer accepting contributions.',
+    );
+  });
+});

--- a/frontend/config/health-breakdown-templates.ts
+++ b/frontend/config/health-breakdown-templates.ts
@@ -51,6 +51,9 @@ export const getLifecycleDescription = (
           : '';
       return `No maintainer activity in over 18 months.${lastCommitDetail}${cveDetail}`;
     }
+    case 'inert': {
+      return 'No commits or activity recorded in the past 18 months. The project appears inactive and may require maintenance attention.';
+    }
     case 'archived': {
       return 'The repository has been explicitly archived. No further updates are expected and the project is no longer accepting contributions.';
     }

--- a/frontend/config/trust-score.test.ts
+++ b/frontend/config/trust-score.test.ts
@@ -1,7 +1,7 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { describe, test, expect } from 'vitest';
-import { getLifecycleLabelConfig, lifecycleLabelConfig } from './trust-score';
+import { getLifecycleLabelConfig } from './trust-score';
 
 describe('getLifecycleLabelConfig', () => {
   test('should return the inert label and color when lifecycle state is "inert"', () => {
@@ -10,12 +10,6 @@ describe('getLifecycleLabelConfig', () => {
       label: 'Inert',
       color: 'bg-warning-600',
     });
-  });
-
-  test('should have inert defined in lifecycleLabelConfig', () => {
-    expect(lifecycleLabelConfig.inert).toBeDefined();
-    expect(lifecycleLabelConfig.inert.label).toBe('Inert');
-    expect(lifecycleLabelConfig.inert.color).toBe('bg-warning-600');
   });
 
   test('should return Unknown for null or undefined lifecycle state', () => {

--- a/frontend/config/trust-score.test.ts
+++ b/frontend/config/trust-score.test.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect } from 'vitest';
+import { getLifecycleLabelConfig, lifecycleLabelConfig } from './trust-score';
+
+describe('getLifecycleLabelConfig', () => {
+  test('should return the inert label and color when lifecycle state is "inert"', () => {
+    const result = getLifecycleLabelConfig('inert');
+    expect(result).toEqual({
+      label: 'Inert',
+      color: 'bg-warning-600',
+    });
+  });
+
+  test('should have inert defined in lifecycleLabelConfig', () => {
+    expect(lifecycleLabelConfig.inert).toBeDefined();
+    expect(lifecycleLabelConfig.inert.label).toBe('Inert');
+    expect(lifecycleLabelConfig.inert.color).toBe('bg-warning-600');
+  });
+
+  test('should return Unknown for null or undefined lifecycle state', () => {
+    const result1 = getLifecycleLabelConfig(null);
+    const result2 = getLifecycleLabelConfig(undefined);
+    expect(result1).toEqual({ label: 'Unknown', color: 'bg-neutral-400' });
+    expect(result2).toEqual({ label: 'Unknown', color: 'bg-neutral-400' });
+  });
+
+  test('should return Unknown for unrecognized lifecycle state', () => {
+    const result = getLifecycleLabelConfig('invalid-state');
+    expect(result).toEqual({ label: 'Unknown', color: 'bg-neutral-400' });
+  });
+});

--- a/frontend/config/trust-score.ts
+++ b/frontend/config/trust-score.ts
@@ -51,13 +51,13 @@ export const getImpactLabelDisplay = (label: string | null): string => {
   return 'Unavailable';
 };
 
-// Lifecycle labels come from health_score_v2's lifecycleLabelV2: active, stable, declining,
-// abandoned, archived (best-state-wins across a project's repos).
+// Lifecycle labels from health_score_v2's lifecycleLabelV2 (best-state-wins across repos).
 export const lifecycleLabelConfig: Record<string, { label: string; color: string }> = {
   active: { label: 'Active', color: 'bg-positive-500' },
   stable: { label: 'Stable', color: 'bg-accent-500' },
   declining: { label: 'Declining', color: 'bg-warning-500' },
   abandoned: { label: 'Abandoned', color: 'bg-negative-500' },
+  inert: { label: 'Inert', color: 'bg-warning-600' },
   archived: { label: 'Archived', color: 'bg-neutral-400' },
 };
 

--- a/frontend/setup/tailwind.ts
+++ b/frontend/setup/tailwind.ts
@@ -8,6 +8,7 @@ export default {
       'bg-negative-900',
       'bg-negative-500',
       'bg-warning-500',
+      'bg-warning-600',
       'bg-accent-500',
       'bg-positive-500',
       'text-accent-500',


### PR DESCRIPTION
## Summary

- The backend's Health Score v2 already returns the `inert` lifecycle state, but the frontend lacked handlers for it, causing it to render as "Unknown". This PR adds the missing cases to `trust-score.ts`, `health-breakdown-templates.ts`, and `collection-lifecycle-badge.vue`.
- Sets `inert` to use the warning color band (amber), matching the declining state visually.
- Frontend-only fix; no backend, database, or deployment changes.

## Changes

| File | What changed |
|------|-------------|
| `frontend/config/trust-score.ts` | Added `inert` to `lifecycleLabelConfig`: label "Inert", color `bg-warning-600` |
| `frontend/config/health-breakdown-templates.ts` | Added `inert` case to `getLifecycleDescription` |
| `frontend/app/components/modules/collection/components/details/collection-lifecycle-badge.vue` | Added `inert: 'warning'` to variations |
| `frontend/config/trust-score.test.ts` | Tests `getLifecycleLabelConfig` with inert state and edge cases |
| `frontend/config/health-breakdown-templates.test.ts` | Tests `getLifecycleDescription` with all lifecycle states |

## JIRA

IN-1240 — Inert lifecycle state not handled in UI — renders as Unknown

## Deploy order

No cross-repo dependencies. Insights frontend only.

## DB migrations

None.

## Test plan

- [ ] Verify `health_score_v2` Tinybird pipe returns `inert` as a valid lifecycle state value
- [ ] Load a collection with `inert` state in staging; confirm badge displays "Inert" with amber color
- [ ] Hover badge and confirm description text appears
- [x] `pnpm test` passes
- [x] `pnpm lint:fix` and `pnpm tsc-check` pass