### PR TITLE
fix: correct open vulnerability count and unknown-severity scoring IN-1255

### DIFF
--- a/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts
+++ b/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts
@@ -5,12 +5,9 @@ import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import VulnerabilitySummary from './vulnerability-summary.vue';
 
-// Mock dependencies so the component can be mounted in isolation.
 vi.mock('~/components/modules/project/services/vulnerability.api.service', () => ({
   VULNERABILITY_API_SERVICE: {
     fetchVulnerabilitySummary: vi.fn(() => ({
-      // openclaw production data (IN-1255): count=18, fixedPercentage=87.32.
-      // The real OPEN-status count from the vulnerabilities_list Tinybird pipe is 16.
       data: ref({
         count: 18,
         openCount: 16,
@@ -32,8 +29,8 @@ vi.mock('~/components/uikit/toast/toast.service', () => ({
   }),
 }));
 
-describe('vulnerability-summary.vue IN-1255', () => {
-  test('open vulnerabilities count should match real OPEN-status count (fails on current fixedPercentage-derived formula)', () => {
+describe('vulnerability-summary.vue', () => {
+  test('open vulnerabilities count uses the real OPEN-status count, not one derived from fixedPercentage', () => {
     const wrapper = mount(VulnerabilitySummary, {
       props: {
         params: { projectSlug: 'openclaw' },
@@ -46,11 +43,6 @@ describe('vulnerability-summary.vue IN-1255', () => {
       },
     });
 
-    // Real OPEN-status count for openclaw, per the vulnerabilities_list Tinybird pipe
-    // (status=OPEN&count=true), is 16.
-    // Current formula: count - round(fixedPercentage/100 * count) = 18 - round(0.8732*18) = 18 - 16 = 2.
-    // This assertion fails against current code (renders "2") and is expected to pass once the
-    // fix consumes a real openCount field instead of deriving it from fixedPercentage.
     const openVulnerabilitiesText = wrapper.find('p.text-xl').text();
 
     expect(openVulnerabilitiesText).toBe('16');

--- a/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts
+++ b/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi } from 'vitest';
+import { mount } from '@vue/test-utils';
+import { ref } from 'vue';
+import VulnerabilitySummary from './vulnerability-summary.vue';
+
+// Mock dependencies so the component can be mounted in isolation.
+vi.mock('~/components/modules/project/services/vulnerability.api.service', () => ({
+  VULNERABILITY_API_SERVICE: {
+    fetchVulnerabilitySummary: vi.fn(() => ({
+      // openclaw production data (IN-1255): count=18, fixedPercentage=87.32.
+      // The real OPEN-status count from the vulnerabilities_list Tinybird pipe is 16.
+      data: ref({
+        count: 18,
+        openCount: 16,
+        fixedPercentage: 87.32,
+        daysSinceLastVuln: 5,
+        avgCvssScore: 7.2,
+        ecosystems: ['npm'],
+        lastScanStatus: 'completed',
+      }),
+      error: ref(null),
+      isLoading: ref(false),
+    })),
+  },
+}));
+
+vi.mock('~/components/uikit/toast/toast.service', () => ({
+  default: () => ({
+    showToast: vi.fn(),
+  }),
+}));
+
+describe('vulnerability-summary.vue IN-1255', () => {
+  test('open vulnerabilities count should match real OPEN-status count (fails on current fixedPercentage-derived formula)', () => {
+    const wrapper = mount(VulnerabilitySummary, {
+      props: {
+        params: { projectSlug: 'openclaw' },
+      },
+      global: {
+        stubs: {
+          LfxTooltip: { template: '<div><slot /><slot name="content" /></div>' },
+          LfxSkeleton: { template: '<div></div>' },
+        },
+      },
+    });
+
+    // Real OPEN-status count for openclaw, per the vulnerabilities_list Tinybird pipe
+    // (status=OPEN&count=true), is 16.
+    // Current formula: count - round(fixedPercentage/100 * count) = 18 - round(0.8732*18) = 18 - 16 = 2.
+    // This assertion fails against current code (renders "2") and is expected to pass once the
+    // fix consumes a real openCount field instead of deriving it from fixedPercentage.
+    const openVulnerabilitiesText = wrapper.find('p.text-xl').text();
+
+    expect(openVulnerabilitiesText).toBe('16');
+  });
+});

--- a/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts
+++ b/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts
@@ -4,6 +4,7 @@ import { describe, test, expect, vi } from 'vitest';
 import { mount } from '@vue/test-utils';
 import { ref } from 'vue';
 import VulnerabilitySummary from './vulnerability-summary.vue';
+import { VULNERABILITY_API_SERVICE } from '~/components/modules/project/services/vulnerability.api.service';
 
 vi.mock('~/components/modules/project/services/vulnerability.api.service', () => ({
   VULNERABILITY_API_SERVICE: {
@@ -46,5 +47,28 @@ describe('vulnerability-summary.vue', () => {
     const openVulnerabilitiesText = wrapper.find('p.text-xl').text();
 
     expect(openVulnerabilitiesText).toBe('16');
+  });
+
+  test('renders no summary fields for a never-scanned project (undefined data)', () => {
+    vi.mocked(VULNERABILITY_API_SERVICE.fetchVulnerabilitySummary).mockReturnValueOnce({
+      data: ref(undefined),
+      error: ref(null),
+      isLoading: ref(false),
+    } as unknown as ReturnType<typeof VULNERABILITY_API_SERVICE.fetchVulnerabilitySummary>);
+
+    const wrapper = mount(VulnerabilitySummary, {
+      props: {
+        params: { projectSlug: 'never-scanned' },
+      },
+      global: {
+        stubs: {
+          LfxTooltip: { template: '<div><slot /><slot name="content" /></div>' },
+          LfxSkeleton: { template: '<div></div>' },
+        },
+      },
+    });
+
+    expect(wrapper.text()).not.toContain('undefined');
+    expect(wrapper.text()).not.toContain('NaN');
   });
 });

--- a/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.vue
+++ b/frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.vue
@@ -165,7 +165,7 @@ const fixedCount = computed(() => {
 
 const openVulnerabilities = computed(() => {
   if (!data.value) return 0;
-  return data.value.count - fixedCount.value;
+  return data.value.openCount;
 });
 
 const formattedOpenVulnerabilities = computed(() => formatNumber(openVulnerabilities.value));

--- a/frontend/config/health-breakdown-templates.ts
+++ b/frontend/config/health-breakdown-templates.ts
@@ -473,27 +473,26 @@ export const getOpenVulnRow = (signals: HealthBreakdownResults): SignalRow => {
   const criticals = signals.openCriticals ?? 0;
   const highs = signals.openHighs ?? 0;
   const moderates = signals.openModerates ?? 0;
-  if (signals.openVulnScore >= 10) {
-    return { status: 'positive', description: 'No open vulnerabilities of any severity.' };
-  }
-  if (signals.openVulnScore >= 5) {
-    const parts: string[] = [];
-    if (criticals + highs > 0)
-      parts.push(
-        `${criticals + highs} critical or high vulnerabilit${criticals + highs === 1 ? 'y' : 'ies'}`,
-      );
-    if (moderates > 0)
-      parts.push(`${moderates} medium or low vulnerabilit${moderates === 1 ? 'y' : 'ies'}`);
+  const unknowns = signals.openUnknowns ?? 0;
+  if (criticals + highs > 0) {
     return {
-      status: 'warning',
-      description:
-        parts.length > 0 ? `${parts.join(', ')} open.` : 'Some open vulnerabilities detected.',
+      status: 'negative',
+      description: `${criticals + highs} open critical or high vulnerabilit${criticals + highs === 1 ? 'y' : 'ies'}.`,
     };
   }
-  return {
-    status: 'negative',
-    description: `${criticals + highs} open critical or high vulnerabilit${criticals + highs === 1 ? 'y' : 'ies'}.`,
-  };
+  if (moderates > 0) {
+    return {
+      status: 'warning',
+      description: `${moderates} open medium/low severity vulnerabilit${moderates === 1 ? 'y' : 'ies'}, no critical or high.`,
+    };
+  }
+  if (unknowns > 0) {
+    return {
+      status: 'warning',
+      description: `${unknowns} open vulnerabilit${unknowns === 1 ? 'y' : 'ies'} with unscored severity (e.g. unmaintained dependencies).`,
+    };
+  }
+  return { status: 'positive', description: 'No open vulnerabilities of any severity.' };
 };
 
 export const getScorecardRow = (signals: HealthBreakdownResults): SignalRow => {

--- a/frontend/server/api/project/[slug]/security/vulnerabilities-summary.get.ts
+++ b/frontend/server/api/project/[slug]/security/vulnerabilities-summary.get.ts
@@ -26,7 +26,9 @@ export default defineEventHandler(async (event): Promise<VulnerabilitiesSummary 
         count: true,
       }),
     ]);
-    return { ...summaryRes.data[0], openCount: openCountRes.data[0]?.count ?? 0 };
+    return summaryRes.data[0]
+      ? { ...summaryRes.data[0], openCount: openCountRes.data[0]?.count ?? 0 }
+      : undefined;
   } catch (err: unknown) {
     if (err && typeof err === 'object' && 'statusCode' in err && err.statusCode === 404) throw err;
     console.error('Error fetching vulnerabilities summary:', err);

--- a/frontend/server/api/project/[slug]/security/vulnerabilities-summary.get.ts
+++ b/frontend/server/api/project/[slug]/security/vulnerabilities-summary.get.ts
@@ -14,11 +14,19 @@ export default defineEventHandler(async (event): Promise<VulnerabilitiesSummary 
   const project = (event.context.params as { slug: string }).slug;
 
   try {
-    const res = await fetchFromTinybird<VulnerabilitiesSummary[]>(
-      '/v0/pipes/vulnerabilities_summary.json',
-      { project, repos },
-    );
-    return res.data[0];
+    const [summaryRes, openCountRes] = await Promise.all([
+      fetchFromTinybird<VulnerabilitiesSummary[]>('/v0/pipes/vulnerabilities_summary.json', {
+        project,
+        repos,
+      }),
+      fetchFromTinybird<{ count: number }[]>('/v0/pipes/vulnerabilities_list.json', {
+        project,
+        repos,
+        status: 'OPEN',
+        count: true,
+      }),
+    ]);
+    return { ...summaryRes.data[0], openCount: openCountRes.data[0]?.count ?? 0 };
   } catch (err: unknown) {
     if (err && typeof err === 'object' && 'statusCode' in err && err.statusCode === 404) throw err;
     console.error('Error fetching vulnerabilities summary:', err);

--- a/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
+++ b/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
@@ -4,7 +4,7 @@ import { describe, test, expect } from 'vitest';
 import { getOpenVulnRow } from '../../config/health-breakdown-templates';
 import type { HealthBreakdownResults } from '../../types/overview/responses.types';
 
-describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities IN-1255', () => {
+describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities', () => {
   const defaultSignals: HealthBreakdownResults = {
     busFactorScore: null,
     busFactorAvailable: false,
@@ -58,10 +58,7 @@ describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities IN-1255', () => {
     medianMergeS: null,
   };
 
-  test('reports "positive" (clean) even though 16 UNKNOWN-severity OPEN vulnerabilities exist', () => {
-    // openclaw production data (IN-1255): all known-severity open counts are 0 and
-    // openVulnScore is a perfect 10, but there are 16 OPEN vulnerabilities of UNKNOWN
-    // severity that none of openCriticals/openHighs/openModerates track.
+  test('reports "warning", not "positive", when only UNKNOWN-severity open vulnerabilities exist', () => {
     const signals: HealthBreakdownResults = {
       ...defaultSignals,
       openVulnAvailable: true,
@@ -74,11 +71,6 @@ describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities IN-1255', () => {
 
     const result = getOpenVulnRow(signals);
 
-    // Bug: getOpenVulnRow has no visibility into UNKNOWN-severity open vulns, so it
-    // falls through to the openVulnScore >= 10 branch and reports a false "clean" ('positive')
-    // status instead of the 'warning' status warranted by the 16 untracked open vulnerabilities.
-    // This assertion fails against current code (actual status is 'positive') and is expected
-    // to pass once an `openUnknowns` field is added and threaded into this function.
     expect(result.status).toBe('warning');
   });
 
@@ -134,9 +126,6 @@ describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities IN-1255', () => {
   });
 
   test('treats a null severity count as 0/absent rather than as a positive signal', () => {
-    // fails before fix: the original code had no unknowns handling at all, so this
-    // boundary case (null openUnknowns alongside all-zero known counts) only becomes
-    // meaningful once getOpenVulnRow's `?? 0` coalescing exists for every count.
     const signals: HealthBreakdownResults = {
       ...defaultSignals,
       openVulnAvailable: true,

--- a/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
+++ b/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
@@ -81,4 +81,75 @@ describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities IN-1255', () => {
     // to pass once an `openUnknowns` field is added and threaded into this function.
     expect(result.status).toBe('warning');
   });
+
+  test('reports "negative" when there are open critical or high severity vulnerabilities', () => {
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      openVulnAvailable: true,
+      openVulnScore: 2,
+      openCriticals: 1,
+      openHighs: 2,
+      openModerates: 5,
+      openUnknowns: 5,
+    };
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('negative');
+    expect(result.description).toBe('3 open critical or high vulnerabilities.');
+  });
+
+  test('reports "warning" for open moderate-severity vulnerabilities when no criticals or highs are open', () => {
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      openVulnAvailable: true,
+      openVulnScore: 6,
+      openCriticals: 0,
+      openHighs: 0,
+      openModerates: 4,
+      openUnknowns: 0,
+    };
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('warning');
+    expect(result.description).toBe('4 open medium/low severity vulnerabilities, no critical or high.');
+  });
+
+  test('reports "positive" when all open vulnerability severity counts are zero', () => {
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      openVulnAvailable: true,
+      openVulnScore: 10,
+      openCriticals: 0,
+      openHighs: 0,
+      openModerates: 0,
+      openUnknowns: 0,
+    };
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('positive');
+    expect(result.description).toBe('No open vulnerabilities of any severity.');
+  });
+
+  test('treats a null severity count as 0/absent rather than as a positive signal', () => {
+    // fails before fix: the original code had no unknowns handling at all, so this
+    // boundary case (null openUnknowns alongside all-zero known counts) only becomes
+    // meaningful once getOpenVulnRow's `?? 0` coalescing exists for every count.
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      openVulnAvailable: true,
+      openVulnScore: 10,
+      openCriticals: 0,
+      openHighs: 0,
+      openModerates: 0,
+      openUnknowns: null,
+    };
+
+    const result = getOpenVulnRow(signals);
+
+    expect(result.status).toBe('positive');
+    expect(result.description).toBe('No open vulnerabilities of any severity.');
+  });
 });

--- a/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
+++ b/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
@@ -105,7 +105,9 @@ describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities', () => {
     const result = getOpenVulnRow(signals);
 
     expect(result.status).toBe('warning');
-    expect(result.description).toBe('4 open medium/low severity vulnerabilities, no critical or high.');
+    expect(result.description).toBe(
+      '4 open medium/low severity vulnerabilities, no critical or high.',
+    );
   });
 
   test('reports "positive" when all open vulnerability severity counts are zero', () => {

--- a/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
+++ b/frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect } from 'vitest';
+import { getOpenVulnRow } from '../../config/health-breakdown-templates';
+import type { HealthBreakdownResults } from '../../types/overview/responses.types';
+
+describe('getOpenVulnRow UNKNOWN-severity open vulnerabilities IN-1255', () => {
+  const defaultSignals: HealthBreakdownResults = {
+    busFactorScore: null,
+    busFactorAvailable: false,
+    busFactorCount: null,
+    orgDiversityScore: null,
+    orgDiversityAvailable: false,
+    orgCount: null,
+    responsivenessScore: null,
+    responsivenessAvailable: false,
+    medianPrResponseS: null,
+    medianIssueResponseS: null,
+    isGerrit: false,
+    isExcluded: false,
+
+    openVulnScore: null,
+    openVulnAvailable: false,
+    openCriticals: null,
+    openHighs: null,
+    openModerates: null,
+    openUnknowns: null,
+    scorecardScorePts: null,
+    scorecardAvailable: false,
+    scorecardScore: null,
+    securityPracticesScore: null,
+    securityPracticesAvailable: false,
+    securityPolicyEnabled: null,
+    branchProtectionEnabled: null,
+    branchProtectionRequiredReviews: null,
+    branchProtectionRequiresStatusChecks: null,
+    branchProtectionAllowsForcePush: null,
+    dependencyHealthScore: null,
+    dependencyHealthAvailable: false,
+    vulnerableDeps: null,
+
+    releaseCadenceScore: null,
+    releaseCadenceAvailable: false,
+    daysSinceLatest: null,
+    daysBetweenRecent: null,
+    commitActivityScore: null,
+    commitsLast6m: null,
+    lastCommitAt: null,
+    issueResolutionScore: null,
+    issueResolutionAvailable: false,
+    closed12m: null,
+    opened12m: null,
+    medianCloseS: null,
+    prMergeScore: null,
+    prMergeAvailable: false,
+    merged12m: null,
+    closedUnmerged12m: null,
+    medianMergeS: null,
+  };
+
+  test('reports "positive" (clean) even though 16 UNKNOWN-severity OPEN vulnerabilities exist', () => {
+    // openclaw production data (IN-1255): all known-severity open counts are 0 and
+    // openVulnScore is a perfect 10, but there are 16 OPEN vulnerabilities of UNKNOWN
+    // severity that none of openCriticals/openHighs/openModerates track.
+    const signals: HealthBreakdownResults = {
+      ...defaultSignals,
+      openVulnAvailable: true,
+      openVulnScore: 10,
+      openCriticals: 0,
+      openHighs: 0,
+      openModerates: 0,
+      openUnknowns: 16,
+    };
+
+    const result = getOpenVulnRow(signals);
+
+    // Bug: getOpenVulnRow has no visibility into UNKNOWN-severity open vulns, so it
+    // falls through to the openVulnScore >= 10 branch and reports a false "clean" ('positive')
+    // status instead of the 'warning' status warranted by the 16 untracked open vulnerabilities.
+    // This assertion fails against current code (actual status is 'positive') and is expected
+    // to pass once an `openUnknowns` field is added and threaded into this function.
+    expect(result.status).toBe('warning');
+  });
+});

--- a/frontend/types/overview/responses.types.ts
+++ b/frontend/types/overview/responses.types.ts
@@ -109,6 +109,7 @@ export interface HealthBreakdownResults {
   openCriticals: number | null;
   openHighs: number | null;
   openModerates: number | null;
+  openUnknowns: number | null;
   scorecardScorePts: number | null;
   scorecardAvailable: boolean | null;
   scorecardScore: number | null;

--- a/frontend/types/security/vulnerabilities.types.ts
+++ b/frontend/types/security/vulnerabilities.types.ts
@@ -3,6 +3,7 @@
 
 export interface VulnerabilitiesSummary {
   count: number;
+  openCount: number;
   fixedPercentage: number;
   daysSinceLastVuln: number;
   avgCvssScore: number;

--- a/frontend/types/vulnerabilities/responses.types.ts
+++ b/frontend/types/vulnerabilities/responses.types.ts
@@ -98,6 +98,7 @@ export const STATUS_OPTIONS = Object.values(STATUS_CONFIG);
 
 export interface VulnerabilitySummary {
   count: number;
+  openCount: number;
   fixedPercentage: number;
   daysSinceLastVuln: number;
   avgCvssScore: number;


### PR DESCRIPTION
## Summary

- The vulnerability summary widget derived its open-vulnerability count from `fixedPercentage` (a resolved ratio), which undercounted UNKNOWN-severity vulns. It now calls `vulnerabilities_list` with `status=OPEN, count=true` and uses that count directly.
- `getOpenVulnRow()` branched only on `openVulnScore`, so a project with only UNKNOWN-severity open vulns scored a false "positive." It now branches explicitly on `openCriticals + openHighs`, `openModerates`, and a new `openUnknowns` field.
- `openUnknowns` depends on a matching Tinybird field added in a companion crowd.dev PR — see Deploy order below. No other data model or scoring changes.

## Changes

| File | What changed |
|------|-------------|
| `frontend/server/api/project/[slug]/security/vulnerabilities-summary.get.ts` | Added a parallel `vulnerabilities_list` call (`status=OPEN, count=true`) and merged its count into the response as `openCount` |
| `frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.vue` | `openVulnerabilities` now reads `data.value.openCount` instead of `count - fixedCount` |
| `frontend/config/health-breakdown-templates.ts` | `getOpenVulnRow()` rewritten to branch on `openCriticals+openHighs` / `openModerates` / `openUnknowns` instead of the `openVulnScore` threshold |
| `frontend/types/overview/responses.types.ts` | Added `openUnknowns: number \| null` to `HealthBreakdownResults` |
| `frontend/types/security/vulnerabilities.types.ts`, `frontend/types/vulnerabilities/responses.types.ts` | Added `openCount: number` to the summary response types |
| `frontend/app/components/modules/project/components/vulnerabilities/vulnerability-summary.test.ts` | New test: open-vulnerabilities figure renders from `openCount`, not the fixed-percentage derivation |
| `frontend/test/config/health-breakdown-templates-open-vuln-unknown-severity.test.ts` | Full branch coverage for `getOpenVulnRow` — criticals/highs, moderates, unknowns-only, all-zero, and null-as-absent |

## JIRA

[IN-1255](https://linuxfoundation.atlassian.net/browse/IN-1255) — Fix open vulnerability count and scoring for unknown severity vulns

## Deploy order

1. crowd.dev `fix/IN-1255-open-vuln-severity`: deploy first. It adds the `openUnknowns` Tinybird field this PR reads. Until it's live in production, `HealthBreakdownResults.openUnknowns` is `null`/absent, which `getOpenVulnRow()` already treats as 0 (see the null-as-absent test) — so this insights PR degrades safely but won't show the UNKNOWN-severity branch until the pipe deploys.
2. This PR: merge and deploy after the Tinybird field is confirmed live.

## DB migrations

_No DB migrations._

## Test plan

- [ ] `pnpm test` passes (both new test files, plus existing suites)
- [ ] Manually verify a project with only UNKNOWN-severity open vulns: summary widget open count matches the real OPEN-status count, and the health breakdown row shows "warning" (not a false "positive")
- [ ] Manually verify a project with open critical/high vulns still shows "negative" with the correct combined count
- [ ] Manually verify a project with zero open vulns of any severity still shows "positive"
- [ ] After the companion crowd.dev PR deploys, confirm `openUnknowns` arrives non-null from the pipe in a real project response
- [ ] No regression in the existing moderate-severity ("warning") path

## Checklist

- [x] `git commit --signoff -S` on every commit
- [x] MIT license header on every new source file
- [x] PR diff < 1000 lines (~227 insertions, 23 deletions)
- [x] No unrelated changes bundled
- [x] Cross-repo impact documented (companion crowd.dev PR, deploy order above)


[IN-1255]: https://linuxfoundation.atlassian.net/browse/IN-1255?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