### PR TITLE
feat: add signal availability widget standalone code IN-1290

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/signal-availability.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/signal-availability.vue
@@ -1,0 +1,144 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 05 "Availability of each signal" component for the Health Score Coverage report
+  (IN-1290, epic IN-1276). Not yet wired into health-score-coverage-report.vue - see
+  health-score-coverage-signal-availability.types.ts for why.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div>
+        <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">05 · Availability</p>
+        <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+          Availability of each signal
+        </h3>
+      </div>
+
+      <p class="text-body-2 text-neutral-500">
+        Share of tracked repositories where each signal can be measured. A signal counts only if the data is both
+        present and recent.
+      </p>
+
+      <div v-if="isLoading">
+        <div class="h-[420px]">
+          <lfx-skeleton
+            height="100%"
+            width="100%"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[420px]"
+      >
+        <p class="text-neutral-500">No signal availability data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="h-[420px]"
+      >
+        <client-only>
+          <lfx-chart
+            :config="chartConfig"
+            :animation="true"
+          />
+        </client-only>
+      </div>
+
+      <p class="text-xs text-neutral-400">Signal availability · all tracked repositories</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue';
+import { merge } from 'lodash-es';
+import { fetchHealthScoreCoverageSignalAvailabilityQuery } from '../services/signal-availability.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import { getHorizontalBarChartConfig, type HorizontalBarData } from '~/components/uikit/chart/configs/bar.chart';
+import { lfxColors } from '~/config/styles/colors';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type {
+  HealthScoreCoverageScope,
+  HealthScoreCoverageSignalAvailabilityCount,
+} from '~~/types/report/health-score-coverage-signal-availability.types';
+
+// Display names per the design copy, keyed by the pipe's `signal_key`. Duplicated here rather than
+// imported from config/signals.ts because that shared file is created by IN-1285 and isn't ready
+// for this widget to depend on yet - see the types file for the merge-order explanation.
+const SIGNAL_LABELS: Record<string, string> = {
+  commitActivity: 'Commit activity',
+  responsiveness: 'Responsiveness',
+  orgDiversity: 'Organizational diversity',
+  prMerge: 'Pull request merge',
+  busFactor: 'Bus factor',
+  openVuln: 'Known vulnerabilities',
+  issueResolution: 'Issue resolution',
+  securityPractices: 'Security practices',
+  dependencyHealth: 'Dependency health',
+  scorecard: 'OpenSSF Scorecard',
+  releaseCadence: 'Release cadence',
+};
+
+const displayLabel = (signalKey: string): string => SIGNAL_LABELS[signalKey] ?? signalKey;
+
+// Fixed scope=all per the ticket - this widget has no scope toggle. `fetchSignalAvailabilityQuery`
+// still takes a scope so the underlying fetcher/mapper support lf/other, reused by widget 06.
+const scope = ref<HealthScoreCoverageScope>('all');
+
+const { data, isLoading } = fetchHealthScoreCoverageSignalAvailabilityQuery(computed(() => scope.value));
+
+const signals = computed<HealthScoreCoverageSignalAvailabilityCount[]>(() => data.value?.signals ?? []);
+
+const isEmpty = computed(() => !isLoading.value && signals.value.length === 0);
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+interface SignalAvailabilityTooltipParam {
+  dataIndex: number;
+  value: number;
+}
+
+// Single-series horizontal bar chart, built on top of the shared getHorizontalBarChartConfig
+// helper per the report's chart-config conventions - matches how
+// report/agentic-ai-momentum/components/research-chart.vue builds its own chart config inline
+// rather than in a separate .ts module.
+const chartConfig = computed<ECOption>(() => {
+  const chartData: HorizontalBarData[] = signals.value.map((signal) => ({
+    category: displayLabel(signal.signalKey),
+    value: round1(signal.availablePct),
+  }));
+
+  const baseConfig = getHorizontalBarChartConfig(chartData, lfxColors.brand[500]);
+
+  return merge({}, baseConfig, {
+    xAxis: {
+      max: 100,
+      axisLabel: { formatter: '{value}%' },
+    },
+    tooltip: {
+      formatter: (params: unknown) => {
+        const paramArray = params as SignalAvailabilityTooltipParam[];
+        if (!paramArray || paramArray.length === 0) return '';
+        const param = paramArray[0];
+        const signal = signals.value[param.dataIndex];
+        if (!signal) return '';
+        return `${displayLabel(signal.signalKey)}: ${param.value}% (${formatNumber(signal.reposAvailable)})`;
+      },
+    },
+  });
+});
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageSignalAvailability',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/signal-availability.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/signal-availability.query.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Availability of each signal" widget (IN-1290), written as a
+// plain exported function rather than a method on the shared HEALTH_SCORE_COVERAGE_API_SERVICE
+// class - that class is created by IN-1285 and it isn't IN-1290's turn to edit it yet. This will
+// become a `fetchSignalAvailability(scope)` method on the shared service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_SIGNAL_AVAILABILITY`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { ComputedRef } from 'vue';
+import { computed } from 'vue';
+import type {
+  HealthScoreCoverageScope,
+  HealthScoreCoverageSignalAvailabilityData,
+} from '~~/types/report/health-score-coverage-signal-availability.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-signal-availability';
+
+export function fetchHealthScoreCoverageSignalAvailabilityQuery(
+  scope: ComputedRef<HealthScoreCoverageScope>,
+) {
+  const queryKey = computed(() => [TANSTACK_KEY, scope.value]);
+  const queryFn: QueryFunction<HealthScoreCoverageSignalAvailabilityData> = () =>
+    $fetch<HealthScoreCoverageSignalAvailabilityData>(
+      '/api/report/health-score-coverage/signal-availability',
+      { params: { scope: scope.value } },
+    );
+
+  return useQuery<HealthScoreCoverageSignalAvailabilityData>({
+    queryKey,
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/signal-availability.get.ts
+++ b/frontend/server/api/report/health-score-coverage/signal-availability.get.ts
@@ -1,0 +1,38 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Availability of each signal" widget (IN-1290). Not yet wired into
+// the shared health-score-coverage report view/service - see
+// health-score-coverage-signal-availability.types.ts.
+
+import { fetchHealthScoreCoverageSignalAvailability } from '~~/server/data/tinybird/report/health-score-coverage-signal-availability';
+import type {
+  HealthScoreCoverageScope,
+  HealthScoreCoverageSignalAvailabilityData,
+} from '~~/types/report/health-score-coverage-signal-availability.types';
+
+const VALID_SCOPES: HealthScoreCoverageScope[] = ['all', 'lf', 'other'];
+
+export default defineEventHandler(
+  async (event): Promise<HealthScoreCoverageSignalAvailabilityData> => {
+    const query = getQuery(event);
+    const scope = (query.scope as string) || 'all';
+
+    if (!VALID_SCOPES.includes(scope as HealthScoreCoverageScope)) {
+      throw createError({ statusCode: 400, statusMessage: `Invalid scope: ${scope}` });
+    }
+
+    try {
+      return await fetchHealthScoreCoverageSignalAvailability(scope as HealthScoreCoverageScope);
+    } catch (error: unknown) {
+      console.error('[health-score-coverage/signal-availability] error:', error);
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        throw error;
+      }
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Failed to fetch health score coverage signal availability',
+      });
+    }
+  },
+);

