### PR TITLE
feat: add signal availability lf vs other widget

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/signal-availability-lf.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/signal-availability-lf.vue
@@ -1,0 +1,250 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 06 "Signal availability inside and outside the Linux Foundation" component for
+  the Health Score Coverage report (IN-1291, epic IN-1276). Not yet wired into
+  health-score-coverage-report.vue - see health-score-coverage-signal-availability-lf.types.ts for
+  why. Reuses the widget 05 pipe (IN-1290) but is a fully separate component - IN-1290's own
+  signal-availability.vue is not touched here.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div>
+        <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">06 · Availability</p>
+        <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+          Signal availability inside and outside the Linux Foundation
+        </h3>
+      </div>
+
+      <p class="text-body-2 text-neutral-500">
+        The widest gaps come from where code is hosted, not from how projects are run. OpenSSF Scorecard and security
+        practices are collected for GitHub only, and Linux Foundation repositories sit on Gerrit, GitLab and other hosts
+        where those signals do not exist at all.
+      </p>
+
+      <div v-if="isLoading">
+        <div class="h-[420px]">
+          <lfx-skeleton
+            height="100%"
+            width="100%"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[420px]"
+      >
+        <p class="text-neutral-500">No signal availability data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="flex flex-col gap-4"
+      >
+        <div
+          v-for="group in categoryGroups"
+          :key="group.categoryKey"
+          class="flex flex-col gap-1"
+        >
+          <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">{{ group.label }}</p>
+          <div :style="{ height: `${group.signals.length * 64 + 24}px` }">
+            <client-only>
+              <lfx-chart
+                :config="group.chartConfig"
+                :animation="true"
+              />
+            </client-only>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-x-6 gap-y-1 text-body-2 text-neutral-500">
+          <span class="flex items-center gap-2">
+            <i
+              class="inline-block w-3 h-3 rounded-sm"
+              :style="{ background: lfxColors.brand[500] }"
+            />
+            Linux Foundation projects ({{ formatNumber(lfReposTracked) }} repositories)
+          </span>
+          <span class="flex items-center gap-2">
+            <i
+              class="inline-block w-3 h-3 rounded-sm"
+              :style="{ background: lfxColors.accent[500] }"
+            />
+            Other tracked projects ({{ formatNumber(otherReposTracked) }} repositories)
+          </span>
+        </div>
+      </div>
+
+      <p class="text-xs text-neutral-400">Signal availability · Linux Foundation and other projects</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { fetchHealthScoreCoverageSignalAvailabilityLfQuery } from '../services/signal-availability-lf.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import { lfxColors } from '~/config/styles/colors';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type { HealthScoreCoverageSignalAvailabilityLfSignal } from '~~/types/report/health-score-coverage-signal-availability-lf.types';
+
+// Display names per the design copy, keyed by the pipe's `signal_key`. Duplicated from IN-1290's
+// signal-availability.vue rather than imported - that component isn't merged into this release
+// branch yet, and this widget owns fully separate files per the merge-order rule (see the types
+// file). Same reasoning IN-1290 gives for not importing from a shared config/signals.ts.
+const SIGNAL_LABELS: Record<string, string> = {
+  commitActivity: 'Commit activity',
+  responsiveness: 'Responsiveness',
+  orgDiversity: 'Organizational diversity',
+  prMerge: 'Pull request merge',
+  busFactor: 'Bus factor',
+  openVuln: 'Known vulnerabilities',
+  issueResolution: 'Issue resolution',
+  securityPractices: 'Security practices',
+  dependencyHealth: 'Dependency health',
+  scorecard: 'OpenSSF Scorecard',
+  releaseCadence: 'Release cadence',
+};
+
+const displayLabel = (signalKey: string): string => SIGNAL_LABELS[signalKey] ?? signalKey;
+
+// Category grouping and order per the ticket copy: Maintainer health, Security & supply chain,
+// Development activity - matches the `category_key` values the pipe already returns per signal.
+const CATEGORY_LABELS: Record<string, string> = {
+  maintainerHealth: 'Maintainer health',
+  securitySupplyChain: 'Security & supply chain',
+  developmentActivity: 'Development activity',
+};
+const CATEGORY_ORDER = ['maintainerHealth', 'securitySupplyChain', 'developmentActivity'];
+
+const { data, isLoading } = fetchHealthScoreCoverageSignalAvailabilityLfQuery();
+
+const signals = computed<HealthScoreCoverageSignalAvailabilityLfSignal[]>(() => data.value?.signals ?? []);
+const lfReposTracked = computed(() => data.value?.lfReposTracked ?? 0);
+const otherReposTracked = computed(() => data.value?.otherReposTracked ?? 0);
+
+const isEmpty = computed(() => !isLoading.value && signals.value.length === 0);
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+interface CategoryGroup {
+  categoryKey: string;
+  label: string;
+  signals: HealthScoreCoverageSignalAvailabilityLfSignal[];
+  chartConfig: ECOption;
+}
+
+// Same visual approach as widget 03 (three grouped horizontal bar charts in one card): each
+// category gets its own chart, sized to its own row count, rather than one chart with 11
+// categories and inline group headers echarts has no native support for. Inline here rather than
+// a separate chart-config module - `pnpm tsc-check` doesn't parse `.vue` files, which broke a
+// prior widget's standalone module that imported a type re-exported only from a `.vue` file.
+const buildCategoryChartConfig = (categorySignals: HealthScoreCoverageSignalAvailabilityLfSignal[]): ECOption => {
+  const categories = categorySignals.map((signal) => displayLabel(signal.signalKey));
+  const lfValues = categorySignals.map((signal) => round1(signal.lf.availablePct));
+  const otherValues = categorySignals.map((signal) => round1(signal.other.availablePct));
+
+  return {
+    grid: {
+      left: 170,
+      right: '5%',
+      top: 4,
+      bottom: 4,
+      containLabel: false,
+    },
+    xAxis: {
+      type: 'value',
+      max: 100,
+      axisLabel: {
+        fontSize: 10,
+        fontWeight: 'normal',
+        color: lfxColors.neutral[400],
+        formatter: '{value}%',
+      },
+      axisLine: { show: false },
+      splitLine: {
+        lineStyle: {
+          type: 'solid',
+          color: lfxColors.neutral[200],
+        },
+      },
+      axisTick: { show: false },
+    },
+    yAxis: {
+      type: 'category',
+      data: categories,
+      inverse: true,
+      axisLabel: {
+        fontSize: 13,
+        fontWeight: 500,
+        color: lfxColors.neutral[900],
+        align: 'left',
+        width: 150,
+        margin: 150,
+        overflow: 'truncate',
+      },
+      axisLine: { show: false },
+      axisTick: { show: false },
+    },
+    legend: { show: false },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (params: unknown) => {
+        const paramArray = params as Array<{ seriesName: string; value: number }>;
+        if (!paramArray || paramArray.length === 0) return '';
+        return paramArray.map((param) => `${param.seriesName}: ${param.value}%`).join('<br/>');
+      },
+    },
+    series: [
+      {
+        name: 'Linux Foundation projects',
+        type: 'bar',
+        data: lfValues,
+        barMaxWidth: 8,
+        itemStyle: {
+          color: lfxColors.brand[500],
+          borderRadius: [10, 10, 10, 10],
+        },
+      },
+      {
+        name: 'Other tracked projects',
+        type: 'bar',
+        data: otherValues,
+        barMaxWidth: 8,
+        itemStyle: {
+          color: lfxColors.accent[500],
+          borderRadius: [10, 10, 10, 10],
+        },
+      },
+    ],
+  };
+};
+
+const categoryGroups = computed(() =>
+  CATEGORY_ORDER.map((categoryKey) => {
+    const categorySignals = signals.value
+      .filter((signal) => signal.categoryKey === categoryKey)
+      .sort((a, b) => b.lf.availablePct - a.lf.availablePct);
+
+    return {
+      categoryKey,
+      label: CATEGORY_LABELS[categoryKey] ?? categoryKey,
+      signals: categorySignals,
+      chartConfig: buildCategoryChartConfig(categorySignals),
+    } satisfies CategoryGroup;
+  }).filter((group) => group.signals.length > 0),
+);
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageSignalAvailabilityLf',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/signal-availability-lf.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/signal-availability-lf.query.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Signal availability inside and outside the Linux Foundation"
+// widget (IN-1291), written as a plain exported function rather than a method on the shared
+// HEALTH_SCORE_COVERAGE_API_SERVICE class - that class is created by IN-1285 and it isn't
+// IN-1291's turn to edit it yet. This will become a `fetchSignalAvailabilityLf()` method on the
+// shared service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_SIGNAL_AVAILABILITY_LF`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { HealthScoreCoverageSignalAvailabilityLfData } from '~~/types/report/health-score-coverage-signal-availability-lf.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-signal-availability-lf';
+
+export function fetchHealthScoreCoverageSignalAvailabilityLfQuery() {
+  const queryFn: QueryFunction<HealthScoreCoverageSignalAvailabilityLfData> = () =>
+    $fetch<HealthScoreCoverageSignalAvailabilityLfData>(
+      '/api/report/health-score-coverage/signal-availability-lf',
+    );
+
+  return useQuery<HealthScoreCoverageSignalAvailabilityLfData>({
+    queryKey: [TANSTACK_KEY],
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/signal-availability-lf.get.ts
+++ b/frontend/server/api/report/health-score-coverage/signal-availability-lf.get.ts
@@ -1,0 +1,29 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Signal availability inside and outside the Linux Foundation"
+// widget (IN-1291). Not yet wired into the shared health-score-coverage report view/service - see
+// health-score-coverage-signal-availability-lf.types.ts.
+//
+// No `scope` query param, unlike IN-1290's signal-availability route - this widget always renders
+// both the lf and other series together, so the fetcher below fetches both scopes internally.
+
+import { fetchHealthScoreCoverageSignalAvailabilityLf } from '~~/server/data/tinybird/report/health-score-coverage-signal-availability-lf';
+import type { HealthScoreCoverageSignalAvailabilityLfData } from '~~/types/report/health-score-coverage-signal-availability-lf.types';
+
+export default defineEventHandler(
+  async (): Promise<HealthScoreCoverageSignalAvailabilityLfData> => {
+    try {
+      return await fetchHealthScoreCoverageSignalAvailabilityLf();
+    } catch (error: unknown) {
+      console.error('[health-score-coverage/signal-availability-lf] error:', error);
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        throw error;
+      }
+      throw createError({
+        statusCode: 500,
+        statusMessage: 'Failed to fetch health score coverage signal availability (LF vs other)',
+      });
+    }
+  },
+);

--- a/frontend/server/data/tinybird/report/health-score-coverage-signal-availability-lf.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-signal-availability-lf.test.ts
@@ -1,0 +1,147 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { combineHealthScoreCoverageSignalAvailabilityLfRows } from './health-score-coverage-signal-availability-lf';
+import type { HealthScoreCoverageSignalAvailabilityLfRow } from '~~/types/report/health-score-coverage-signal-availability-lf.types';
+
+describe('combineHealthScoreCoverageSignalAvailabilityLfRows', () => {
+  test('pairs lf and other rows by signal_key', () => {
+    const lfRows: HealthScoreCoverageSignalAvailabilityLfRow[] = [
+      {
+        signal_key: 'busFactor',
+        category_key: 'maintainerHealth',
+        available_pct: 41.0,
+        repos_available: 434,
+        repos_tracked: 1097,
+      },
+      {
+        signal_key: 'scorecard',
+        category_key: 'securitySupplyChain',
+        available_pct: 9.8,
+        repos_available: 107,
+        repos_tracked: 1097,
+      },
+    ];
+    const otherRows: HealthScoreCoverageSignalAvailabilityLfRow[] = [
+      {
+        signal_key: 'busFactor',
+        category_key: 'maintainerHealth',
+        available_pct: 82.3,
+        repos_available: 8675,
+        repos_tracked: 10541,
+      },
+      {
+        signal_key: 'scorecard',
+        category_key: 'securitySupplyChain',
+        available_pct: 50.5,
+        repos_available: 5323,
+        repos_tracked: 10541,
+      },
+    ];
+
+    const result = combineHealthScoreCoverageSignalAvailabilityLfRows(lfRows, otherRows);
+
+    expect(result).toEqual({
+      signals: [
+        {
+          signalKey: 'busFactor',
+          categoryKey: 'maintainerHealth',
+          lf: { availablePct: 41.0, reposAvailable: 434, reposTracked: 1097 },
+          other: { availablePct: 82.3, reposAvailable: 8675, reposTracked: 10541 },
+        },
+        {
+          signalKey: 'scorecard',
+          categoryKey: 'securitySupplyChain',
+          lf: { availablePct: 9.8, reposAvailable: 107, reposTracked: 1097 },
+          other: { availablePct: 50.5, reposAvailable: 5323, reposTracked: 10541 },
+        },
+      ],
+      lfReposTracked: 1097,
+      otherReposTracked: 10541,
+    });
+  });
+
+  test('drops a signal present in lf rows but missing from other rows', () => {
+    const lfRows: HealthScoreCoverageSignalAvailabilityLfRow[] = [
+      {
+        signal_key: 'busFactor',
+        category_key: 'maintainerHealth',
+        available_pct: 41.0,
+        repos_available: 434,
+        repos_tracked: 1097,
+      },
+    ];
+
+    const result = combineHealthScoreCoverageSignalAvailabilityLfRows(lfRows, []);
+
+    expect(result.signals).toEqual([]);
+    expect(result.lfReposTracked).toBe(1097);
+    expect(result.otherReposTracked).toBe(0);
+  });
+
+  test('returns an empty result for empty responses', () => {
+    const result = combineHealthScoreCoverageSignalAvailabilityLfRows([], []);
+
+    expect(result).toEqual({ signals: [], lfReposTracked: 0, otherReposTracked: 0 });
+  });
+});
+
+describe('fetchHealthScoreCoverageSignalAvailabilityLf', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the
+    // combine-function tests) already cached a copy wired to the real '../tinybird'. Reset the
+    // module registry so the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe for both scopes and combines the rows', async () => {
+    const { fetchHealthScoreCoverageSignalAvailabilityLf } =
+      await import('./health-score-coverage-signal-availability-lf');
+
+    mockFetchFromTinybird
+      .mockResolvedValueOnce({
+        data: [
+          {
+            signal_key: 'busFactor',
+            category_key: 'maintainerHealth',
+            available_pct: 41.0,
+            repos_available: 434,
+            repos_tracked: 1097,
+          },
+        ],
+      })
+      .mockResolvedValueOnce({
+        data: [
+          {
+            signal_key: 'busFactor',
+            category_key: 'maintainerHealth',
+            available_pct: 82.3,
+            repos_available: 8675,
+            repos_tracked: 10541,
+          },
+        ],
+      });
+
+    const result = await fetchHealthScoreCoverageSignalAvailabilityLf();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_signal_availability.json',
+      { scope: 'lf' },
+    );
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_signal_availability.json',
+      { scope: 'other' },
+    );
+    expect(result.signals).toHaveLength(1);
+    expect(result.signals[0]?.signalKey).toBe('busFactor');
+    expect(result.lfReposTracked).toBe(1097);
+    expect(result.otherReposTracked).toBe(10541);
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-signal-availability-lf.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-signal-availability-lf.ts
@@ -1,0 +1,69 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Signal availability inside and outside the Linux Foundation"
+// widget (IN-1291). Kept out of the shared server/data/tinybird/report/health-score-coverage.ts
+// file for the same merge-order reason as the types file next to it - see
+// health-score-coverage-signal-availability-lf.types.ts.
+//
+// Reuses the `health_score_report_signal_availability` pipe already deployed for IN-1290
+// (crowd.dev PR #4581), calling it twice with `scope=lf` and `scope=other` and pairing the rows
+// by `signal_key`.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageSignalAvailabilityLfData,
+  HealthScoreCoverageSignalAvailabilityLfRow,
+} from '~~/types/report/health-score-coverage-signal-availability-lf.types';
+
+const PIPE_PATH = '/v0/pipes/health_score_report_signal_availability.json';
+
+/**
+ * Pairs the `lf` and `other` scope rows by `signal_key` into one combined row per signal. A
+ * signal missing from either side (shouldn't happen - both calls cover the same fixed signal
+ * set) is dropped rather than rendered with a missing series.
+ */
+export function combineHealthScoreCoverageSignalAvailabilityLfRows(
+  lfRows: HealthScoreCoverageSignalAvailabilityLfRow[],
+  otherRows: HealthScoreCoverageSignalAvailabilityLfRow[],
+): HealthScoreCoverageSignalAvailabilityLfData {
+  const otherBySignalKey = new Map(otherRows.map((row) => [row.signal_key, row]));
+
+  const signals = lfRows
+    .filter((lfRow) => otherBySignalKey.has(lfRow.signal_key))
+    .map((lfRow) => {
+      const otherRow = otherBySignalKey.get(
+        lfRow.signal_key,
+      ) as HealthScoreCoverageSignalAvailabilityLfRow;
+
+      return {
+        signalKey: lfRow.signal_key,
+        categoryKey: lfRow.category_key,
+        lf: {
+          availablePct: lfRow.available_pct,
+          reposAvailable: lfRow.repos_available,
+          reposTracked: lfRow.repos_tracked,
+        },
+        other: {
+          availablePct: otherRow.available_pct,
+          reposAvailable: otherRow.repos_available,
+          reposTracked: otherRow.repos_tracked,
+        },
+      };
+    });
+
+  return {
+    signals,
+    lfReposTracked: lfRows[0]?.repos_tracked ?? 0,
+    otherReposTracked: otherRows[0]?.repos_tracked ?? 0,
+  };
+}
+
+export async function fetchHealthScoreCoverageSignalAvailabilityLf(): Promise<HealthScoreCoverageSignalAvailabilityLfData> {
+  const [lfResult, otherResult] = await Promise.all([
+    fetchFromTinybird<HealthScoreCoverageSignalAvailabilityLfRow[]>(PIPE_PATH, { scope: 'lf' }),
+    fetchFromTinybird<HealthScoreCoverageSignalAvailabilityLfRow[]>(PIPE_PATH, { scope: 'other' }),
+  ]);
+
+  return combineHealthScoreCoverageSignalAvailabilityLfRows(lfResult.data, otherResult.data);
+}

