### PR TITLE
feat: add standalone lifecycle distribution widget

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/lifecycle-distribution.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/lifecycle-distribution.vue
@@ -1,0 +1,162 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 02 "How projects are maintained" component for the Health Score Coverage report
+  (IN-1287, epic IN-1276). Not yet wired into health-score-coverage-report.vue - see
+  health-score-coverage-lifecycle.types.ts for why.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div class="flex items-start justify-between gap-4 flex-wrap">
+        <div>
+          <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">02 · Distribution</p>
+          <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+            How projects are maintained
+          </h3>
+        </div>
+        <lfx-tabs
+          v-model="scope"
+          :tabs="SCOPE_TABS"
+          tab-style="pill"
+          width-type="inline"
+        />
+      </div>
+
+      <p class="text-body-2 text-neutral-500">
+        Lifecycle tracks maintenance, not health. A project can be actively maintained and still score poorly. A project
+        takes the best state among the packages it publishes, so a single maintained package keeps it active.
+        Unavailable means no published package is linked to the project yet.
+      </p>
+
+      <div v-if="isLoading">
+        <div class="h-[280px] sm:h-[350px]">
+          <lfx-skeleton
+            height="100%"
+            width="100%"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[280px] sm:h-[350px]"
+      >
+        <p class="text-neutral-500">No lifecycle data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="h-[280px] sm:h-[350px]"
+      >
+        <client-only>
+          <lfx-chart
+            :config="chartConfig"
+            :animation="true"
+          />
+        </client-only>
+      </div>
+
+      <p class="text-xs text-neutral-400">{{ captionText }}</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { merge } from 'lodash-es';
+import { fetchHealthScoreCoverageLifecycleQuery } from '../services/lifecycle-distribution.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import LfxTabs from '~/components/uikit/tabs/tabs.vue';
+import { getHorizontalBarChartConfig, type HorizontalBarData } from '~/components/uikit/chart/configs/bar.chart';
+import { lfxColors } from '~/config/styles/colors';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type {
+  HealthScoreCoverageLifecycleCount,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-lifecycle.types';
+
+const SCOPE_TABS = [
+  { value: 'all', label: 'All projects' },
+  { value: 'lf', label: 'Linux Foundation' },
+  { value: 'other', label: 'Other' },
+];
+
+// Caption wording per scope, matching the artifact: "Project lifecycle · all tracked projects (n)"
+// swapped to "Linux Foundation" / "other" for the lf/other toggles.
+const SCOPE_CAPTION_WORDING: Record<HealthScoreCoverageScope, string> = {
+  all: 'all',
+  lf: 'Linux Foundation',
+  other: 'other',
+};
+
+const LABEL_DISPLAY_OVERRIDES: Record<string, string> = {
+  unavailable: 'Unavailable',
+};
+
+const displayLabel = (label: string): string =>
+  LABEL_DISPLAY_OVERRIDES[label] ?? label.charAt(0).toUpperCase() + label.slice(1);
+
+const scope = ref<HealthScoreCoverageScope>('all');
+
+const { data, isLoading } = fetchHealthScoreCoverageLifecycleQuery(computed(() => scope.value));
+
+const rows = computed<HealthScoreCoverageLifecycleCount[]>(() => data.value?.rows ?? []);
+const total = computed(() => data.value?.total ?? 0);
+
+const isEmpty = computed(() => !isLoading.value && total.value === 0);
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+const percentOf = (count: number, totalCount: number): number =>
+  totalCount > 0 ? round1((count / totalCount) * 100) : 0;
+
+const captionText = computed(
+  () => `Project lifecycle · ${SCOPE_CAPTION_WORDING[scope.value]} tracked projects (${formatNumber(total.value)})`,
+);
+
+interface LifecycleTooltipParam {
+  dataIndex: number;
+  value: number;
+}
+
+// Single-series horizontal bar chart, built on top of the shared getHorizontalBarChartConfig
+// helper per the report's chart-config conventions - matches how
+// report/agentic-ai-momentum/components/research-chart.vue builds its own chart config inline
+// rather than in a separate .ts module.
+const chartConfig = computed<ECOption>(() => {
+  const chartData: HorizontalBarData[] = rows.value.map((row) => ({
+    category: displayLabel(row.label),
+    value: percentOf(row.projects, total.value),
+  }));
+
+  const baseConfig = getHorizontalBarChartConfig(chartData, lfxColors.brand[500]);
+
+  return merge({}, baseConfig, {
+    xAxis: {
+      max: 100,
+      axisLabel: { formatter: '{value}%' },
+    },
+    tooltip: {
+      formatter: (params: unknown) => {
+        const paramArray = params as LifecycleTooltipParam[];
+        if (!paramArray || paramArray.length === 0) return '';
+        const param = paramArray[0];
+        const row = rows.value[param.dataIndex];
+        if (!row) return '';
+        return `${displayLabel(row.label)}: ${param.value}% (${formatNumber(row.projects)})`;
+      },
+    },
+  });
+});
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageLifecycleDistribution',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/lifecycle-distribution.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/lifecycle-distribution.query.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "How projects are maintained" widget (IN-1287), written as a
+// plain exported function rather than a method on the shared HEALTH_SCORE_COVERAGE_API_SERVICE
+// class - that class is created by IN-1285 and it isn't IN-1287's turn to edit it yet. This will
+// become a `fetchLifecycle(scope)` method on the shared service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_LIFECYCLE`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { ComputedRef } from 'vue';
+import { computed } from 'vue';
+import type {
+  HealthScoreCoverageLifecycleData,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-lifecycle.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-lifecycle';
+
+export function fetchHealthScoreCoverageLifecycleQuery(
+  scope: ComputedRef<HealthScoreCoverageScope>,
+) {
+  const queryKey = computed(() => [TANSTACK_KEY, scope.value]);
+  const queryFn: QueryFunction<HealthScoreCoverageLifecycleData> = () =>
+    $fetch<HealthScoreCoverageLifecycleData>('/api/report/health-score-coverage/lifecycle', {
+      params: { scope: scope.value },
+    });
+
+  return useQuery<HealthScoreCoverageLifecycleData>({
+    queryKey,
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/lifecycle.get.ts
+++ b/frontend/server/api/report/health-score-coverage/lifecycle.get.ts
@@ -1,0 +1,36 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "How projects are maintained" widget (IN-1287). Not yet wired into
+// the shared health-score-coverage report view/service - see
+// health-score-coverage-lifecycle.types.ts.
+
+import { fetchHealthScoreCoverageLifecycle } from '~~/server/data/tinybird/report/health-score-coverage-lifecycle';
+import type {
+  HealthScoreCoverageLifecycleData,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-lifecycle.types';
+
+const VALID_SCOPES: HealthScoreCoverageScope[] = ['all', 'lf', 'other'];
+
+export default defineEventHandler(async (event): Promise<HealthScoreCoverageLifecycleData> => {
+  const query = getQuery(event);
+  const scope = (query.scope as string) || 'all';
+
+  if (!VALID_SCOPES.includes(scope as HealthScoreCoverageScope)) {
+    throw createError({ statusCode: 400, statusMessage: `Invalid scope: ${scope}` });
+  }
+
+  try {
+    return await fetchHealthScoreCoverageLifecycle(scope as HealthScoreCoverageScope);
+  } catch (error: unknown) {
+    console.error('[health-score-coverage/lifecycle] error:', error);
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch health score coverage lifecycle distribution',
+    });
+  }
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-lifecycle.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-lifecycle.test.ts
@@ -1,0 +1,82 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageLifecycleRows } from './health-score-coverage-lifecycle';
+import type { HealthScoreCoverageLifecycleRow } from '~~/types/report/health-score-coverage-lifecycle.types';
+
+describe('mapHealthScoreCoverageLifecycleRows', () => {
+  test('maps the NULL label to "unavailable" and sorts by project count descending', () => {
+    const rows: HealthScoreCoverageLifecycleRow[] = [
+      { label: 'stable', projects: 306 },
+      { label: 'active', projects: 9758 },
+      { label: null, projects: 366 },
+      { label: 'declining', projects: 488 },
+    ];
+
+    const result = mapHealthScoreCoverageLifecycleRows(rows);
+
+    expect(result.rows).toEqual([
+      { label: 'active', projects: 9758 },
+      { label: 'declining', projects: 488 },
+      { label: 'unavailable', projects: 366 },
+      { label: 'stable', projects: 306 },
+    ]);
+    expect(result.total).toBe(10918);
+  });
+
+  test('returns an empty result for an empty response', () => {
+    const result = mapHealthScoreCoverageLifecycleRows([]);
+
+    expect(result.rows).toEqual([]);
+    expect(result.total).toBe(0);
+  });
+});
+
+describe('fetchHealthScoreCoverageLifecycle', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with the given scope and maps the rows', async () => {
+    const { fetchHealthScoreCoverageLifecycle } = await import('./health-score-coverage-lifecycle');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [{ label: 'active', projects: 1097 }],
+    });
+
+    const result = await fetchHealthScoreCoverageLifecycle('lf');
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_lifecycle.json',
+      {
+        scope: 'lf',
+      },
+    );
+    expect(result.total).toBe(1097);
+  });
+
+  test('defaults to scope "all"', async () => {
+    const { fetchHealthScoreCoverageLifecycle } = await import('./health-score-coverage-lifecycle');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({ data: [] });
+
+    await fetchHealthScoreCoverageLifecycle();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_lifecycle.json',
+      {
+        scope: 'all',
+      },
+    );
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-lifecycle.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-lifecycle.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "How projects are maintained" widget (IN-1287). Kept out of the
+// shared server/data/tinybird/report/health-score-coverage.ts file for the same merge-order reason
+// as the types file next to it - see health-score-coverage-lifecycle.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageLifecycleCount,
+  HealthScoreCoverageLifecycleData,
+  HealthScoreCoverageLifecycleRow,
+  HealthScoreCoverageScope,
+} from '~~/types/report/health-score-coverage-lifecycle.types';
+
+/**
+ * Maps the raw `health_score_report_lifecycle` rows into the shape the chart consumes: the NULL
+ * label becomes 'unavailable', and rows are sorted by project count descending.
+ */
+export function mapHealthScoreCoverageLifecycleRows(
+  rows: HealthScoreCoverageLifecycleRow[],
+): HealthScoreCoverageLifecycleData {
+  const counts: HealthScoreCoverageLifecycleCount[] = rows
+    .map((row) => ({ label: row.label ?? 'unavailable', projects: row.projects }))
+    .sort((a, b) => b.projects - a.projects);
+
+  return {
+    rows: counts,
+    total: counts.reduce((sum, row) => sum + row.projects, 0),
+  };
+}
+
+export async function fetchHealthScoreCoverageLifecycle(
+  scope: HealthScoreCoverageScope = 'all',
+): Promise<HealthScoreCoverageLifecycleData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageLifecycleRow[]>(
+    '/v0/pipes/health_score_report_lifecycle.json',
+    { scope },
+  );
+
+  return mapHealthScoreCoverageLifecycleRows(result.data);
+}

