### PR TITLE
feat: add GitHub security funnel table widget IN-1293

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/github-security-funnel.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/github-security-funnel.vue
@@ -1,0 +1,104 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 08 "Security coverage on GitHub-hosted repositories" component for the Health
+  Score Coverage report (IN-1293, epic IN-1276). Not yet wired into health-score-coverage-report.vue
+  - see health-score-coverage-github-security.types.ts for why.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div>
+        <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">08 · Availability</p>
+        <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+          Security coverage on GitHub-hosted repositories
+        </h3>
+      </div>
+
+      <p class="text-body-2 text-neutral-500">
+        Two of the four security signals, OpenSSF Scorecard and security practices, exist only for repositories hosted
+        on GitHub. Every repository below is GitHub-hosted, so this is the furthest security scoring can currently
+        reach, and how much of that reach we have covered.
+      </p>
+
+      <div v-if="isLoading">
+        <lfx-skeleton
+          height="220px"
+          width="100%"
+        />
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[220px]"
+      >
+        <p class="text-neutral-500">No security coverage data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="overflow-x-auto"
+      >
+        <lfx-table>
+          <thead>
+            <tr>
+              <th>Stage</th>
+              <th>Linux Foundation</th>
+              <th>Share</th>
+              <th>Other projects</th>
+              <th>Share</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="stage in stages"
+              :key="stage.stage"
+            >
+              <td>{{ stage.label }}</td>
+              <td>{{ formatNumber(stage.lf) }}</td>
+              <td>{{ stage.lfSharePct }}%</td>
+              <td>{{ formatNumber(stage.other) }}</td>
+              <td>{{ stage.otherSharePct }}%</td>
+            </tr>
+          </tbody>
+        </lfx-table>
+      </div>
+
+      <p
+        v-if="!isLoading && !isEmpty"
+        class="text-xs text-neutral-400"
+      >
+        A further {{ formatNumber(lfNonGithub) }} repositories sit on Gerrit, GitLab and elsewhere. There, these two
+        signals are absent by design rather than simply unscanned.
+      </p>
+
+      <p class="text-xs text-neutral-400">GitHub-hosted repositories · by stage</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { fetchHealthScoreCoverageGithubSecurityQuery } from '../services/github-security.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import LfxTable from '~/components/uikit/table/table.vue';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type { HealthScoreCoverageGithubSecurityStageCount } from '~~/types/report/health-score-coverage-github-security.types';
+
+const { data, isLoading } = fetchHealthScoreCoverageGithubSecurityQuery();
+
+const stages = computed<HealthScoreCoverageGithubSecurityStageCount[]>(() => data.value?.stages ?? []);
+
+const lfNonGithub = computed(() => data.value?.lfNonGithub ?? 0);
+
+const isEmpty = computed(() => !isLoading.value && stages.value.length === 0);
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageGithubSecurityFunnel',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/github-security.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/github-security.query.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Security coverage on GitHub-hosted repositories" widget
+// (IN-1293), written as a plain exported function rather than a method on the shared
+// HEALTH_SCORE_COVERAGE_API_SERVICE class - that class is created by IN-1285 and it isn't
+// IN-1293's turn to edit it yet. This will become a `fetchGithubSecurity()` method on the shared
+// service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_GITHUB_SECURITY`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { HealthScoreCoverageGithubSecurityData } from '~~/types/report/health-score-coverage-github-security.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-github-security';
+
+export function fetchHealthScoreCoverageGithubSecurityQuery() {
+  const queryFn: QueryFunction<HealthScoreCoverageGithubSecurityData> = () =>
+    $fetch<HealthScoreCoverageGithubSecurityData>(
+      '/api/report/health-score-coverage/github-security',
+    );
+
+  return useQuery<HealthScoreCoverageGithubSecurityData>({
+    queryKey: [TANSTACK_KEY],
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/github-security.get.ts
+++ b/frontend/server/api/report/health-score-coverage/github-security.get.ts
@@ -1,0 +1,28 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Security coverage on GitHub-hosted repositories" widget
+// (IN-1293). Not yet wired into the shared health-score-coverage report view/service - see
+// health-score-coverage-github-security.types.ts.
+//
+// Unlike the other widgets' routes, this one takes no `scope` query param: the
+// `health_score_report_github_security` pipe returns both the LF and Other columns in a single
+// call (see its DESCRIPTION block), so there is nothing to filter by.
+
+import { fetchHealthScoreCoverageGithubSecurity } from '~~/server/data/tinybird/report/health-score-coverage-github-security';
+import type { HealthScoreCoverageGithubSecurityData } from '~~/types/report/health-score-coverage-github-security.types';
+
+export default defineEventHandler(async (): Promise<HealthScoreCoverageGithubSecurityData> => {
+  try {
+    return await fetchHealthScoreCoverageGithubSecurity();
+  } catch (error: unknown) {
+    console.error('[health-score-coverage/github-security] error:', error);
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch health score coverage github security',
+    });
+  }
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-github-security.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-github-security.test.ts
@@ -1,0 +1,152 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageGithubSecurityRows } from './health-score-coverage-github-security';
+import type { HealthScoreCoverageGithubSecurityRow } from '~~/types/report/health-score-coverage-github-security.types';
+
+describe('mapHealthScoreCoverageGithubSecurityRows', () => {
+  test('maps both isLF rows into the fixed funnel stages with per-column share', () => {
+    const rows: HealthScoreCoverageGithubSecurityRow[] = [
+      {
+        isLF: 0,
+        tracked: 11712,
+        health_published: 10758,
+        security_scored: 7756,
+        scorecard_scanned: 5901,
+        lf_non_github: 2632,
+      },
+      {
+        isLF: 1,
+        tracked: 17231,
+        health_published: 8192,
+        security_scored: 4515,
+        scorecard_scanned: 1942,
+        lf_non_github: 2632,
+      },
+    ];
+
+    const result = mapHealthScoreCoverageGithubSecurityRows(rows);
+
+    expect(result.stages).toEqual([
+      {
+        stage: 'tracked',
+        label: 'Tracked in Insights',
+        lf: 17231,
+        lfSharePct: 100,
+        other: 11712,
+        otherSharePct: 100,
+      },
+      {
+        stage: 'healthPublished',
+        label: 'Health score published',
+        lf: 8192,
+        lfSharePct: 47.5,
+        other: 10758,
+        otherSharePct: 91.9,
+      },
+      {
+        stage: 'securityScored',
+        label: 'Security category scored',
+        lf: 4515,
+        lfSharePct: 26.2,
+        other: 7756,
+        otherSharePct: 66.2,
+      },
+      {
+        stage: 'scorecardScanned',
+        label: 'Scanned by Scorecard',
+        lf: 1942,
+        lfSharePct: 11.3,
+        other: 5901,
+        otherSharePct: 50.4,
+      },
+    ]);
+    expect(result.lfNonGithub).toBe(2632);
+  });
+
+  test('funnel is monotonically decreasing in both columns', () => {
+    const rows: HealthScoreCoverageGithubSecurityRow[] = [
+      {
+        isLF: 0,
+        tracked: 11712,
+        health_published: 10758,
+        security_scored: 7756,
+        scorecard_scanned: 5901,
+        lf_non_github: 2632,
+      },
+      {
+        isLF: 1,
+        tracked: 17231,
+        health_published: 8192,
+        security_scored: 4515,
+        scorecard_scanned: 1942,
+        lf_non_github: 2632,
+      },
+    ];
+
+    const { stages } = mapHealthScoreCoverageGithubSecurityRows(rows);
+
+    for (let i = 1; i < stages.length; i += 1) {
+      expect(stages[i]!.lf).toBeLessThanOrEqual(stages[i - 1]!.lf);
+      expect(stages[i]!.other).toBeLessThanOrEqual(stages[i - 1]!.other);
+    }
+  });
+
+  test('returns zeroed stages and lfNonGithub for an empty response', () => {
+    const result = mapHealthScoreCoverageGithubSecurityRows([]);
+
+    expect(result.stages.every((s) => s.lf === 0 && s.other === 0)).toBe(true);
+    expect(result.lfNonGithub).toBe(0);
+  });
+});
+
+describe('fetchHealthScoreCoverageGithubSecurity', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with no params and maps the rows', async () => {
+    const { fetchHealthScoreCoverageGithubSecurity } =
+      await import('./health-score-coverage-github-security');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [
+        {
+          isLF: 0,
+          tracked: 100,
+          health_published: 80,
+          security_scored: 60,
+          scorecard_scanned: 40,
+          lf_non_github: 5,
+        },
+        {
+          isLF: 1,
+          tracked: 200,
+          health_published: 150,
+          security_scored: 100,
+          scorecard_scanned: 50,
+          lf_non_github: 5,
+        },
+      ],
+    });
+
+    const result = await fetchHealthScoreCoverageGithubSecurity();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_github_security.json',
+      {},
+    );
+    expect(result.stages).toHaveLength(4);
+    expect(result.lfNonGithub).toBe(5);
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-github-security.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-github-security.ts
@@ -1,0 +1,81 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Security coverage on GitHub-hosted repositories" widget
+// (IN-1293). Kept out of the shared server/data/tinybird/report/health-score-coverage.ts file for
+// the same merge-order reason as the types file next to it - see
+// health-score-coverage-github-security.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageGithubSecurityData,
+  HealthScoreCoverageGithubSecurityRow,
+  HealthScoreCoverageGithubSecurityStageCount,
+  HealthScoreCoverageGithubSecurityStageKey,
+} from '~~/types/report/health-score-coverage-github-security.types';
+
+const EMPTY_ROW: HealthScoreCoverageGithubSecurityRow = {
+  isLF: 0,
+  tracked: 0,
+  health_published: 0,
+  security_scored: 0,
+  scorecard_scanned: 0,
+  lf_non_github: 0,
+};
+
+// Fixed funnel order per the pipe's DESCRIPTION (monotonically decreasing):
+// tracked >= healthPublished >= securityScored >= scorecardScanned.
+const STAGE_ORDER: {
+  stage: HealthScoreCoverageGithubSecurityStageKey;
+  label: string;
+  key: keyof Pick<
+    HealthScoreCoverageGithubSecurityRow,
+    'tracked' | 'health_published' | 'security_scored' | 'scorecard_scanned'
+  >;
+}[] = [
+  { stage: 'tracked', label: 'Tracked in Insights', key: 'tracked' },
+  { stage: 'healthPublished', label: 'Health score published', key: 'health_published' },
+  { stage: 'securityScored', label: 'Security category scored', key: 'security_scored' },
+  { stage: 'scorecardScanned', label: 'Scanned by Scorecard', key: 'scorecard_scanned' },
+];
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+const sharePct = (count: number, tracked: number): number =>
+  tracked === 0 ? 0 : round1((count / tracked) * 100);
+
+/**
+ * Maps the raw `health_score_report_github_security` rows (one per `isLF`) into the fixed
+ * 4-stage funnel shape the table consumes, plus the `lf_non_github` footnote count.
+ */
+export function mapHealthScoreCoverageGithubSecurityRows(
+  rows: HealthScoreCoverageGithubSecurityRow[],
+): HealthScoreCoverageGithubSecurityData {
+  const lfRow = rows.find((row) => row.isLF === 1) ?? EMPTY_ROW;
+  const otherRow = rows.find((row) => row.isLF === 0) ?? EMPTY_ROW;
+
+  const stages: HealthScoreCoverageGithubSecurityStageCount[] = STAGE_ORDER.map(
+    ({ stage, label, key }) => ({
+      stage,
+      label,
+      lf: lfRow[key],
+      lfSharePct: sharePct(lfRow[key], lfRow.tracked),
+      other: otherRow[key],
+      otherSharePct: sharePct(otherRow[key], otherRow.tracked),
+    }),
+  );
+
+  return {
+    stages,
+    lfNonGithub: lfRow.lf_non_github || otherRow.lf_non_github,
+  };
+}
+
+export async function fetchHealthScoreCoverageGithubSecurity(): Promise<HealthScoreCoverageGithubSecurityData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageGithubSecurityRow[]>(
+    '/v0/pipes/health_score_report_github_security.json',
+    {},
+  );
+
+  return mapHealthScoreCoverageGithubSecurityRows(result.data);
+}

--- a/frontend/types/report/health-score-coverage-github-security.types.ts
+++ b/frontend/types/report/health-score-coverage-github-security.types.ts
@@ -1,0 +1,41 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Security coverage on GitHub-hosted repositories" widget (IN-1293,
+// widget 08 of the Health Score Coverage report, epic IN-1276). Kept in its own file rather than
+// the shared types/report/health-score-coverage.types.ts because that file is edited sequentially
+// by each widget ticket in merge order, and it isn't IN-1293's turn yet (IN-1285's insights PR
+// #2164, IN-1286's insights PR #2165, IN-1287's insights PR #2166 and IN-1290's insights PR #2167
+// are still open). Will be merged into the shared types file in a follow-up.
+
+// Raw TB row from `health_score_report_github_security`: one row per `isLF` value (0 = Other,
+// 1 = Linux Foundation). `lf_non_github` is the same value repeated on every row.
+export interface HealthScoreCoverageGithubSecurityRow {
+  isLF: 0 | 1;
+  tracked: number;
+  health_published: number;
+  security_scored: number;
+  scorecard_scanned: number;
+  lf_non_github: number;
+}
+
+export type HealthScoreCoverageGithubSecurityStageKey =
+  'tracked' | 'healthPublished' | 'securityScored' | 'scorecardScanned';
+
+// One funnel stage, ready for the table. Stages are monotonically decreasing (each stage's `lf`
+// and `other` are <= the previous stage's) per the pipe's DESCRIPTION.
+export interface HealthScoreCoverageGithubSecurityStageCount {
+  stage: HealthScoreCoverageGithubSecurityStageKey;
+  label: string;
+  lf: number;
+  lfSharePct: number;
+  other: number;
+  otherSharePct: number;
+}
+
+export interface HealthScoreCoverageGithubSecurityData {
+  stages: HealthScoreCoverageGithubSecurityStageCount[];
+  // LF-affiliated tracked repos NOT hosted on GitHub, for the widget's footnote. Reused by
+  // IN-1291's widget 06 legend per the pipe's DESCRIPTION.
+  lfNonGithub: number;
+}