--- a/frontend/server/data/tinybird/report/health-score-coverage-signal-availability.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-signal-availability.test.ts
@@ -1,0 +1,107 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageSignalAvailabilityRows } from './health-score-coverage-signal-availability';
+import type { HealthScoreCoverageSignalAvailabilityRow } from '~~/types/report/health-score-coverage-signal-availability.types';
+
+describe('mapHealthScoreCoverageSignalAvailabilityRows', () => {
+  test('maps raw rows to camelCase and sorts by availablePct descending', () => {
+    const rows: HealthScoreCoverageSignalAvailabilityRow[] = [
+      {
+        signal_key: 'releaseCadence',
+        category_key: 'developmentActivity',
+        available_pct: 14.2,
+        repos_available: 4486,
+        repos_tracked: 31593,
+      },
+      {
+        signal_key: 'responsiveness',
+        category_key: 'maintainerHealth',
+        available_pct: 82.5,
+        repos_available: 26054,
+        repos_tracked: 31593,
+      },
+    ];
+
+    const result = mapHealthScoreCoverageSignalAvailabilityRows(rows);
+
+    expect(result.signals).toEqual([
+      {
+        signalKey: 'responsiveness',
+        categoryKey: 'maintainerHealth',
+        availablePct: 82.5,
+        reposAvailable: 26054,
+        reposTracked: 31593,
+      },
+      {
+        signalKey: 'releaseCadence',
+        categoryKey: 'developmentActivity',
+        availablePct: 14.2,
+        reposAvailable: 4486,
+        reposTracked: 31593,
+      },
+    ]);
+  });
+
+  test('returns an empty result for an empty response', () => {
+    const result = mapHealthScoreCoverageSignalAvailabilityRows([]);
+
+    expect(result.signals).toEqual([]);
+  });
+});
+
+describe('fetchHealthScoreCoverageSignalAvailability', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with the given scope and maps the rows', async () => {
+    const { fetchHealthScoreCoverageSignalAvailability } =
+      await import('./health-score-coverage-signal-availability');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [
+        {
+          signal_key: 'busFactor',
+          category_key: 'maintainerHealth',
+          available_pct: 56.3,
+          repos_available: 17776,
+          repos_tracked: 31593,
+        },
+      ],
+    });
+
+    const result = await fetchHealthScoreCoverageSignalAvailability('lf');
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_signal_availability.json',
+      { scope: 'lf' },
+    );
+    expect(result.signals).toHaveLength(1);
+    expect(result.signals[0]?.signalKey).toBe('busFactor');
+  });
+
+  test('defaults to scope "all"', async () => {
+    const { fetchHealthScoreCoverageSignalAvailability } =
+      await import('./health-score-coverage-signal-availability');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({ data: [] });
+
+    await fetchHealthScoreCoverageSignalAvailability();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_signal_availability.json',
+      { scope: 'all' },
+    );
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-signal-availability.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-signal-availability.ts
@@ -1,0 +1,46 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Availability of each signal" widget (IN-1290). Kept out of the
+// shared server/data/tinybird/report/health-score-coverage.ts file for the same merge-order reason
+// as the types file next to it - see health-score-coverage-signal-availability.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageScope,
+  HealthScoreCoverageSignalAvailabilityCount,
+  HealthScoreCoverageSignalAvailabilityData,
+  HealthScoreCoverageSignalAvailabilityRow,
+} from '~~/types/report/health-score-coverage-signal-availability.types';
+
+/**
+ * Maps the raw `health_score_report_signal_availability` rows into the shape the chart consumes,
+ * sorted by `availablePct` descending (the pipe already sorts this way, but the mapper doesn't
+ * rely on that).
+ */
+export function mapHealthScoreCoverageSignalAvailabilityRows(
+  rows: HealthScoreCoverageSignalAvailabilityRow[],
+): HealthScoreCoverageSignalAvailabilityData {
+  const signals: HealthScoreCoverageSignalAvailabilityCount[] = rows
+    .map((row) => ({
+      signalKey: row.signal_key,
+      categoryKey: row.category_key,
+      availablePct: row.available_pct,
+      reposAvailable: row.repos_available,
+      reposTracked: row.repos_tracked,
+    }))
+    .sort((a, b) => b.availablePct - a.availablePct);
+
+  return { signals };
+}
+
+export async function fetchHealthScoreCoverageSignalAvailability(
+  scope: HealthScoreCoverageScope = 'all',
+): Promise<HealthScoreCoverageSignalAvailabilityData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageSignalAvailabilityRow[]>(
+    '/v0/pipes/health_score_report_signal_availability.json',
+    { scope },
+  );
+
+  return mapHealthScoreCoverageSignalAvailabilityRows(result.data);
+}

--- a/frontend/types/report/health-score-coverage-signal-availability.types.ts
+++ b/frontend/types/report/health-score-coverage-signal-availability.types.ts
@@ -1,0 +1,33 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Availability of each signal" widget (IN-1290, widget 05 of the
+// Health Score Coverage report, epic IN-1276). Kept in its own file rather than the shared
+// types/report/health-score-coverage.types.ts because that file is edited sequentially by each
+// widget ticket in merge order, and it isn't IN-1290's turn yet (IN-1285's insights PR #2164,
+// IN-1286's insights PR #2165 and IN-1287's insights PR #2166 are still open). Will be merged into
+// the shared types file in a follow-up.
+
+export type HealthScoreCoverageScope = 'all' | 'lf' | 'other';
+
+// Raw TB row from `health_score_report_signal_availability`: one row per signal.
+export interface HealthScoreCoverageSignalAvailabilityRow {
+  signal_key: string;
+  category_key: string;
+  available_pct: number;
+  repos_available: number;
+  repos_tracked: number;
+}
+
+// One signal's availability, ready for the chart. Rows are sorted by `availablePct` descending.
+export interface HealthScoreCoverageSignalAvailabilityCount {
+  signalKey: string;
+  categoryKey: string;
+  availablePct: number;
+  reposAvailable: number;
+  reposTracked: number;
+}
+
+export interface HealthScoreCoverageSignalAvailabilityData {
+  signals: HealthScoreCoverageSignalAvailabilityCount[];
+}


### PR DESCRIPTION
## Summary

Standalone widget code only for IN-1290, widget 05 "Availability of each signal" of the Health Score Coverage report (epic IN-1276) — **NOT yet wired into the shared report view/service/types/data files.** Wiring happens in a follow-up once prior widgets (#2164, #2165, #2166) merge into this release branch and it's IN-1290's turn in the sequential merge order.

crowd.dev pipe `health_score_report_signal_availability` param `scope` (`all | lf | other`), 11 signals sorted by `available_pct` descending: linuxfoundation/crowd.dev#4581.

**Note on pipe deploy status:** the ticket instructions state this pipe is "already deployed to production," but `gh pr view 4581` shows that PR is still **open** (not merged) as of this writing. This PR does not block on that — the deploy-order note below reflects what the ticket asked me to state, but the owner should confirm #4581 is actually live before merging this into the release branch.

### Files added

- `frontend/app/components/modules/report/health-score-coverage/components/signal-availability.vue`
- `frontend/app/components/modules/report/health-score-coverage/services/signal-availability.query.ts`
- `frontend/server/api/report/health-score-coverage/signal-availability.get.ts`
- `frontend/server/data/tinybird/report/health-score-coverage-signal-availability.ts` (+ mapper test)
- `frontend/types/report/health-score-coverage-signal-availability.types.ts`

## Test plan

- [x] `pnpm tsc-check` clean
- [x] `pnpm lint:fix` clean (0 errors)
- [x] `pnpm test --run` — 254/254 passing, including the new mapper test
- [ ] Owner to confirm crowd.dev PR #4581 is merged/deployed before merging this PR

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add signal availability widget standalone code IN-1290** :point\_left:
