### PR TITLE
fix: change 'Org diversity' label to 'Organization Diversity' IN-1238

### DIFF
--- a/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
@@ -211,7 +211,7 @@ const selectedCategoryRows = computed(() => {
     return [
       { name: 'Maintainer responsiveness', ...getResponsivenessRow(signals) },
       { name: 'Bus factor', ...getBusFactorRow(signals) },
-      { name: 'Org diversity', ...getOrgDiversityRow(signals) },
+      { name: 'Organization Diversity', ...getOrgDiversityRow(signals) },
     ];
   }
   if (selectedCategoryKey.value === 'security-supply-chain') {

--- a/frontend/config/health-breakdown-templates.ts
+++ b/frontend/config/health-breakdown-templates.ts
@@ -247,7 +247,7 @@ const getCategoryUnavailableDescription = (
     const availableSignals: string[] = [];
     if (signals?.responsivenessAvailable) availableSignals.push('maintainer responsiveness');
     if (signals?.busFactorAvailable) availableSignals.push('bus factor');
-    if (signals?.orgDiversityAvailable) availableSignals.push('org diversity');
+    if (signals?.orgDiversityAvailable) availableSignals.push('organization diversity');
     const namedAvailable =
       availableSignals.length > 0
         ? `Only ${availableSignals.join(', ')} ${availableSignals.length === 1 ? 'is' : 'are'} available.`
@@ -352,7 +352,10 @@ export const getBusFactorRow = (signals: HealthBreakdownResults): SignalRow => {
 
 export const getOrgDiversityRow = (signals: HealthBreakdownResults): SignalRow => {
   if (!signals.orgDiversityAvailable) {
-    return { status: 'no-data', description: blockedSignalDescription('Org diversity', signals) };
+    return {
+      status: 'no-data',
+      description: blockedSignalDescription('Organization diversity', signals),
+    };
   }
   const count = signals.orgCount ?? 0;
   if (count >= 3) {

--- a/frontend/test/config/health-breakdown-templates-org-diversity.test.ts
+++ b/frontend/test/config/health-breakdown-templates-org-diversity.test.ts
@@ -1,0 +1,52 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect } from 'vitest';
+import {
+  getOrgDiversityRow,
+  getCategoryDescription,
+} from '../../config/health-breakdown-templates';
+import type { HealthBreakdownResults } from '../../types/overview/responses.types';
+
+describe('Organization Diversity label capitalization IN-1238', () => {
+  const defaultSignals: HealthBreakdownResults = {
+    responsivenessAvailable: false,
+    busFactorAvailable: false,
+    orgDiversityAvailable: false,
+    scorecardAvailable: false,
+    securityPracticesAvailable: false,
+    dependencyHealthAvailable: false,
+    releaseCadenceAvailable: false,
+    issueResolutionAvailable: false,
+    prMergeAvailable: false,
+    isGerrit: false,
+    isExcluded: false,
+  };
+
+  test('getOrgDiversityRow outputs full word "organization diversity"', () => {
+    const result = getOrgDiversityRow(defaultSignals);
+    expect(result.status).toBe('no-data');
+    expect(result.description).toContain('organization diversity');
+  });
+
+  test('getCategoryDescription includes "organization diversity" in signal list', () => {
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      responsivenessAvailable: true,
+      busFactorAvailable: true,
+      orgDiversityAvailable: true,
+    };
+    const result = getCategoryDescription('maintainer', null, false, signals);
+    expect(result).toContain('maintainer responsiveness');
+    expect(result).toContain('bus factor');
+    expect(result).toContain('organization diversity');
+  });
+
+  test('getCategoryDescription with only org diversity uses full word', () => {
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      orgDiversityAvailable: true,
+    };
+    const result = getCategoryDescription('maintainer', null, false, signals);
+    expect(result).toContain('organization diversity');
+  });
+});


### PR DESCRIPTION
## Summary

- Changed label from "Org diversity" to "Organization Diversity" in the Health Breakdown view's Maintainer Health section (part of IN-1192 Akrites Methodology / Health Score v2)
- Updated two template functions (`getOrgDiversityRow` and `getCategoryDescription`) plus the Vue template to use the full word "Organization" consistently
- Added unit test file covering both template functions to verify the corrected capitalization
- Design source: Figma node 3426-4941 — visual verification against this frame is still pending (no dev server checked against it in this run)

## Changes

| File | What changed |
|------|-------------|
| `frontend/app/components/modules/project/components/overview/health-breakdown-section.vue` | Updated label text from "Org diversity" to "Organization Diversity" in the selectedCategoryRows computed property |
| `frontend/config/health-breakdown-templates.ts` | Updated label in two locations: getCategoryDescription (unavailable signal list) and getOrgDiversityRow (blocked signal description) |
| `frontend/test/config/health-breakdown-templates-org-diversity.test.ts` | New test file with MIT header validating the corrected "Organization Diversity" label in both template functions |

## JIRA

IN-1238 — Verify that Org diversity label should read "Organization Diversity"

## Deploy order

_No deploy ordering constraints — self-contained frontend text fix._

## DB migrations

_No DB migrations._

## Test plan

- [ ] Verify label displays "Organization Diversity" (not "Org diversity") in the Health Breakdown view under Maintainer Health section, and matches Figma node 3426-4941
- [ ] Test both the "no data" unavailable state and with actual diversity data
- [ ] `cd frontend && pnpm test` passes (validates new unit tests)
- [ ] `pnpm tsc-check` passes (TypeScript validation)
- [ ] No regressions in other Health Score metrics or labels

## Checklist

- [x] `git commit --signoff -S` on every commit (verified in commit history)
- [x] MIT license header on every new source file (header present in new test file)
- [x] PR diff < 1000 lines (58 lines, well under limit)
- [x] No unrelated changes bundled (single focused fix)
- [x] Cross-repo impact documented (none — self-contained to insights frontend)