### PR DESCRIPTION
## Summary

Standalone insights code for widget 08 of the Health Score Coverage report (IN-1293) — a table showing security-signal coverage across GitHub-hosted repos, split into a Linux Foundation and Other projects column, funnel-shaped by stage (Tracked in Insights → Health score published → Security category scored → Scanned by Scorecard).

- `github-security-funnel.vue` — table widget, skeleton loading state, empty state, footnote with the `lf_non_github` count
- `health-score-coverage-github-security.ts` — data-fetcher + mapper (no `scope` param — the pipe returns both LF/Other columns in one call)
- `health-score-coverage-github-security.test.ts` — mapper unit tests, including a funnel-monotonicity assertion
- `github-security.get.ts` — API route
- `github-security.query.ts` — TanStack Query wrapper
- `health-score-coverage-github-security.types.ts` — standalone types

**Standalone widget code only — NOT yet wired into the shared report view/service/types/data files.** Wiring happens in a follow-up once prior widgets (#2164, #2165, #2166, #2167) merge into this release branch and it's IN-1293's turn in the sequential merge order. crowd.dev pipe `health_score_report_github_security` is already deployed to Tinybird production (crowd.dev PR #4582).

## Ground-truth discrepancy found vs. dispatch brief

The Jira ticket's prose lists the four table rows in this order: "Tracked in Insights, Scanned by Scorecard, Security category scored, Health score published." Taken literally, that order is **not** monotonically decreasing given the pipe's own validated production data (e.g. Other: tracked=11712, health\_published=10758, security\_scored=7756, scorecard\_scanned=5901) — which conflicts with the ticket's own acceptance criterion "Each stage count is ≤ the stage above it in both columns."

Built to the funnel order stated in the pipe's DESCRIPTION block (`tracked >= health_published >= security_scored >= scorecard_scanned`) and confirmed against live production data via the Tinybird MCP, treating the ticket's row-order sentence as a wording slip rather than the intended row order.

## Test plan

- [x] `pnpm lint:fix` — no errors (pre-existing warnings elsewhere, untouched)
- [x] `pnpm tsc-check` — clean
- [x] `pnpm test --run` — 254/254 passing, including the new mapper tests

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add GitHub security funnel table widget IN-1293** :point\_left:
