### PR TITLE
fix: use accent color for fair health score, not concerning's amber

### DIFF
--- a/frontend/app/components/modules/collection/components/details/collection-health-score-pill.vue
+++ b/frontend/app/components/modules/collection/components/details/collection-health-score-pill.vue
@@ -132,7 +132,8 @@ const healthScoreDotClass = computed(() => {
 
 const progressBarColor = computed(() => {
   if (band.value === 'excellent' || band.value === 'healthy') return 'positive';
-  if (band.value === 'fair' || band.value === 'concerning') return 'warning';
+  if (band.value === 'fair') return 'accent';
+  if (band.value === 'concerning') return 'warning';
   return 'negative';
 });
 

--- a/frontend/app/components/modules/project/components/overview/trust-score-v2.vue
+++ b/frontend/app/components/modules/project/components/overview/trust-score-v2.vue
@@ -230,8 +230,8 @@ const scoreLabel = computed(() => getHealthScoreV2Config(props.healthLabel).labe
 const scoreColorHex = computed(() => {
   const label = props.healthLabel;
   if (label === 'excellent' || label === 'healthy') return lfxColors.positive[500];
-  if (label === 'fair') return lfxColors.accent[500];
-  if (label === 'concerning') return lfxColors.warning[500];
+  if (label === 'fair') return lfxColors.health.fair;
+  if (label === 'concerning') return lfxColors.health.concerning;
   return lfxColors.negative[500];
 });
 

--- a/frontend/app/components/shared/components/__tests__/health-score.spec.ts
+++ b/frontend/app/components/shared/components/__tests__/health-score.spec.ts
@@ -1,0 +1,14 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { mount } from '@vue/test-utils';
+import HealthScore from '../health-score.vue';
+
+describe('health-score.vue', () => {
+  it('renders the Fair band with the accent tag variation', () => {
+    const wrapper = mount(HealthScore, { props: { score: 60 } });
+
+    expect(wrapper.text()).toContain('Fair');
+    expect(wrapper.find('.c-tag--accent').exists()).toBe(true);
+  });
+});

--- a/frontend/app/components/shared/components/health-score.vue
+++ b/frontend/app/components/shared/components/health-score.vue
@@ -30,7 +30,7 @@ SPDX-License-Identifier: MIT
   </lfx-tag>
   <lfx-tag
     v-else-if="props.score >= 50"
-    variation="info"
+    variation="accent"
   >
     Fair
   </lfx-tag>

--- a/frontend/app/components/uikit/progress-bar/progress-bar.scss
+++ b/frontend/app/components/uikit/progress-bar/progress-bar.scss
@@ -22,6 +22,11 @@
       @apply bg-positive-500;
     }
   }
+  &--accent {
+    .c-progress-bar__value {
+      @apply bg-accent-500;
+    }
+  }
   &--warning {
     .c-progress-bar__value {
       @apply bg-warning-500;

--- a/frontend/app/components/uikit/progress-bar/types/progress-bar.types.ts
+++ b/frontend/app/components/uikit/progress-bar/types/progress-bar.types.ts
@@ -1,5 +1,5 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-export const progressBarTypes = ['normal', 'positive', 'warning', 'negative'] as const;
+export const progressBarTypes = ['normal', 'positive', 'accent', 'warning', 'negative'] as const;
 
 export type ProgressBarType = (typeof progressBarTypes)[number];

--- a/frontend/app/components/uikit/tag/tag.scss
+++ b/frontend/app/components/uikit/tag/tag.scss
@@ -16,6 +16,10 @@
     @apply bg-brand-50 text-brand-600;
   }
 
+  &--accent {
+    @apply bg-accent-50 text-accent-600;
+  }
+
   &--positive {
     @apply bg-positive-50 text-positive-600;
   }

--- a/frontend/app/components/uikit/tag/tag.scss
+++ b/frontend/app/components/uikit/tag/tag.scss
@@ -17,7 +17,7 @@
   }
 
   &--accent {
-    @apply bg-accent-50 text-accent-600;
+    @apply bg-accent-50 text-accent-500;
   }
 
   &--positive {

--- a/frontend/app/components/uikit/tag/types/tag.types.ts
+++ b/frontend/app/components/uikit/tag/types/tag.types.ts
@@ -4,6 +4,7 @@ export const tagStyles = [
   'default',
   'neutral',
   'info',
+  'accent',
   'positive',
   'warning',
   'negative',

--- a/frontend/app/config/styles/__tests__/colors.spec.ts
+++ b/frontend/app/config/styles/__tests__/colors.spec.ts
@@ -1,0 +1,15 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, it, expect } from 'vitest';
+import { lfxColors } from '../colors';
+
+describe('lfxColors.health', () => {
+  it('gives fair and concerning distinct colors', () => {
+    expect(lfxColors.health.fair).not.toBe(lfxColors.health.concerning);
+  });
+
+  it('uses the accent color for fair and the warning color for concerning', () => {
+    expect(lfxColors.health.fair).toBe(lfxColors.accent[500]);
+    expect(lfxColors.health.concerning).toBe(lfxColors.warning[500]);
+  });
+});

--- a/frontend/app/config/styles/colors.ts
+++ b/frontend/app/config/styles/colors.ts
@@ -112,12 +112,11 @@ export const lfxColors = {
   // TODO: Verify with Nuno what color alias we should use
   yellow: '#FFD6A7',
   // Health-score tier colors — Figma-exact hexes, distinct from the generic positive/warning/negative
-  // scale. TODO: Verify with Nuno whether these should be folded into an existing scale.
   health: {
     excellent: '#00bc7d',
     healthy: '#00bc7d',
-    fair: '#fe9a00',
-    concerning: '#fe9a00',
+    fair: '#009AFF',
+    concerning: '#F59E0B',
     critical: '#fb2c36',
   },
 };


### PR DESCRIPTION
## Summary

The "Fair" health-score band rendered amber in the collection projects table because `colors.ts` aliased `health.fair` and `health.concerning` to the same hex (`#fe9a00`). The project overview page used a separate lookup and rendered fair correctly as accent-blue, so the two views disagreed on the same rating.

- `health.fair` now resolves to `#009AFF` (`accent[500]`), matching the project overview page and the confirmed content-spec.
- `health.concerning` now resolves to `#F59E0B` (`warning[500]`), distinct from fair.
- Removed the stale TODO comment that flagged this exact color ambiguity — it's resolved.
- Added `colors.spec.ts` asserting `fair !== concerning` and both match the correct scale values, so a future edit can't silently re-collapse them.
- `health-score.vue`'s Fair tag used the `info` variation, which renders `accent[600]` (`#0082D9`), not `accent[500]` (`#009AFF`). Added a new `accent` variation to the `lfx-tag` uikit component and switched the Fair tag to it.
- That new `accent` variation initially applied `text-accent-600` — still the wrong shade. Corrected it to `text-accent-500` so the tag's rendered text color is an exact hex match to the spec's `#009AFF`, not an adjacent shade.

Colors were confirmed against the linked Health Score v2 content-spec doc (Section 3), not Figma — the ticket has no Figma link.

Two follow-up fixes for items originally flagged as out of scope:

- The health-score progress bar (`collection-health-score-pill.vue`) still rendered amber for "Fair" because the `lfx-progress-bar` uikit component had no `accent` color variant. Added an `accent` variant to `lfx-progress-bar` and switched the pill's Fair mapping to use it; Concerning still maps to `warning`.
- `trust-score-v2.vue` derived the fair/concerning colors independently (`lfxColors.accent[500]`/`lfxColors.warning[500]`) instead of using `lfxColors.health.fair`/`.concerning`, so the mapping existed in two unlinked places that happened to agree. It now reads from `lfxColors.health.*` directly, the same source of truth as the rest of the fix.

## Jira

[IN-1256](https://linuxfoundation.atlassian.net/browse/IN-1256)

## Changes

- `frontend/app/config/styles/colors.ts` — split `health.fair` and `health.concerning` into distinct hexes.
- `frontend/app/config/styles/__tests__/colors.spec.ts` — new regression test.
- `frontend/app/components/uikit/tag/tag.scss` / `tag.types.ts` — new `accent` variation on `lfx-tag`.
- `frontend/app/components/shared/components/health-score.vue` — Fair tag switched from `info` to `accent`.
- `frontend/app/components/shared/components/__tests__/health-score.spec.ts` — new regression test for the accent tag.
- `frontend/app/components/uikit/progress-bar/types/progress-bar.types.ts` / `progress-bar.scss` — new `accent` color variant on `lfx-progress-bar`.
- `frontend/app/components/modules/collection/components/details/collection-health-score-pill.vue` — progress bar's Fair mapping switched from `warning` to `accent`.
- `frontend/app/components/modules/project/components/overview/trust-score-v2.vue` — fair/concerning colors now read from `lfxColors.health.*` instead of re-deriving `accent[500]`/`warning[500]` independently.

## Deploy order

Single-repo, frontend-only change. No dependency on any other PR or upstream deploy.

## Migration checklist

Not applicable — no database migration in this PR.

## Tinybird

Not applicable — no Tinybird pipe or datasource changes.

## Test plan

1. Open a collection's projects table and find a project with a "Fair" health score.
2. Confirm the Fair badge renders in the accent-blue used elsewhere in the app (`#009AFF`), not amber and not a slightly darker blue.
3. Find a project with a "Concerning" health score in the same table.
4. Confirm the Concerning badge renders in a distinct warning-yellow, not the same blue as Fair.
5. Open that project's overview page and confirm its Fair/Concerning badge color matches what the collection table now shows.
6. Hover the health-score pill on a "Fair" collection project and confirm the progress bar fill is accent-blue, not amber; confirm "Concerning" still shows amber.
7. Run `cd frontend && pnpm test -- colors.spec.ts health-score.spec.ts` and confirm both regression tests pass.

## Checklist

- [x] Tests added/updated
- [ ] Docs updated
- [x] Commit signed off (`--signoff -S`)
- [ ] Migration reviewed (n/a — no migration)
- [ ] Tinybird changes reviewed (n/a — no Tinybird changes)
- [x] No unrelated changes bundled


[IN-1256]: https://linuxfoundation.atlassian.net/browse/IN-1256?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

