### PR TITLE
fix: handle unavailable open vulnerability score (IN-1241)

### DIFF
--- a/frontend/config/health-breakdown-templates.test.ts
+++ b/frontend/config/health-breakdown-templates.test.ts
@@ -1,7 +1,8 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
 import { describe, test, expect } from 'vitest';
-import { getLifecycleDescription } from './health-breakdown-templates';
+import type { HealthBreakdownResults } from '../types/overview/responses.types';
+import { getLifecycleDescription, getOpenVulnRow } from './health-breakdown-templates';
 
 describe('getLifecycleDescription', () => {
   test('should return the inert description when lifecycle state is "inert"', () => {
@@ -39,5 +40,55 @@ describe('getLifecycleDescription', () => {
     expect(result).toBe(
       'The repository has been explicitly archived. No further updates are expected and the project is no longer accepting contributions.',
     );
+  });
+});
+
+describe('health-breakdown-templates', () => {
+  test('getOpenVulnRow returns no-data when openVulnScore is null', () => {
+    const signals = {
+      openVulnScore: null,
+      openVulnAvailable: null,
+      openCriticals: null,
+      openHighs: null,
+      openModerates: null,
+      isGerrit: null,
+      isExcluded: null,
+    } as HealthBreakdownResults;
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('no-data');
+  });
+
+  test('getOpenVulnRow returns no-data when the repo has never completed a vulnerability scan', () => {
+    const signals = {
+      openVulnScore: 10,
+      openVulnAvailable: false,
+      openCriticals: null,
+      openHighs: null,
+      openModerates: null,
+      isGerrit: false,
+      isExcluded: false,
+    } as HealthBreakdownResults;
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('no-data');
+  });
+
+  test('getOpenVulnRow returns positive when the repo has been scanned and is clean', () => {
+    const signals = {
+      openVulnScore: 10,
+      openVulnAvailable: true,
+      openCriticals: 0,
+      openHighs: 0,
+      openModerates: 0,
+      isGerrit: false,
+      isExcluded: false,
+    } as HealthBreakdownResults;
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('positive');
   });
 });

--- a/frontend/config/health-breakdown-templates.ts
+++ b/frontend/config/health-breakdown-templates.ts
@@ -379,6 +379,12 @@ export const getOrgDiversityRow = (signals: HealthBreakdownResults): SignalRow =
 // --- Security signals ---
 
 export const getOpenVulnRow = (signals: HealthBreakdownResults): SignalRow => {
+  if (signals.openVulnScore === null) {
+    return {
+      status: 'no-data',
+      description: blockedSignalDescription('Open vulnerabilities', signals),
+    };
+  }
   const criticals = signals.openCriticals ?? 0;
   const highs = signals.openHighs ?? 0;
   const moderates = signals.openModerates ?? 0;

--- a/frontend/config/health-breakdown-templates.ts
+++ b/frontend/config/health-breakdown-templates.ts
@@ -259,14 +259,15 @@ const getCategoryUnavailableDescription = (
   }
   if (category === 'security') {
     const availableSignals: string[] = [];
+    if (signals?.openVulnAvailable) availableSignals.push('open vulnerability data');
     if (signals?.scorecardAvailable) availableSignals.push('OpenSSF Scorecard');
     if (signals?.securityPracticesAvailable) availableSignals.push('security practices');
     if (signals?.dependencyHealthAvailable) availableSignals.push('dependency health');
     const reason = signals?.isGerrit ? 'Gerrit-hosted projects' : 'this repository type';
     const namedAvailable =
       availableSignals.length > 0
-        ? `Only open vulnerability data and ${availableSignals.join(', ')} ${availableSignals.length === 1 ? 'is' : 'are'} available for ${reason}.`
-        : `Only open vulnerability data is available for ${reason}.`;
+        ? `Only ${availableSignals.join(', ')} ${availableSignals.length === 1 ? 'is' : 'are'} available for ${reason}.`
+        : `No security signals are available for ${reason}.`;
     return `${namedAvailable} The category has been dropped from the Health Score composite.`;
   }
   const availableSignals: string[] = [];
@@ -379,7 +380,7 @@ export const getOrgDiversityRow = (signals: HealthBreakdownResults): SignalRow =
 // --- Security signals ---
 
 export const getOpenVulnRow = (signals: HealthBreakdownResults): SignalRow => {
-  if (signals.openVulnScore === null) {
+  if (!signals.openVulnAvailable || signals.openVulnScore === null) {
     return {
       status: 'no-data',
       description: blockedSignalDescription('Open vulnerabilities', signals),

--- a/frontend/types/overview/responses.types.ts
+++ b/frontend/types/overview/responses.types.ts
@@ -105,6 +105,7 @@ export interface HealthBreakdownResults {
 
   // Security
   openVulnScore: number | null;
+  openVulnAvailable: boolean | null;
   openCriticals: number | null;
   openHighs: number | null;
   openModerates: number | null;


### PR DESCRIPTION
## Summary

- `getOpenVulnRow()` now treats the open-vulnerabilities signal as blocked (`status: 'no-data'`) when either `signals.openVulnScore` is null OR `signals.openVulnAvailable` is falsy, matching the pattern already used by sibling signal functions (`getResponsivenessRow()`, `getBusFactorRow()`, `getOrgDiversityRow()`).
- Added `openVulnAvailable: boolean | null` to `HealthBreakdownResults` — a repo that has never completed a vulnerability scan was previously scored a false-positive "clean" `10`.
- Updated the security category's "unavailable" description builder to include open-vulnerability data in its list of named-available signals, since it's no longer unconditionally treated as covered.
- Added Vitest coverage for: score null, never-scanned (`openVulnAvailable: false`), and scanned-and-clean (`openVulnAvailable: true`).

## Cross-repo dependency

This PR reads a new `openVulnAvailable` field from the `project_insights_health_breakdown` Tinybird endpoint. That field is added by [crowd.dev#4509](https://github.com/linuxfoundation/crowd.dev/pull/4509) (adds an `openVulnAvailable` coverage flag through the full `health_score_v2_security` pipe chain, based on the `vulnerability_scans` datasource).

**Deploy order:** the crowd.dev Tinybird pipe change must be deployed to staging and production *before* this PR is deployed — until then, the field is simply absent from the API response and `getOpenVulnRow` falls back to its existing null-score check, so this PR is safe to merge independently but should not go live ahead of the pipe deploy.

Both the Tinybird deploy and end-to-end QA verification are intentionally deferred to a follow-up session.
