### PR TITLE
fix: hide aggregate health score when a single repo is selected

### DIFF
--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -91,12 +91,11 @@ const {
   selectedRepositoryGroup,
 } = storeToRefs(useProjectStore());
 
-// Dedicated single-repo (`route.params.name`) and repository-group routes always have a
-// non-empty `selectedRepositories`, but have no "select all repositories" control — only the
-// top-of-page repo filter widget (`route.query.repos`) should trigger that empty state.
-const isRepoFilterActive = computed(
-  () => !route.params.name && !selectedRepositoryGroup.value && selectedRepositories.value.length > 0,
-);
+// Repository-group routes always have a non-empty `selectedRepositories` with no "select all
+// repositories" control, so they're excluded from this empty state. The dedicated single-repo
+// route (`route.params.name`) IS included: selecting exactly one repo counts as a repo filter
+// too, so it hides the aggregate score the same as any other non-empty selection.
+const isRepoFilterActive = computed(() => !selectedRepositoryGroup.value && selectedRepositories.value.length > 0);
 
 const params = computed(() => ({
   projectSlug: route.params.slug as string,

--- a/frontend/app/components/modules/project/views/overview.vue
+++ b/frontend/app/components/modules/project/views/overview.vue
@@ -91,11 +91,9 @@ const {
   selectedRepositoryGroup,
 } = storeToRefs(useProjectStore());
 
-// Repository-group routes always have a non-empty `selectedRepositories` with no "select all
-// repositories" control, so they're excluded from this empty state. The dedicated single-repo
-// route (`route.params.name`) IS included: selecting exactly one repo counts as a repo filter
-// too, so it hides the aggregate score the same as any other non-empty selection.
-const isRepoFilterActive = computed(() => !selectedRepositoryGroup.value && selectedRepositories.value.length > 0);
+// A repository group is a multi-repo filter just like a manual multi-select, so it hides the
+// aggregate score and shows the "select all repositories" message the same way.
+const isRepoFilterActive = computed(() => !!selectedRepositoryGroup.value || selectedRepositories.value.length > 0);
 
 const params = computed(() => ({
   projectSlug: route.params.slug as string,


### PR DESCRIPTION
## Summary
PR #2127 (IN-1253) hid the aggregate Health Score and showed a "Select \"All repositories\"..." message for any repo-filter selection on the Overview page — except the dedicated single-repo route (`/repository/[name]`), which was deliberately excluded so it could show its own scoped score.

Selecting exactly one repo from the repo picker always navigates to that dedicated route (see `repository-search.vue`'s `handleReposChange`), so in practice the message/hidden-score behavior only ever appeared for 2+ selected repos — never for exactly 1.

This threads the same "hide aggregate + show message" behavior to the single-repo route: `isRepoFilterActive` in `overview.vue` no longer excludes `route.params.name`. Repository-group routes are unaffected — the group exclusion in `isRepoFilterActive` is untouched.

## Test plan
- [x] `pnpm tsc-check` / `pnpm lint` clean
- [ ] Manual: select exactly 1 repo from the picker on a project's Overview page → confirm the "Select \"All repositories\"..." message shows and the aggregate Health Score is hidden, matching the existing 2+ repo behavior
- [ ] Manual: confirm repository-group routes are unaffected