### PR TITLE
fix: correct maintainer responsiveness availability check

### DIFF
--- a/frontend/config/health-breakdown-templates.ts
+++ b/frontend/config/health-breakdown-templates.ts
@@ -387,10 +387,17 @@ export const getResponsivenessRow = (signals: HealthBreakdownResults): SignalRow
       description: blockedSignalDescription('Maintainer responsiveness', signals),
     };
   }
-  if (signals.medianIssueResponseS === null || signals.responsivenessScore === null) {
+  if (signals.responsivenessScore === null) {
     return {
       status: 'no-data',
       description: 'No issue or PR response data available for this project.',
+    };
+  }
+  if (signals.medianIssueResponseS === null) {
+    return {
+      status: 'negative',
+      description:
+        'No PRs or issues were opened in the review window, so response time could not be measured.',
     };
   }
   const responseText = formatDays(signals.medianIssueResponseS);


### PR DESCRIPTION
## Summary
- The Maintainer responsiveness sub-signal was checking the raw `medianIssueResponseS` quantile for null to decide "no data," but that field is structurally null whenever a repo had zero PR/issue activity in the window — a case the Tinybird pipe (`health_score_v2_maintainer.pipe`) deliberately scores as a real, available `0/15` signal, not missing data.
- This made the frontend disagree with the backend's own 40%-coverage accounting: EasyCLA's Maintainer Health category showed two rows as "no data" even though the pipe counted the responsiveness signal as available, which is why the category survived the coverage threshold (55% by weight) while visually looking like only 1 of 3 signals had data.
- Fix: only treat the signal as unavailable when `responsivenessScore` itself is null; a null median with a real score is now rendered as its own state ("No PRs or issues were opened in the review window, so response time could not be measured.") instead of being folded into the no-data copy.

No JIRA ticket exists for this — reported directly by a user comparing the EasyCLA health breakdown against the documented coverage rule.

## Test plan
- [x] `pnpm vitest run config/health-breakdown-templates.test.ts` — 8/8 passing
- [x] `pnpm lint:fix` / `pnpm tsc-check` clean
- [ ] Manual verification on the EasyCLA project page pending local dev environment fix (unrelated `@temporalio/client` resolution issue, now resolved by rebasing onto the #2159 dependency upgrade)