--- a/frontend/types/report/health-score-coverage-lifecycle.types.ts
+++ b/frontend/types/report/health-score-coverage-lifecycle.types.ts
@@ -1,0 +1,31 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "How projects are maintained" widget (IN-1287, widget 02 of the
+// Health Score Coverage report, epic IN-1276). Kept in its own file rather than the shared
+// types/report/health-score-coverage.types.ts because that file is edited sequentially by each
+// widget ticket in merge order, and it isn't IN-1287's turn yet (IN-1285's insights PR #2164 and
+// IN-1286's insights PR #2165 are still open). Will be merged into the shared types file in a
+// follow-up.
+
+export type HealthScoreCoverageScope = 'all' | 'lf' | 'other';
+
+// Raw TB row from `health_score_report_lifecycle`: one row per `lifecycleLabel` value, or `null`
+// when the project has no linked package data to derive a lifecycle state from.
+export interface HealthScoreCoverageLifecycleRow {
+  label: string | null;
+  projects: number;
+}
+
+// One lifecycle label's project count, ready for the chart. `label` is the raw lifecycleLabel
+// value (active, stable, declining, inert, abandoned, archived) or 'unavailable' for the NULL
+// row. Rows are sorted by `projects` descending.
+export interface HealthScoreCoverageLifecycleCount {
+  label: string;
+  projects: number;
+}
+
+export interface HealthScoreCoverageLifecycleData {
+  rows: HealthScoreCoverageLifecycleCount[];
+  total: number;
+}


### PR DESCRIPTION
## Summary

Standalone widget code only — NOT yet wired into the shared report view/service/types/data files. Wiring happens in a follow-up once IN-1285 (#2164) and IN-1286 (#2165) merge into this release branch and it's IN-1287's turn in the sequential merge order. crowd.dev pipe `health_score_report_lifecycle` is already deployed to production (crowd.dev PR #4580).

Widget 02 "How projects are maintained" of the Health Score Coverage report (IN-1276): a single-series horizontal bar chart of project lifecycle-label distribution (active, stable, declining, inert, abandoned, archived, plus an "Unavailable" row for NULL), with an all/Linux Foundation/other scope toggle. Rows are sorted by share descending; the denominator is all tracked projects in scope, not just scored ones.

- `frontend/app/components/modules/report/health-score-coverage/components/lifecycle-distribution.vue` — chart component with skeleton/empty states and scope toggle
- `frontend/app/components/modules/report/health-score-coverage/services/lifecycle-distribution.query.ts` — standalone TanStack Query wrapper
- `frontend/server/api/report/health-score-coverage/lifecycle.get.ts` — API route, scope validated to `all|lf|other`
- `frontend/server/data/tinybird/report/health-score-coverage-lifecycle.ts` — data-fetcher + pure mapper (NULL → `unavailable`, sorted by count descending)
- `frontend/server/data/tinybird/report/health-score-coverage-lifecycle.test.ts` — mapper/fetcher unit tests
- `frontend/types/report/health-score-coverage-lifecycle.types.ts` — this widget's own types

Follows the file layout and conventions of IN-1286's insights PR #2165 (band-distribution widget).

## Test plan

- [x] `pnpm test --run` — 254/254 passing, including the new mapper/fetcher tests
- [x] `pnpm tsc-check` — clean
- [x] `pnpm lint:fix` — 0 errors (pre-existing unrelated warnings only)
- [ ] Manual QA once wired into the report view (follow-up ticket)

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add standalone lifecycle distribution widget** :point\_left:
