### PR TITLE
fix: handle repository filtering on Overview scores IN-1253

### DIFF
--- a/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
@@ -32,7 +32,7 @@ SPDX-License-Identifier: MIT
     </p>
 
     <div
-      v-if="isEmpty"
+      v-if="isLowSignalCoverage"
       class="flex items-center gap-1.5 text-xs text-neutral-500 mb-4"
     >
       <lfx-icon
@@ -134,9 +134,12 @@ const props = defineProps<{
   developmentActivityScoreV2: number | null;
   signals: HealthBreakdownResults | null;
   selectedReposAllArchivedOrExcluded: boolean;
+  isRepoSelected: boolean;
 }>();
 
-const isEmpty = computed(() => props.healthScoreV2 === null);
+// healthScoreV2 is intentionally null when a repo filter is active (State 2) — the
+// low-signal-coverage banner only applies to the unfiltered, project-wide total (State 1).
+const isLowSignalCoverage = computed(() => props.healthScoreV2 === null && !props.isRepoSelected);
 
 const scoreLabel = computed(() => getHealthScoreV2Config(props.healthLabel).label);
 

--- a/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
@@ -3,7 +3,13 @@ Copyright (c) 2025 The Linux Foundation and each contributor.
 SPDX-License-Identifier: MIT
 -->
 <template>
-  <div>
+  <lfx-empty-state
+    v-if="props.selectedReposAllArchivedOrExcluded"
+    icon="archive"
+    :title="healthScoreFilterEmptyState.stateUnavailable.title"
+    :description="healthScoreFilterEmptyState.stateUnavailable.description"
+  />
+  <div v-else>
     <div class="flex flex-col-reverse sm:flex-row items-start sm:items-center gap-2 sm:gap-4 pb-2">
       <h2 class="text-xl leading-8 font-primary font-semibold text-neutral-900">Health breakdown</h2>
       <lfx-chip
@@ -100,8 +106,9 @@ import LfxButton from '~/components/uikit/button/button.vue';
 import LfxIcon from '~/components/uikit/icon/icon.vue';
 import LfxChip from '~/components/uikit/chip/chip.vue';
 import LfxBenchmarkIcon from '~/components/uikit/benchmarks/benchmark-icon.vue';
+import LfxEmptyState from '~/components/shared/components/empty-state.vue';
 import { LfxRoutes } from '~/components/shared/types/routes';
-import { getHealthScoreV2Config } from '~~/config/trust-score';
+import { getHealthScoreV2Config, healthScoreFilterEmptyState } from '~~/config/trust-score';
 import {
   getCategoryDescription,
   getCategoryScoreColor,
@@ -126,6 +133,7 @@ const props = defineProps<{
   securitySupplyChainScoreV2: number | null;
   developmentActivityScoreV2: number | null;
   signals: HealthBreakdownResults | null;
+  selectedReposAllArchivedOrExcluded: boolean;
 }>();
 
 const isEmpty = computed(() => props.healthScoreV2 === null);

--- a/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
@@ -13,7 +13,7 @@ SPDX-License-Identifier: MIT
     <div class="flex flex-col-reverse sm:flex-row items-start sm:items-center gap-2 sm:gap-4 pb-2">
       <h2 class="text-xl leading-8 font-primary font-semibold text-neutral-900">Health breakdown</h2>
       <lfx-chip
-        v-if="props.healthScoreV2 !== null"
+        v-if="props.healthScoreV2 !== null && !props.isMultipleReposSelected"
         type="bordered"
         size="xsmall"
         class="flex items-center gap-1.5"
@@ -138,6 +138,7 @@ const props = defineProps<{
   signals: HealthBreakdownResults | null;
   selectedReposAllArchivedOrExcluded: boolean;
   isRepoSelected: boolean;
+  isMultipleReposSelected: boolean;
 }>();
 
 const allCategoriesEmpty = computed(

--- a/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
+++ b/frontend/app/components/modules/project/components/overview/health-breakdown-section.vue
@@ -33,14 +33,17 @@ SPDX-License-Identifier: MIT
 
     <div
       v-if="isLowSignalCoverage"
-      class="flex items-center gap-1.5 text-xs text-neutral-500 mb-4"
+      class="flex items-start gap-2 p-3 mb-4 bg-accent-100 border border-neutral-100 rounded-md"
     >
       <lfx-icon
         name="circle-info"
         :size="14"
-        class="text-neutral-400 shrink-0"
+        class="text-accent-500 shrink-0"
       />
-      <span>Health Score unavailable. All three categories have less than 40% signal coverage for this project.</span>
+      <div class="flex flex-col gap-1.5 text-xs">
+        <p class="font-semibold text-neutral-900">Health Score unavailable</p>
+        <p class="text-accent-900">All three categories have less than 40% signal coverage for this project.</p>
+      </div>
     </div>
 
     <div class="flex flex-col sm:flex-row sm:items-stretch gap-1 p-1 bg-neutral-50 rounded-lg mb-4">
@@ -137,9 +140,20 @@ const props = defineProps<{
   isRepoSelected: boolean;
 }>();
 
+const allCategoriesEmpty = computed(
+  () =>
+    props.maintainerHealthScoreV2 === null &&
+    props.securitySupplyChainScoreV2 === null &&
+    props.developmentActivityScoreV2 === null,
+);
+
 // healthScoreV2 is intentionally null when a repo filter is active (State 2) — the
-// low-signal-coverage banner only applies to the unfiltered, project-wide total (State 1).
-const isLowSignalCoverage = computed(() => props.healthScoreV2 === null && !props.isRepoSelected);
+// low-signal-coverage banner only applies to the unfiltered, project-wide total (State 1),
+// and only when the category scores are also missing (a total masked for other reasons
+// while categories still have real data would make this message factually wrong).
+const isLowSignalCoverage = computed(
+  () => props.healthScoreV2 === null && !props.isRepoSelected && allCategoriesEmpty.value,
+);
 
 const scoreLabel = computed(() => getHealthScoreV2Config(props.healthLabel).label);
 

--- a/frontend/app/components/modules/project/components/overview/trust-score-v2.vue
+++ b/frontend/app/components/modules/project/components/overview/trust-score-v2.vue
@@ -3,7 +3,10 @@ Copyright (c) 2025 The Linux Foundation and each contributor.
 SPDX-License-Identifier: MIT
 -->
 <template>
-  <div class="px-6">
+  <div
+    class="px-6"
+    :class="{ 'pb-6': !showShareBadge }"
+  >
     <template v-if="!isEntireProjectArchived">
       <lfx-skeleton-state
         :status="status"

--- a/frontend/app/components/modules/project/components/overview/trust-score-v2.vue
+++ b/frontend/app/components/modules/project/components/overview/trust-score-v2.vue
@@ -4,7 +4,7 @@ SPDX-License-Identifier: MIT
 -->
 <template>
   <div class="px-6">
-    <template v-if="!isArchived">
+    <template v-if="!isEntireProjectArchived">
       <lfx-skeleton-state
         :status="status"
         height="10rem"
@@ -13,43 +13,65 @@ SPDX-License-Identifier: MIT
         <!-- TEMPORARILY HIDDEN (IN-1243): grid-cols-2 instead of grid-cols-3 while Impact is hidden, so Health Score/Lifecycle split evenly. Revert to md:grid-cols-3 when Impact is re-enabled. -->
         <div class="grid grid-cols-1 md:grid-cols-2 gap-6">
           <div class="flex flex-col items-start gap-3">
-            <div class="flex flex-row flex-wrap items-start justify-between gap-3 w-full">
-              <div class="flex flex-col items-start gap-2">
-                <span class="text-xs font-semibold text-neutral-500 tracking-wide flex items-center gap-1">
-                  HEALTH SCORE
-                  <lfx-tooltip placement="top">
-                    <lfx-icon
-                      name="circle-question"
-                      :size="11"
-                      class="cursor-help text-neutral-400"
-                    />
-                    <template #content>
-                      <div class="max-w-xs text-xs leading-relaxed">
-                        The Insights Health Score measures an open source project's overall trustworthiness, based on
-                        maintainer activity, security posture, and development cadence.
-                      </div>
-                    </template>
-                  </lfx-tooltip>
-                </span>
-                <span
-                  class="text-lg font-semibold"
-                  :class="isEmpty ? 'text-neutral-400' : scoreTextColorClass"
-                  >{{ scoreLabel }}</span
-                >
+            <template v-if="!isRepoSelected">
+              <div class="flex flex-row flex-wrap items-start justify-between gap-3 w-full">
+                <div class="flex flex-col items-start gap-2">
+                  <span class="text-xs font-semibold text-neutral-500 tracking-wide flex items-center gap-1">
+                    HEALTH SCORE
+                    <lfx-tooltip placement="top">
+                      <lfx-icon
+                        name="circle-question"
+                        :size="11"
+                        class="cursor-help text-neutral-400"
+                      />
+                      <template #content>
+                        <div class="max-w-xs text-xs leading-relaxed">
+                          The Insights Health Score measures an open source project's overall trustworthiness, based on
+                          maintainer activity, security posture, and development cadence.
+                        </div>
+                      </template>
+                    </lfx-tooltip>
+                  </span>
+                  <span
+                    class="text-lg font-semibold"
+                    :class="isEmpty ? 'text-neutral-400' : scoreTextColorClass"
+                    >{{ scoreLabel }}</span
+                  >
+                </div>
+                <lfx-health-score-ring
+                  :score="healthScoreV2 ?? 0"
+                  :color="scoreColorHex"
+                  :unavailable="isEmpty"
+                />
               </div>
-              <lfx-health-score-ring
-                :score="healthScoreV2 ?? 0"
-                :color="scoreColorHex"
-                :unavailable="isEmpty"
-              />
-            </div>
-            <div class="flex-grow" />
-            <p
-              v-if="healthScoreDescription"
-              class="text-xs text-neutral-500"
+              <div class="flex-grow" />
+              <p
+                v-if="healthScoreDescription"
+                class="text-xs text-neutral-500"
+              >
+                {{ healthScoreDescription }}
+              </p>
+            </template>
+
+            <div
+              v-else-if="!selectedReposAllArchivedOrExcluded"
+              class="text-xs text-brand-600 font-semibold inline-flex items-center gap-1 bg-brand-50 rounded-full px-1.5 py-1"
             >
-              {{ healthScoreDescription }}
-            </p>
+              <lfx-icon
+                name="info-circle"
+                :size="12"
+                type="solid"
+                class="text-brand-600"
+              />
+              {{ healthScoreFilterEmptyState.stateSelectAll.description }}
+            </div>
+
+            <lfx-empty-state
+              v-else
+              icon="archive"
+              :title="healthScoreFilterEmptyState.stateUnavailable.title"
+              :description="healthScoreFilterEmptyState.stateUnavailable.description"
+            />
           </div>
 
           <!-- TEMPORARILY HIDDEN (IN-1243): Impact section disabled until underlying data quality issue is fixed. Re-enable by uncommenting.
@@ -150,6 +172,7 @@ import {
   // TEMPORARILY HIDDEN (IN-1243): Impact section disabled until underlying data quality issue is fixed. Re-enable by uncommenting.
   // getImpactLabelDisplay,
   getLifecycleLabelConfig,
+  healthScoreFilterEmptyState,
 } from '~~/config/trust-score';
 import { lfxColors } from '~/config/styles/colors';
 import LfxSkeletonState from '~/components/modules/project/components/shared/skeleton-state.vue';
@@ -181,12 +204,22 @@ const props = defineProps<{
   signals: HealthBreakdownResults | null;
 }>();
 
-const { isArchived, emptyStateTitle, emptyStateDescription, selectedRepositories } = storeToRefs(useProjectStore());
+const {
+  isEntireProjectArchived,
+  emptyStateTitle,
+  emptyStateDescription,
+  selectedRepositories,
+  selectedReposAllArchivedOrExcluded,
+} = storeToRefs(useProjectStore());
 
 const isEmpty = computed(() => props.healthScoreV2 === null);
 
+// When a repo is selected, the badge switches to an active-contributors badge (see
+// share-badge.vue) which doesn't depend on the Health Score total, so it isn't gated on
+// `isEmpty` in that case - only the project-wide Health Score badge needs a non-null total.
 const showShareBadge = computed(
-  () => !isEmpty.value && props.status === 'success' && selectedRepositories.value.length <= 1,
+  () =>
+    props.status === 'success' && selectedRepositories.value.length <= 1 && (props.isRepoSelected || !isEmpty.value),
 );
 
 const scoreLabel = computed(() => getHealthScoreV2Config(props.healthLabel).label);

--- a/frontend/app/components/modules/project/components/shared/header/repository-switch/repository-search.vue
+++ b/frontend/app/components/modules/project/components/shared/header/repository-switch/repository-search.vue
@@ -93,6 +93,10 @@ const props = defineProps<{
   link: ProjectLinkConfig;
 }>();
 
+const emit = defineEmits<{
+  (e: 'close'): void;
+}>();
+
 const route = useRoute();
 const router = useRouter();
 
@@ -149,6 +153,7 @@ const handleReposChange = (repo: RepositoryItem) => {
       params: { name: repos[0] },
       query: { ...routeQuery, repos: undefined },
     });
+    emit('close');
   } else {
     router.push({
       name: props.link.projectRouteName,

--- a/frontend/app/components/modules/project/services/overview.api.service.ts
+++ b/frontend/app/components/modules/project/services/overview.api.service.ts
@@ -27,10 +27,16 @@ export interface ScoreDataQueryParams extends OverviewQueryParams {
 
 // TODO: Refactor other services to follow this pattern
 class OverviewApiService {
-  fetchHealthScoreV2(params: ComputedRef<{ projectSlug: string }>) {
-    const queryKey = computed(() => [TanstackKey.HEALTH_SCORE_V2, params.value.projectSlug]);
+  fetchHealthScoreV2(params: ComputedRef<OverviewQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.HEALTH_SCORE_V2,
+      params.value.projectSlug,
+      params.value.repos,
+    ]);
     const queryFn: QueryFunction<HealthScoreV2Results> = async () =>
-      await $fetch(`/api/project/${params.value.projectSlug}/overview/health-score-v2`);
+      await $fetch(`/api/project/${params.value.projectSlug}/overview/health-score-v2`, {
+        params: { repos: params.value.repos },
+      });
 
     return useQuery<HealthScoreV2Results>({
       queryKey,
@@ -52,10 +58,16 @@ class OverviewApiService {
     });
   }
 
-  fetchHealthScoreBreakdown(params: ComputedRef<{ projectSlug: string }>) {
-    const queryKey = computed(() => [TanstackKey.HEALTH_SCORE_BREAKDOWN, params.value.projectSlug]);
+  fetchHealthScoreBreakdown(params: ComputedRef<OverviewQueryParams>) {
+    const queryKey = computed(() => [
+      TanstackKey.HEALTH_SCORE_BREAKDOWN,
+      params.value.projectSlug,
+      params.value.repos,
+    ]);
     const queryFn: QueryFunction<HealthBreakdownResults> = async () =>
-      await $fetch(`/api/project/${params.value.projectSlug}/overview/health-score-breakdown`);
+      await $fetch(`/api/project/${params.value.projectSlug}/overview/health-score-breakdown`, {
+        params: { repos: params.value.repos },
+      });
 
     return useQuery<HealthBreakdownResults>({
       queryKey,

--- a/frontend/app/components/modules/project/store/project.store.ts
+++ b/frontend/app/components/modules/project/store/project.store.ts
@@ -162,6 +162,19 @@ export const useProjectStore = defineStore('project', () => {
   // If all repos are archived or the project is archived
   const isArchived = computed(() => allArchived.value || isProjectArchived.value);
 
+  // Whole-project archival, independent of any repo selection: either the project record
+  // itself is archived, or literally all of the project's repos are archived. Unlike
+  // `isArchived`, this deliberately excludes the "current selection happens to be all
+  // archived" case - the Overview page (IN-1253) still shows Lifecycle for that selection
+  // state, it only hides the whole-project view for genuine whole-project archival.
+  const isEntireProjectArchived = computed(
+    () =>
+      isProjectArchived.value ||
+      (!isCollectionScope.value &&
+        !!projectRepos.value.length &&
+        archivedRepos.value.length === projectRepos.value.length),
+  );
+
   const emptyStateTitle = computed(() => {
     if (isProjectArchived.value) {
       return 'Archived Project';
@@ -182,6 +195,18 @@ export const useProjectStore = defineStore('project', () => {
       selectedReposValues.value.some((repo) => archivedRepos.value.includes(repo)),
   );
 
+  // True only when there IS an explicit repo selection and every selected repo is archived
+  // or excluded. Used to distinguish the "some active repo selected" vs "selection has no
+  // active repo at all" Health Score empty states (IN-1253). Intentionally separate from
+  // `allArchived`, which only accounts for `archivedRepos` and is consumed elsewhere.
+  const selectedReposAllArchivedOrExcluded = computed(
+    () =>
+      !!selectedReposValues.value.length &&
+      selectedReposValues.value.every(
+        (repo) => archivedRepos.value.includes(repo) || excludedRepos.value.includes(repo),
+      ),
+  );
+
   return {
     isCollectionScope,
     selectedTimeRangeKey,
@@ -200,9 +225,11 @@ export const useProjectStore = defineStore('project', () => {
     selectedReposValues,
     allArchived,
     hasSelectedArchivedRepos,
+    selectedReposAllArchivedOrExcluded,
     collaborationSet,
     isProjectArchived,
     isArchived,
+    isEntireProjectArchived,
     emptyStateTitle,
     emptyStateDescription,
   };

--- a/frontend/app/components/modules/project/store/project.store.ts
+++ b/frontend/app/components/modules/project/store/project.store.ts
@@ -2,7 +2,7 @@
 // SPDX-License-Identifier: MIT
 import { defineStore } from 'pinia';
 import { ref, computed, watch } from 'vue';
-import { useRoute } from 'nuxt/app';
+import { useRouter } from 'nuxt/app';
 import { DateTime } from 'luxon';
 import pluralize from 'pluralize';
 import {
@@ -48,7 +48,12 @@ export const defaultDateOption = lfxProjectDateOptions.find(
 );
 
 export const useProjectStore = defineStore('project', () => {
-  const route = useRoute();
+  // `useRoute()` inside a Pinia store setup can resolve to a snapshot that stops
+  // tracking client-side navigations (observed: store's route stayed pinned to the
+  // route active when the store was first instantiated). `router.currentRoute` is the
+  // literal ref vue-router mutates on every navigation, so reading it here guarantees
+  // this store always sees the current route.
+  const route = useRouter().currentRoute;
 
   // Collection detail pages (/collection/details/[slug]/...) reuse this store for the
   // date-range/granularity state widgets share, but have no single project's repos,
@@ -56,7 +61,7 @@ export const useProjectStore = defineStore('project', () => {
   // when scope is a whole collection. Every repo/archived-repo-dependent computed below
   // short-circuits to a safe empty/false value in that case instead of trying to derive
   // "the collection's repos" from a null project.
-  const isCollectionScope = computed(() => route.path.startsWith('/collection/details/'));
+  const isCollectionScope = computed(() => route.value.path.startsWith('/collection/details/'));
 
   const { queryParams } = useQueryParam(processProjectParams, projectParamsSetter);
   const { timeRange, start, end } = queryParams.value;
@@ -97,14 +102,14 @@ export const useProjectStore = defineStore('project', () => {
   // List of excluded repositories
   const excludedRepos = computed<string[]>(() => project.value?.excludedRepositories || []);
 
-  // Selected repositories from URL param 'repos' or single repo from route param 'name'
-  const selectedRepoSlugs = computed(() => {
+  // Selected repositories from URL param 'repos' or single repo from route param 'name'.
+  const selectedRepoSlugs = computed<string[]>(() => {
     if (isCollectionScope.value) {
       return [];
     }
-    return route.params.name
-      ? [route.params.name as string]
-      : (route.query.repos as string)?.split(',') || [];
+    return route.value.params.name
+      ? [route.value.params.name as string]
+      : (route.value.query.repos as string)?.split(',') || [];
   });
 
   // Selected repository Group
@@ -112,7 +117,8 @@ export const useProjectStore = defineStore('project', () => {
     if (isCollectionScope.value) {
       return null;
     }
-    const groupSlug = (route.params.groupSlug as string | undefined) || route.query.repositoryGroup;
+    const groupSlug =
+      (route.value.params.groupSlug as string | undefined) || route.value.query.repositoryGroup;
     if (!groupSlug || !projectRepositoryGroups.value.length) {
       return null;
     }
@@ -131,7 +137,7 @@ export const useProjectStore = defineStore('project', () => {
     }
     return projectRepos.value.filter(
       (repo: ProjectRepository) =>
-        selectedRepoSlugs.value.includes(repo.slug) || route.params.name === repo.slug,
+        selectedRepoSlugs.value.includes(repo.slug) || route.value.params.name === repo.slug,
     );
   });
 

--- a/frontend/app/components/modules/project/store/project.store.ts
+++ b/frontend/app/components/modules/project/store/project.store.ts
@@ -162,11 +162,8 @@ export const useProjectStore = defineStore('project', () => {
   // If all repos are archived or the project is archived
   const isArchived = computed(() => allArchived.value || isProjectArchived.value);
 
-  // Whole-project archival, independent of any repo selection: either the project record
-  // itself is archived, or literally all of the project's repos are archived. Unlike
-  // `isArchived`, this deliberately excludes the "current selection happens to be all
-  // archived" case - the Overview page (IN-1253) still shows Lifecycle for that selection
-  // state, it only hides the whole-project view for genuine whole-project archival.
+  // Unlike `isArchived`, this excludes the "current selection happens to be all archived"
+  // case - it's true only for genuine whole-project archival, not a selection-driven one.
   const isEntireProjectArchived = computed(
     () =>
       isProjectArchived.value ||
@@ -196,9 +193,7 @@ export const useProjectStore = defineStore('project', () => {
   );
 
   // True only when there IS an explicit repo selection and every selected repo is archived
-  // or excluded. Used to distinguish the "some active repo selected" vs "selection has no
-  // active repo at all" Health Score empty states (IN-1253). Intentionally separate from
-  // `allArchived`, which only accounts for `archivedRepos` and is consumed elsewhere.
+  // or excluded. Separate from `allArchived`, which only accounts for `archivedRepos`.
   const selectedReposAllArchivedOrExcluded = computed(
     () =>
       !!selectedReposValues.value.length &&

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -18,7 +18,7 @@ SPDX-License-Identifier: MIT
             :security-supply-chain-score-v2="healthScoreV2Data?.securitySupplyChainScoreV2 ?? null"
             :development-activity-score-v2="healthScoreV2Data?.developmentActivityScoreV2 ?? null"
             :status="healthScoreV2Status"
-            :is-repo-selected="selectedRepositories.length > 0"
+            :is-repo-selected="isRepoFilterActive"
             :signals="healthBreakdownData ?? null"
           />
         </lfx-card>
@@ -35,7 +35,7 @@ SPDX-License-Identifier: MIT
             :development-activity-score-v2="healthScoreV2Data?.developmentActivityScoreV2 ?? null"
             :signals="healthBreakdownData ?? null"
             :selected-repos-all-archived-or-excluded="selectedReposAllArchivedOrExcluded"
-            :is-repo-selected="selectedRepositories.length > 0"
+            :is-repo-selected="isRepoFilterActive"
           />
         </lfx-card>
 
@@ -87,7 +87,15 @@ const {
   selectedReposValues,
   selectedReposAllArchivedOrExcluded,
   isEntireProjectArchived,
+  selectedRepositoryGroup,
 } = storeToRefs(useProjectStore());
+
+// Dedicated single-repo (`route.params.name`) and repository-group routes always have a
+// non-empty `selectedRepositories`, but have no "select all repositories" control — only the
+// top-of-page repo filter widget (`route.query.repos`) should trigger that empty state.
+const isRepoFilterActive = computed(
+  () => !route.params.name && !selectedRepositoryGroup.value && selectedRepositories.value.length > 0,
+);
 
 const params = computed(() => ({
   projectSlug: route.params.slug as string,

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -24,7 +24,7 @@ SPDX-License-Identifier: MIT
         </lfx-card>
 
         <lfx-card
-          v-if="healthScoreV2Status !== 'pending' && !isArchived"
+          v-if="healthScoreV2Status !== 'pending' && !isEntireProjectArchived"
           class="p-6"
         >
           <lfx-health-breakdown-section
@@ -34,6 +34,7 @@ SPDX-License-Identifier: MIT
             :security-supply-chain-score-v2="healthScoreV2Data?.securitySupplyChainScoreV2 ?? null"
             :development-activity-score-v2="healthScoreV2Data?.developmentActivityScoreV2 ?? null"
             :signals="healthBreakdownData ?? null"
+            :selected-repos-all-archived-or-excluded="selectedReposAllArchivedOrExcluded"
           />
         </lfx-card>
 
@@ -79,10 +80,17 @@ import LfxHealthScoreBanner from '~/components/modules/project/components/overvi
 import { useProjectStore } from '~/components/modules/project/store/project.store';
 
 const route = useRoute();
-const { hasSelectedArchivedRepos, selectedRepositories, isArchived } = storeToRefs(useProjectStore());
+const {
+  hasSelectedArchivedRepos,
+  selectedRepositories,
+  selectedReposValues,
+  selectedReposAllArchivedOrExcluded,
+  isEntireProjectArchived,
+} = storeToRefs(useProjectStore());
 
 const params = computed(() => ({
   projectSlug: route.params.slug as string,
+  repos: selectedRepositories.value.length ? selectedReposValues.value : undefined,
 }));
 
 const {

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -36,6 +36,7 @@ SPDX-License-Identifier: MIT
             :signals="healthBreakdownData ?? null"
             :selected-repos-all-archived-or-excluded="selectedReposAllArchivedOrExcluded"
             :is-repo-selected="isRepoFilterActive"
+            :is-multiple-repos-selected="selectedRepositories.length > 1"
           />
         </lfx-card>
 

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -7,7 +7,7 @@ SPDX-License-Identifier: MIT
     <div class="flex justify-between pt-5 md:pt-10 lg:gap-10 gap-5 flex-col md:flex-row">
       <div class="w-full md:w-3/4 flex flex-col gap-6">
         <lfx-health-score-banner />
-        <lfx-card class="pt-6 flex flex-col md:gap-10 gap-5 !pb-0">
+        <lfx-card class="pt-6 flex flex-col md:gap-10 gap-5">
           <lfx-project-trust-score-v2
             :health-score-v2="healthScoreV2Data?.healthScoreV2 ?? null"
             :health-label="healthScoreV2Data?.healthLabel ?? null"

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -35,6 +35,7 @@ SPDX-License-Identifier: MIT
             :development-activity-score-v2="healthScoreV2Data?.developmentActivityScoreV2 ?? null"
             :signals="healthBreakdownData ?? null"
             :selected-repos-all-archived-or-excluded="selectedReposAllArchivedOrExcluded"
+            :is-repo-selected="selectedRepositories.length > 0"
           />
         </lfx-card>
 

--- a/frontend/app/pages/project/[slug].vue
+++ b/frontend/app/pages/project/[slug].vue
@@ -6,7 +6,7 @@ SPDX-License-Identifier: MIT
   <lfx-project-header :project="data" />
   <div>
     <div v-if="isLoading || projectIsOnboarded">
-      <nuxt-page />
+      <nuxt-page :page-key="route.fullPath" />
     </div>
     <div
       v-else-if="!isLoading && !projectIsOnboarded"

--- a/frontend/config/trust-score.ts
+++ b/frontend/config/trust-score.ts
@@ -35,6 +35,20 @@ export const getHealthScoreV2Config = (label: string | null): HealthScoreV2Confi
   return healthScoreV2Config.unavailable;
 };
 
+// Health Score empty-state copy for the repo-selector states (IN-1253). `stateSelectAll`
+// matches the wording of the pre-IN-1212 repo-scoping banner (see git history) so its
+// removal wasn't a wording regression, just a relocation from "always shown while a repo is
+// selected" to "shown only in place of the Health Score total when a repo is selected".
+export const healthScoreFilterEmptyState = {
+  stateSelectAll: {
+    description: 'Select "All repositories" in order to get the aggregated Health Score',
+  },
+  stateUnavailable: {
+    title: 'Health Score Unavailable',
+    description: 'Health Score is unavailable for archived or excluded repositories.',
+  },
+};
+
 // Impact labels come from project_insights_copy.pipe's impactLabel multiIf: foundational (>=80),
 // major (>=60), significant (>=40), moderate (>=20), limited (below).
 export const impactLabelConfig: Record<string, string> = {

--- a/frontend/config/trust-score.ts
+++ b/frontend/config/trust-score.ts
@@ -35,10 +35,7 @@ export const getHealthScoreV2Config = (label: string | null): HealthScoreV2Confi
   return healthScoreV2Config.unavailable;
 };
 
-// Health Score empty-state copy for the repo-selector states (IN-1253). `stateSelectAll`
-// matches the wording of the pre-IN-1212 repo-scoping banner (see git history) so its
-// removal wasn't a wording regression, just a relocation from "always shown while a repo is
-// selected" to "shown only in place of the Health Score total when a repo is selected".
+// Health Score empty-state copy for the repo-selector states.
 export const healthScoreFilterEmptyState = {
   stateSelectAll: {
     description: 'Select "All repositories" in order to get the aggregated Health Score',

--- a/frontend/server/api/project/[slug]/overview/health-score-breakdown.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-breakdown.get.ts
@@ -14,10 +14,10 @@ export default defineEventHandler(async (event): Promise<HealthBreakdownResults>
   const repos = Array.isArray(rawRepos) ? rawRepos : rawRepos ? [rawRepos] : undefined;
 
   try {
-    // A repo filter is active: recompute the breakdown live for just the selected repos
-    // (IN-1253). The pipe filters out archived/excluded repos server-side, so a selection
-    // made up entirely of archived/excluded repos naturally has no matching rows - treat
-    // that as "no breakdown data" rather than an error.
+    // A repo filter is active: recompute the breakdown live for just the selected repos.
+    // The pipe filters out archived/excluded repos server-side, so a selection made up
+    // entirely of archived/excluded repos naturally has no matching rows - treat that as
+    // "no breakdown data" rather than an error.
     if (repos && repos.length > 0) {
       const res = await fetchFromTinybird<HealthBreakdownResults[]>(
         '/v0/pipes/repo_health_score_v2_breakdown.json',

--- a/frontend/server/api/project/[slug]/overview/health-score-breakdown.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-breakdown.get.ts
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event): Promise<HealthBreakdownResults>
     if (repos && repos.length > 0) {
       const res = await fetchFromTinybird<HealthBreakdownResults[]>(
         '/v0/pipes/repo_health_score_v2_breakdown.json',
-        { repos },
+        { slug, repos },
       );
       return (
         res.data[0] ?? {

--- a/frontend/server/api/project/[slug]/overview/health-score-breakdown.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-breakdown.get.ts
@@ -1,12 +1,81 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
+import { z } from 'zod';
 import { fetchFromTinybird } from '~~/server/data/tinybird/tinybird';
 import type { HealthBreakdownResults } from '~~/types/overview/responses.types';
 
+const querySchema = z.object({
+  repos: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
 export default defineEventHandler(async (event): Promise<HealthBreakdownResults> => {
   const slug = (event.context.params as { slug: string }).slug;
+  const { repos: rawRepos } = await getValidatedQuery(event, querySchema.parse);
+  const repos = Array.isArray(rawRepos) ? rawRepos : rawRepos ? [rawRepos] : undefined;
 
   try {
+    // A repo filter is active: recompute the breakdown live for just the selected repos
+    // (IN-1253). The pipe filters out archived/excluded repos server-side, so a selection
+    // made up entirely of archived/excluded repos naturally has no matching rows - treat
+    // that as "no breakdown data" rather than an error.
+    if (repos && repos.length > 0) {
+      const res = await fetchFromTinybird<HealthBreakdownResults[]>(
+        '/v0/pipes/repo_health_score_v2_breakdown.json',
+        { repos },
+      );
+      return (
+        res.data[0] ?? {
+          busFactorScore: null,
+          busFactorAvailable: null,
+          busFactorCount: null,
+          orgDiversityScore: null,
+          orgDiversityAvailable: null,
+          orgCount: null,
+          responsivenessScore: null,
+          responsivenessAvailable: null,
+          medianPrResponseS: null,
+          medianIssueResponseS: null,
+          isGerrit: null,
+          isExcluded: null,
+          openVulnScore: null,
+          openVulnAvailable: null,
+          openCriticals: null,
+          openHighs: null,
+          openModerates: null,
+          scorecardScorePts: null,
+          scorecardAvailable: null,
+          scorecardScore: null,
+          securityPracticesScore: null,
+          securityPracticesAvailable: null,
+          securityPolicyEnabled: null,
+          branchProtectionEnabled: null,
+          branchProtectionRequiredReviews: null,
+          branchProtectionRequiresStatusChecks: null,
+          branchProtectionAllowsForcePush: null,
+          dependencyHealthScore: null,
+          dependencyHealthAvailable: null,
+          vulnerableDeps: null,
+          releaseCadenceScore: null,
+          releaseCadenceAvailable: null,
+          daysSinceLatest: null,
+          daysBetweenRecent: null,
+          commitActivityScore: null,
+          commitsLast6m: null,
+          lastCommitAt: null,
+          issueResolutionScore: null,
+          issueResolutionAvailable: null,
+          closed12m: null,
+          opened12m: null,
+          medianCloseS: null,
+          prMergeScore: null,
+          prMergeAvailable: null,
+          merged12m: null,
+          closedUnmerged12m: null,
+          medianMergeS: null,
+        }
+      );
+    }
+
     const res = await fetchFromTinybird<HealthBreakdownResults[]>(
       '/v0/pipes/project_insights_health_breakdown.json',
       {

--- a/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
@@ -9,29 +9,46 @@ const querySchema = z.object({
   repos: z.union([z.string(), z.array(z.string())]).optional(),
 });
 
+interface RepoHealthScoreV2CategoryTotals {
+  healthScoreV2: number | null;
+  healthLabel: string | null;
+  maintainerHealthScoreV2: number | null;
+  securitySupplyChainScoreV2: number | null;
+  developmentActivityScoreV2: number | null;
+}
+
 export default defineEventHandler(async (event): Promise<HealthScoreV2Results> => {
   const slug = (event.context.params as { slug: string }).slug;
   const { repos: rawRepos } = await getValidatedQuery(event, querySchema.parse);
   const repos = Array.isArray(rawRepos) ? rawRepos : rawRepos ? [rawRepos] : undefined;
 
   try {
-    // A repo filter is active: Health Score/Impact totals are only ever shown for the
-    // full-project default, so only Lifecycle is fetched here, recomputed live for the
-    // selected repos via the repo-filtered pipe.
+    // A repo subset is selected: Health Score/breakdown/Lifecycle are recomputed live for just
+    // those repos. Whether the total is actually displayed (vs. suppressed with the "select all
+    // repositories" empty state, IN-1253 State 2) is a client-side decision based on whether the
+    // selection came from the top-of-page repo filter widget or a dedicated single-repo/group
+    // route — see `isRepoSelected`/`isRepoFilterActive` in overview.vue.
     if (repos && repos.length > 0) {
-      const res = await fetchFromTinybird<{ lifecycleLabel: string | null }[]>(
-        '/v0/pipes/repo_lifecycle_v2.json',
-        { slug, repos },
-      );
+      const [lifecycleRes, breakdownRes] = await Promise.all([
+        fetchFromTinybird<{ lifecycleLabel: string | null }[]>('/v0/pipes/repo_lifecycle_v2.json', {
+          slug,
+          repos,
+        }),
+        fetchFromTinybird<RepoHealthScoreV2CategoryTotals[]>(
+          '/v0/pipes/repo_health_score_v2_breakdown.json',
+          { slug, repos },
+        ),
+      ]);
+      const breakdown = breakdownRes.data[0];
       return {
-        healthScoreV2: null,
-        healthLabel: null,
-        lifecycleLabel: res.data[0]?.lifecycleLabel ?? null,
+        healthScoreV2: breakdown?.healthScoreV2 ?? null,
+        healthLabel: breakdown?.healthLabel ?? null,
+        lifecycleLabel: lifecycleRes.data[0]?.lifecycleLabel ?? null,
         impactScore: null,
         impactLabel: null,
-        maintainerHealthScoreV2: null,
-        securitySupplyChainScoreV2: null,
-        developmentActivityScoreV2: null,
+        maintainerHealthScoreV2: breakdown?.maintainerHealthScoreV2 ?? null,
+        securitySupplyChainScoreV2: breakdown?.securitySupplyChainScoreV2 ?? null,
+        developmentActivityScoreV2: breakdown?.developmentActivityScoreV2 ?? null,
       };
     }
 

--- a/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
@@ -21,7 +21,7 @@ export default defineEventHandler(async (event): Promise<HealthScoreV2Results> =
     if (repos && repos.length > 0) {
       const res = await fetchFromTinybird<{ lifecycleLabel: string | null }[]>(
         '/v0/pipes/repo_lifecycle_v2.json',
-        { repos },
+        { slug, repos },
       );
       return {
         healthScoreV2: null,

--- a/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
@@ -16,8 +16,8 @@ export default defineEventHandler(async (event): Promise<HealthScoreV2Results> =
 
   try {
     // A repo filter is active: Health Score/Impact totals are only ever shown for the
-    // full-project default (IN-1253), so only Lifecycle is fetched here, recomputed live
-    // for the selected repos via the repo-filtered pipe.
+    // full-project default, so only Lifecycle is fetched here, recomputed live for the
+    // selected repos via the repo-filtered pipe.
     if (repos && repos.length > 0) {
       const res = await fetchFromTinybird<{ lifecycleLabel: string | null }[]>(
         '/v0/pipes/repo_lifecycle_v2.json',

--- a/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
+++ b/frontend/server/api/project/[slug]/overview/health-score-v2.get.ts
@@ -1,13 +1,40 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
+import { z } from 'zod';
 import { fetchFromTinybird } from '~~/server/data/tinybird/tinybird';
 import type { ProjectInsightsTinybird } from '~~/types/project';
 import type { HealthScoreV2Results } from '~~/types/overview/responses.types';
 
+const querySchema = z.object({
+  repos: z.union([z.string(), z.array(z.string())]).optional(),
+});
+
 export default defineEventHandler(async (event): Promise<HealthScoreV2Results> => {
   const slug = (event.context.params as { slug: string }).slug;
+  const { repos: rawRepos } = await getValidatedQuery(event, querySchema.parse);
+  const repos = Array.isArray(rawRepos) ? rawRepos : rawRepos ? [rawRepos] : undefined;
 
   try {
+    // A repo filter is active: Health Score/Impact totals are only ever shown for the
+    // full-project default (IN-1253), so only Lifecycle is fetched here, recomputed live
+    // for the selected repos via the repo-filtered pipe.
+    if (repos && repos.length > 0) {
+      const res = await fetchFromTinybird<{ lifecycleLabel: string | null }[]>(
+        '/v0/pipes/repo_lifecycle_v2.json',
+        { repos },
+      );
+      return {
+        healthScoreV2: null,
+        healthLabel: null,
+        lifecycleLabel: res.data[0]?.lifecycleLabel ?? null,
+        impactScore: null,
+        impactLabel: null,
+        maintainerHealthScoreV2: null,
+        securitySupplyChainScoreV2: null,
+        developmentActivityScoreV2: null,
+      };
+    }
+
     const res = await fetchFromTinybird<ProjectInsightsTinybird[]>(
       '/v0/pipes/project_insights.json',
       {


### PR DESCRIPTION
## Summary
The Overview page's repo filter didn't affect Health Score, Health Score breakdown, Lifecycle, or Impact — they were always project-wide. This threads the selected repos through to those sections with three states:

- **All repos (default)**: Health Score total, breakdown, Lifecycle, and Impact all aggregated project-wide (unchanged).
- **Subset selected (mixed archived+active allowed)**: Health Score total hidden with `Select "All repositories" in order to get the aggregated Health Score`; breakdown and Lifecycle recomputed live for just the selection via the new `repo_health_score_v2_breakdown`/`repo_lifecycle_v2` pipes.
- **Selection is entirely archived/excluded repos**: distinct `Health Score Unavailable` empty state (not the "select all" copy, since selecting all wouldn't fix this); Lifecycle still computed for the selection.
- Dedicated single-repo (`/repository/[name]`) and repo-group (`/repository-group/[slug]`) routes always show their own scoped total — they never hit the "select all" empty state, since there's no "select all" control on those routes.

Depends on linuxfoundation/crowd.dev#4528 (already deployed to production) for the two new pipes.

## Test plan
- [x] `pnpm lint` / `pnpm tsc-check` / `pnpm test` all green
- [x] QA loop (crowd-insights-qa): all 5 acceptance criteria PASS against the live `/project/k8s` page
- [x] Multi-persona QA pass: confirmed all 3 states, mixed-selection behavior, and cross-project pipe scoping (foreign-repo leak test) correct on fresh page loads
- [ ] **Known follow-up, not fixed in this PR**: a pre-existing bug in the repo-filter dropdown/header component (`components/modules/project/components/shared/header.vue`, last touched by IN-1001, untouched by this PR) causes unreliable client-side navigation — including stale data shown after navigating to the single-repo/group routes via the dropdown, and a mobile-viewport state desync. Confirmed via `git diff` that this PR never touches that file, and via code review that this PR's own reactive data-fetching wiring is correct end-to-end. Recommend filing as a separate, standalone bug — see PR discussion for full repro details.