--- a/frontend/types/report/health-score-coverage-signal-availability-lf.types.ts
+++ b/frontend/types/report/health-score-coverage-signal-availability-lf.types.ts
@@ -1,0 +1,42 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Signal availability inside and outside the Linux Foundation" widget
+// (IN-1291, widget 06 of the Health Score Coverage report, epic IN-1276). Kept in its own file
+// rather than the shared types/report/health-score-coverage.types.ts because that file is edited
+// sequentially by each widget ticket in merge order, and it isn't IN-1291's turn yet. Will be
+// merged into the shared types file in a follow-up. Not imported from IN-1290's
+// health-score-coverage-signal-availability.types.ts - that widget's insights PR hasn't merged
+// into this release branch yet, so its files don't exist here.
+
+export type HealthScoreCoverageSignalAvailabilityLfScope = 'lf' | 'other';
+
+// Raw TB row from `health_score_report_signal_availability`, called once per scope.
+export interface HealthScoreCoverageSignalAvailabilityLfRow {
+  signal_key: string;
+  category_key: string;
+  available_pct: number;
+  repos_available: number;
+  repos_tracked: number;
+}
+
+// One signal's availability for a single scope (lf or other).
+export interface HealthScoreCoverageSignalAvailabilityLfScopeCount {
+  availablePct: number;
+  reposAvailable: number;
+  reposTracked: number;
+}
+
+// One signal paired across both scopes, ready for the chart.
+export interface HealthScoreCoverageSignalAvailabilityLfSignal {
+  signalKey: string;
+  categoryKey: string;
+  lf: HealthScoreCoverageSignalAvailabilityLfScopeCount;
+  other: HealthScoreCoverageSignalAvailabilityLfScopeCount;
+}
+
+export interface HealthScoreCoverageSignalAvailabilityLfData {
+  signals: HealthScoreCoverageSignalAvailabilityLfSignal[];
+  lfReposTracked: number;
+  otherReposTracked: number;
+}


