### PR TITLE
feat: add standalone health score bands widget

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/band-distribution.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/band-distribution.vue
@@ -1,0 +1,178 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 01 "Health score bands" component for the Health Score Coverage report
+  (IN-1286, epic IN-1276). Not yet wired into health-score-coverage-report.vue - see
+  health-score-coverage-bands.types.ts for why.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div class="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">01 · Distribution</p>
+          <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+            Health score bands
+          </h3>
+        </div>
+        <lfx-tabs
+          v-model="scope"
+          :tabs="SCOPE_TABS"
+          tab-style="pill"
+          width-type="inline"
+        />
+      </div>
+
+      <p class="text-body-2 text-neutral-500">{{ descriptionText }}</p>
+
+      <div v-if="isLoading">
+        <div class="h-[280px] sm:h-[350px]">
+          <lfx-skeleton
+            height="100%"
+            width="100%"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[280px] sm:h-[350px]"
+      >
+        <p class="text-neutral-500">No health score data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="h-[280px] sm:h-[350px]"
+      >
+        <client-only>
+          <lfx-chart
+            :config="chartConfig"
+            :animation="true"
+          />
+        </client-only>
+      </div>
+
+      <p class="text-xs text-neutral-400">Project health scores · grouped by band</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { merge } from 'lodash-es';
+import { fetchHealthScoreCoverageBandsQuery } from '../services/band-distribution.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import LfxTabs from '~/components/uikit/tabs/tabs.vue';
+import { getHorizontalBarChartConfig, type HorizontalBarData } from '~/components/uikit/chart/configs/bar.chart';
+import { lfxColors } from '~/config/styles/colors';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type {
+  HealthScoreCoverageBandCount,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-bands.types';
+
+const SCOPE_TABS = [
+  { value: 'all', label: 'All projects' },
+  { value: 'lf', label: 'Linux Foundation' },
+  { value: 'other', label: 'Other' },
+];
+
+const scope = ref<HealthScoreCoverageScope>('all');
+
+const { data, isLoading } = fetchHealthScoreCoverageBandsQuery(computed(() => scope.value));
+
+const bandLabels = computed(() =>
+  (data.value?.bands ?? []).map((band) => band.band.charAt(0).toUpperCase() + band.band.slice(1)),
+);
+
+const scoredTotal = computed(() => (data.value?.fullTotal ?? 0) + (data.value?.partialTotal ?? 0));
+
+const descriptionText = computed(
+  () =>
+    `${formatNumber(scoredTotal.value)} projects have a health score. A project scores in full when ` +
+    'all three categories can be measured, and partially when only two can. A partial score is ' +
+    "rescaled to 100 so both read against the same bands. Bars show each group's own share, which " +
+    'keeps the two comparable despite their different sizes.',
+);
+
+const isEmpty = computed(() => !isLoading.value && scoredTotal.value === 0);
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+const percentOf = (count: number, total: number): number => (total > 0 ? round1((count / total) * 100) : 0);
+
+interface BandDistributionTooltipParam {
+  seriesName: string;
+  dataIndex: number;
+  value: number;
+}
+
+// Grouped two-series horizontal bar chart (full vs. partial scoring), built on top of the shared
+// getHorizontalBarChartConfig helper per the report's chart-config conventions - matches how
+// report/agentic-ai-momentum/components/research-chart.vue builds its own chart config inline
+// rather than in a separate .ts module.
+const chartConfig = computed<ECOption>(() => {
+  const bands: HealthScoreCoverageBandCount[] = data.value?.bands ?? [];
+  const fullTotal = data.value?.fullTotal ?? 0;
+  const partialTotal = data.value?.partialTotal ?? 0;
+
+  const baseData: HorizontalBarData[] = bandLabels.value.map((category) => ({ category, value: 0 }));
+  const baseConfig = getHorizontalBarChartConfig(baseData, lfxColors.brand[500]);
+
+  const fullLegendLabel = `Scored in full, three categories (${fullTotal})`;
+  const partialLegendLabel = `Partially scored, two categories (${partialTotal})`;
+
+  return merge({}, baseConfig, {
+    xAxis: {
+      max: 100,
+      axisLabel: { formatter: '{value}%' },
+    },
+    legend: {
+      bottom: 0,
+      data: [fullLegendLabel, partialLegendLabel],
+    },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (params: unknown) => {
+        const paramArray = params as BandDistributionTooltipParam[];
+        if (!paramArray || paramArray.length === 0) return '';
+        return paramArray
+          .map((param) => {
+            const band = bands[param.dataIndex];
+            const count = param.seriesName === fullLegendLabel ? band?.full : band?.partial;
+            return `${param.seriesName}: ${count ?? 0} (${param.value}%)`;
+          })
+          .join('<br/>');
+      },
+    },
+    series: [
+      {
+        name: fullLegendLabel,
+        type: 'bar',
+        barMaxWidth: 8,
+        data: bands.map((band) => percentOf(band.full, fullTotal)),
+        itemStyle: { color: lfxColors.brand[500], borderRadius: [10, 10, 10, 10] },
+      },
+      {
+        name: partialLegendLabel,
+        type: 'bar',
+        barMaxWidth: 8,
+        data: bands.map((band) => percentOf(band.partial, partialTotal)),
+        itemStyle: { color: lfxColors.neutral[400], borderRadius: [10, 10, 10, 10] },
+      },
+    ],
+  });
+});
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageBandDistribution',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/band-distribution.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/band-distribution.query.ts
@@ -1,0 +1,39 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Health score bands" widget (IN-1286), written as a plain
+// exported function rather than a method on the shared HEALTH_SCORE_COVERAGE_API_SERVICE class -
+// that class is created by IN-1285 and it isn't IN-1286's turn to edit it yet. This will become a
+// `fetchBands(scope)` method on the shared service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_BANDS`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { ComputedRef } from 'vue';
+import { computed } from 'vue';
+import type {
+  HealthScoreCoverageBandsData,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-bands.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-bands';
+
+export function fetchHealthScoreCoverageBandsQuery(scope: ComputedRef<HealthScoreCoverageScope>) {
+  const queryKey = computed(() => [TANSTACK_KEY, scope.value]);
+  const queryFn: QueryFunction<HealthScoreCoverageBandsData> = () =>
+    $fetch<HealthScoreCoverageBandsData>('/api/report/health-score-coverage/bands', {
+      params: { scope: scope.value },
+    });
+
+  return useQuery<HealthScoreCoverageBandsData>({
+    queryKey,
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/bands.get.ts
+++ b/frontend/server/api/report/health-score-coverage/bands.get.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Health score bands" widget (IN-1286). Not yet wired into the
+// shared health-score-coverage report view/service - see health-score-coverage-bands.types.ts.
+
+import { fetchHealthScoreCoverageBands } from '~~/server/data/tinybird/report/health-score-coverage-bands';
+import type {
+  HealthScoreCoverageBandsData,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-bands.types';
+
+const VALID_SCOPES: HealthScoreCoverageScope[] = ['all', 'lf', 'other'];
+
+export default defineEventHandler(async (event): Promise<HealthScoreCoverageBandsData> => {
+  const query = getQuery(event);
+  const scope = (query.scope as string) || 'all';
+
+  if (!VALID_SCOPES.includes(scope as HealthScoreCoverageScope)) {
+    throw createError({ statusCode: 400, statusMessage: `Invalid scope: ${scope}` });
+  }
+
+  try {
+    return await fetchHealthScoreCoverageBands(scope as HealthScoreCoverageScope);
+  } catch (error: unknown) {
+    console.error('[health-score-coverage/bands] error:', error);
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch health score coverage bands',
+    });
+  }
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-bands.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-bands.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageBandsRows } from './health-score-coverage-bands';
+import type { HealthScoreCoverageBandsRow } from '~~/types/report/health-score-coverage-bands.types';
+
+describe('mapHealthScoreCoverageBandsRows', () => {
+  test('splits full (covered=3) and partial (covered=2) counts per band', () => {
+    const rows: HealthScoreCoverageBandsRow[] = [
+      { band: 'excellent', covered: 3, projects: 120 },
+      { band: 'excellent', covered: 2, projects: 10 },
+      { band: 'healthy', covered: 3, projects: 80 },
+    ];
+
+    const result = mapHealthScoreCoverageBandsRows(rows);
+
+    expect(result.bands).toEqual([
+      { band: 'excellent', full: 120, partial: 10 },
+      { band: 'healthy', full: 80, partial: 0 },
+      { band: 'fair', full: 0, partial: 0 },
+      { band: 'concerning', full: 0, partial: 0 },
+      { band: 'critical', full: 0, partial: 0 },
+    ]);
+    expect(result.fullTotal).toBe(200);
+    expect(result.partialTotal).toBe(10);
+  });
+
+  test('fills bands missing from the pipe response with 0', () => {
+    const rows: HealthScoreCoverageBandsRow[] = [{ band: 'critical', covered: 3, projects: 5 }];
+
+    const result = mapHealthScoreCoverageBandsRows(rows);
+
+    expect(result.bands.map((band) => band.band)).toEqual([
+      'excellent',
+      'healthy',
+      'fair',
+      'concerning',
+      'critical',
+    ]);
+    expect(result.bands.find((band) => band.band === 'critical')).toEqual({
+      band: 'critical',
+      full: 5,
+      partial: 0,
+    });
+    expect(result.fullTotal).toBe(5);
+    expect(result.partialTotal).toBe(0);
+  });
+
+  test('ignores an unrecognized band', () => {
+    const rows: HealthScoreCoverageBandsRow[] = [{ band: 'unknown', covered: 3, projects: 5 }];
+
+    const result = mapHealthScoreCoverageBandsRows(rows);
+
+    expect(result.fullTotal).toBe(0);
+    expect(result.partialTotal).toBe(0);
+  });
+
+  test('returns all-zero bands for an empty response', () => {
+    const result = mapHealthScoreCoverageBandsRows([]);
+
+    expect(result.bands).toHaveLength(5);
+    expect(result.bands.every((band) => band.full === 0 && band.partial === 0)).toBe(true);
+  });
+});
+
+describe('fetchHealthScoreCoverageBands', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with the given scope and maps the rows', async () => {
+    const { fetchHealthScoreCoverageBands } = await import('./health-score-coverage-bands');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [{ band: 'excellent', covered: 3, projects: 120 }],
+    });
+
+    const result = await fetchHealthScoreCoverageBands('lf');
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith('/v0/pipes/health_score_report_bands.json', {
+      scope: 'lf',
+    });
+    expect(result.fullTotal).toBe(120);
+  });
+
+  test('defaults to scope "all"', async () => {
+    const { fetchHealthScoreCoverageBands } = await import('./health-score-coverage-bands');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({ data: [] });
+
+    await fetchHealthScoreCoverageBands();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith('/v0/pipes/health_score_report_bands.json', {
+      scope: 'all',
+    });
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-bands.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-bands.ts
@@ -1,0 +1,62 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Health score bands" widget (IN-1286). Kept out of the shared
+// server/data/tinybird/report/health-score-coverage.ts file for the same merge-order reason as
+// the types file next to it - see health-score-coverage-bands.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageBandCount,
+  HealthScoreCoverageBandsData,
+  HealthScoreCoverageBandsRow,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-bands.types';
+
+// Fixed display order per the design: Excellent, Healthy, Fair, Concerning, Critical.
+const BAND_ORDER = ['excellent', 'healthy', 'fair', 'concerning', 'critical'] as const;
+
+const COVERED_FULL = 3;
+const COVERED_PARTIAL = 2;
+
+/**
+ * Maps the raw `health_score_report_bands` rows into the fixed 5-band shape the chart consumes,
+ * filling in any band/coverage pair the pipe didn't return with 0.
+ */
+export function mapHealthScoreCoverageBandsRows(
+  rows: HealthScoreCoverageBandsRow[],
+): HealthScoreCoverageBandsData {
+  const counts = new Map<string, { full: number; partial: number }>(
+    BAND_ORDER.map((band) => [band, { full: 0, partial: 0 }]),
+  );
+
+  rows.forEach((row) => {
+    const entry = counts.get(row.band);
+    if (!entry) return;
+    if (row.covered === COVERED_FULL) entry.full += row.projects;
+    else if (row.covered === COVERED_PARTIAL) entry.partial += row.projects;
+  });
+
+  const bands: HealthScoreCoverageBandCount[] = BAND_ORDER.map((band) => ({
+    band,
+    full: counts.get(band)?.full ?? 0,
+    partial: counts.get(band)?.partial ?? 0,
+  }));
+
+  return {
+    bands,
+    fullTotal: bands.reduce((sum, band) => sum + band.full, 0),
+    partialTotal: bands.reduce((sum, band) => sum + band.partial, 0),
+  };
+}
+
+export async function fetchHealthScoreCoverageBands(
+  scope: HealthScoreCoverageScope = 'all',
+): Promise<HealthScoreCoverageBandsData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageBandsRow[]>(
+    '/v0/pipes/health_score_report_bands.json',
+    { scope },
+  );
+
+  return mapHealthScoreCoverageBandsRows(result.data);
+}

--- a/frontend/types/report/health-score-coverage-bands.types.ts
+++ b/frontend/types/report/health-score-coverage-bands.types.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Health score bands" widget (IN-1286, widget 01 of the Health Score
+// Coverage report, epic IN-1276). Kept in its own file rather than the shared
+// types/report/health-score-coverage.types.ts because that file is edited sequentially by each
+// widget ticket in merge order, and it isn't IN-1286's turn yet (IN-1285's insights PR #2164 is
+// still open). Will be merged into the shared types file in a follow-up.
+
+export type HealthScoreCoverageScope = 'all' | 'lf' | 'other';
+
+// Raw TB row from `health_score_report_bands`: one row per (band, covered) pair.
+export interface HealthScoreCoverageBandsRow {
+  band: string;
+  covered: number;
+  projects: number;
+}
+
+// One health-score band's project counts, split by full (3 categories) vs partial (2 categories)
+// scoring. Bands the pipe didn't return for a scope are filled in with 0.
+export interface HealthScoreCoverageBandCount {
+  band: string;
+  full: number;
+  partial: number;
+}
+
+export interface HealthScoreCoverageBandsData {
+  bands: HealthScoreCoverageBandCount[];
+  fullTotal: number;
+  partialTotal: number;
+}


### PR DESCRIPTION
## Summary

Standalone widget code only — NOT yet wired into the shared report view/service/types/data files. Wiring happens in a follow-up once IN-1285 (#2164) merges into this release branch and it's IN-1286's turn in the sequential merge order.

crowd.dev pipe `health_score_report_bands` is already deployed to production (crowd.dev PR #4579).

Implements the non-shared parts of IN-1286 ("Health Score Coverage widget 01: health score bands by full and partial score"), authorized to build ahead of the sequential merge order since none of these files are touched by any other in-flight widget PR:

- `band-distribution.vue` — horizontal grouped bar chart (full vs. partial score, 5 fixed bands), scope toggle (all/lf/other), skeleton loading state, empty state
- `band-distribution.query.ts` — TanStack Query wrapper calling the new API route; written as a plain function, to become a method on the shared API service class once it's IN-1286's turn
- `bands.get.ts` — API route proxying the `health_score_report_bands` Tinybird pipe, with `scope` param validation
- `health-score-coverage-bands.ts` — mapper + fetcher for the pipe response, with a Vitest unit test for the mapper
- `health-score-coverage-bands.types.ts` — this widget's own types, kept separate from the shared report types file

## Test plan

- [x] `pnpm tsc-check` — passes
- [x] `pnpm lint` — passes (0 errors)
- [x] `pnpm test --run` — 256/256 tests pass, including the new mapper unit tests
- [ ] Follow-up PR wires this component into `health-score-coverage-report.vue` and the shared service/types once IN-1285 merges

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add standalone health score bands widget** :point\_left:
