### PR TITLE
fix: return v2 health score total in public project insights api

### DIFF
--- a/frontend/docs/openapi.json
+++ b/frontend/docs/openapi.json
@@ -74,6 +74,7 @@
                   "status": "active",
                   "maturity": "graduated",
                   "healthScore": 87,
+                  "healthLabel": "excellent",
                   "contributorHealthScore": 90,
                   "popularityHealthScore": 95,
                   "developmentHealthScore": 80,
@@ -252,6 +253,19 @@
             "minimum": 0,
             "maximum": 100,
             "description": "Overall health score"
+          },
+          "healthLabel": {
+            "type": "string",
+            "nullable": true,
+            "enum": [
+              "excellent",
+              "healthy",
+              "fair",
+              "concerning",
+              "critical",
+              null
+            ],
+            "description": "Qualitative band for healthScore. Null if not yet computed for this project."
           },
           "contributorHealthScore": {
             "type": "number",

--- a/frontend/server/api/project/[slug]/insights.get.ts
+++ b/frontend/server/api/project/[slug]/insights.get.ts
@@ -43,6 +43,7 @@ export default defineEventHandler(async (event) => {
     return {
       ...project,
       healthScore: project.healthScoreV2,
+      healthLabel: project.healthLabel,
       isLF: !!project.isLF,
       achievements:
         project.achievements?.map(

--- a/frontend/server/api/project/[slug]/insights.get.ts
+++ b/frontend/server/api/project/[slug]/insights.get.ts
@@ -42,6 +42,7 @@ export default defineEventHandler(async (event) => {
 
     return {
       ...project,
+      healthScore: project.healthScoreV2 ?? project.healthScore,
       isLF: !!project.isLF,
       achievements:
         project.achievements?.map(

--- a/frontend/server/api/project/[slug]/insights.get.ts
+++ b/frontend/server/api/project/[slug]/insights.get.ts
@@ -42,7 +42,7 @@ export default defineEventHandler(async (event) => {
 
     return {
       ...project,
-      healthScore: project.healthScoreV2 ?? project.healthScore,
+      healthScore: project.healthScoreV2,
       isLF: !!project.isLF,
       achievements:
         project.achievements?.map(


### PR DESCRIPTION
## Summary
- `/api/project/{slug}/insights` (the public, unauthenticated API documented in `frontend/docs/openapi.json` that CNCF and other LF web properties consume) still returned the legacy v1 `healthScore` field verbatim from the `project_insights` Tinybird pipe, even though that same pipe already computes `healthScoreV2`.
- The internal SSR route (`health-score-v2.get.ts`) was already updated to serve v2, so Insights' own UI shows v2 scores while the public API — and everything that reads it, including cncf.io/projects/* — still shows v1. This is the gap Joana flagged in IN-1212 comment 118228 (Argo showing v1 on cncf.io vs v2 on insights.linuxfoundation.org).
- Fix: the public endpoint now returns `healthScoreV2` as the `healthScore` field value (falling back to the legacy v1 value if v2 hasn't been computed yet for a given project), while every other field in the response is untouched — matching AC #3 on IN-1212 ("system returns v2 total score in public API responses; all other metrics remain unchanged from previous responses").

## Test plan
- [x] `pnpm tsc-check` — passes
- [x] `pnpm lint:fix` — no new warnings/errors introduced
- [ ] Manually verify `/api/project/argo/insights` in staging returns the v2 total score
- [ ] Confirm with Joana whether CNCF also needs the new v2 quality label surfaced, or coordination before they adopt the new score range/labels (open question from her comment, not addressed by this fix)

JIRA: IN-1212