### PR TITLE
docs: sync docs with recent changes

### DIFF
--- a/frontend/docs/features/community-collections/index.md
+++ b/frontend/docs/features/community-collections/index.md
@@ -40,9 +40,9 @@ Every collection detail page opens on the **Projects** tab. The header displays 
 The Projects tab lists all projects in the collection as a sortable table. Each row shows:
 
 - **Project** name (sortable alphabetically)
-- **Lifecycle** — a badge indicating the project's current lifecycle stage (Active, Stable, Declining, Abandoned, or Archived)
+- **Lifecycle** — a badge indicating the project's current lifecycle stage (Active, Stable, Declining, Abandoned, or Archived). Projects without a lifecycle stage show **Unavailable**.
 - **Health Score** — the project's LFX Health Score
-- **Impact** — a pill showing the project's Impact tier (Foundational, Major, Moderate, or Minor) with the underlying score
+- **Impact** — a pill showing the project's Impact tier (Foundational, Major, Moderate, or Minor) with the underlying score. Projects without an impact score show **N/A**.
 - **Contributors** — contributor count (sortable)
 - **Contributor / Organization dependency** — concentration risk indicators
 - **Achievements** — earned badges

--- a/frontend/docs/features/community-collections/index.md
+++ b/frontend/docs/features/community-collections/index.md
@@ -40,7 +40,9 @@ Every collection detail page opens on the **Projects** tab. The header displays 
 The Projects tab lists all projects in the collection as a sortable table. Each row shows:
 
 - **Project** name (sortable alphabetically)
+- **Lifecycle** — a badge indicating the project's current lifecycle stage (Active, Stable, Declining, Abandoned, or Archived)
 - **Health Score** — the project's LFX Health Score
+- **Impact** — a pill showing the project's Impact tier (Foundational, Major, Moderate, or Minor) with the underlying score
 - **Contributors** — contributor count (sortable)
 - **Contributor / Organization dependency** — concentration risk indicators
 - **Achievements** — earned badges


### PR DESCRIPTION
## What changed

- **Community Collections** (`frontend/docs/features/community-collections/index.md`): documented the two new columns now shown in the Projects tab of every collection detail page — **Lifecycle** (Active, Stable, Declining, Abandoned, Archived) and **Impact** (Foundational, Major, Moderate, Minor with the underlying score). The Projects tab is shared across Curated, Community, and My Collections, so the doc entry reflects all variants.

## Source commits

- [c8b1a29](https://github.com/linuxfoundation/insights/commit/c8b1a2929c81c742caf7744364acc1c4c2536909) — feat: display Health Score v2, Impact Score, and Lifecycle columns IN-1196 (#2035)
- [d85d3d1](https://github.com/linuxfoundation/insights/commit/d85d3d151fe025f583f18ac42bc5fb510cc4afa1) — feat: migrate health score displays to v2 and implement Health Score v2 content spec IN-1212 (#2054) (adds the shared Impact Score / Lifecycle pill components used in the Projects tab)

## Notes

- The Health Score v2 migration (#2054) and the impact-section UI alignment (#2108) also change the project overview page, the Avg. Health band thresholds in the collection header, and the health-score breakdown layout. Those touch metric formulas / health-score thresholds, so they were intentionally held back from this sync per the docs-agent confidence gate — please raise a follow-up if you'd like the `metrics/health-score` page updated to reflect the v2 spec.
- Please double-check that the Lifecycle labels documented here (Active / Stable / Declining / Abandoned / Archived) match the customer-facing terminology in the PRD; the source uses lowercase strings that are title-cased at render time.

---
_Generated by [Claude Code](https://claude.ai/code/session_01JdxY4tbb7ZDpADWYBxdCjf)_