### PR DESCRIPTION
## Summary

Standalone widget code only — NOT yet wired into the shared report view/service/types/data files. Wiring happens in a follow-up once prior widgets (#2164-#2168) merge into this release branch and it's IN-1291's turn in the sequential merge order.

Adds widget 06 of the Health Score Coverage report (IN-1291, epic IN-1276): "Signal availability inside and outside the Linux Foundation" — three grouped horizontal bar charts (Maintainer health, Security & supply chain, Development activity), each pairing the Linux Foundation series against the other-tracked-projects series for its signals.

Reuses crowd.dev pipe `health_score_report_signal_availability` (already deployed to Tinybird production, crowd.dev PR [#4581](https://github.com/linuxfoundation/crowd.dev/pull/4581)) — no new crowd.dev PR needed for this ticket, per IN-1291's supervisor-state.md. Calls it twice (`scope=lf`, `scope=other`) and pairs the rows by `signal_key`.

Files added, all standalone (no shared file touched):

- `types/report/health-score-coverage-signal-availability-lf.types.ts`
- `server/data/tinybird/report/health-score-coverage-signal-availability-lf.ts` (+ `.test.ts`)
- `server/api/report/health-score-coverage/signal-availability-lf.get.ts`
- `app/components/modules/report/health-score-coverage/services/signal-availability-lf.query.ts`
- `app/components/modules/report/health-score-coverage/components/signal-availability-lf.vue`

The footnote's `{n}` non-GitHub-LF-repos count depends on the widget 08 pipe (IN-1293, `lf_non_github`) — per the ticket, rendered without the number until widget 08 lands.

## Test plan

- [x] `pnpm lint` — clean (0 errors on touched files; pre-existing warnings elsewhere untouched)
- [x] `pnpm tsc-check` — clean
- [x] `pnpm vitest run server/data/tinybird/report/health-score-coverage-signal-availability-lf.test.ts` — 4/4 passing
- [ ] Manual QA once wired into the shared report view (follow-up PR)

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add signal availability lf vs other widget** :point\_left:
