### PR TITLE
feat: add standalone signal scores widget IN-1288

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/signal-scores.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/signal-scores.vue
@@ -1,0 +1,240 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 03 "Where the strongest repositories pull ahead" component for the Health
+  Score Coverage report (IN-1288, epic IN-1276). Not yet wired into
+  health-score-coverage-report.vue - see health-score-coverage-signal-scores.types.ts for why.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div>
+        <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">03 · Distribution</p>
+        <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+          Where the strongest repositories pull ahead
+        </h3>
+      </div>
+
+      <p class="text-body-2 text-neutral-500">
+        Each signal awards a fixed number of points, shown here as a share of that maximum. Every row compares the
+        strongest fifth of repositories against the median one. Bars close together mean the signal barely distinguishes
+        anyone. Bars far apart mean it is doing real work separating strong repositories from the rest. Repositories
+        count only where the signal can be measured.
+      </p>
+
+      <div v-if="isLoading">
+        <div class="h-[420px]">
+          <lfx-skeleton
+            height="100%"
+            width="100%"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[420px]"
+      >
+        <p class="text-neutral-500">No signal score data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="flex flex-col gap-4"
+      >
+        <div
+          v-for="group in categoryGroups"
+          :key="group.categoryKey"
+          class="flex flex-col gap-1"
+        >
+          <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">{{ group.label }}</p>
+          <div :style="{ height: `${group.signals.length * 64 + 24}px` }">
+            <client-only>
+              <lfx-chart
+                :config="group.chartConfig"
+                :animation="true"
+              />
+            </client-only>
+          </div>
+        </div>
+
+        <div class="flex flex-wrap gap-x-6 gap-y-1 text-body-2 text-neutral-500">
+          <span class="flex items-center gap-2">
+            <i
+              class="inline-block w-3 h-3 rounded-sm"
+              :style="{ background: lfxColors.brand[500] }"
+            />
+            Top 20% of repositories
+          </span>
+          <span class="flex items-center gap-2">
+            <i
+              class="inline-block w-3 h-3 rounded-sm"
+              :style="{ background: lfxColors.neutral[400] }"
+            />
+            Typical repository, the median
+          </span>
+        </div>
+      </div>
+
+      <p class="text-xs text-neutral-400">Signal scores · repositories where the signal can be measured</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { fetchHealthScoreCoverageSignalScoresQuery } from '../services/signal-scores.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import { lfxColors } from '~/config/styles/colors';
+import type { HealthScoreCoverageSignalScore } from '~~/types/report/health-score-coverage-signal-scores.types';
+
+// Display names per the design copy, keyed by the pipe's `signal_key`. Duplicated here rather than
+// imported from config/signals.ts because that shared file is created by IN-1285 and isn't ready
+// for this widget to depend on yet - see the types file for the merge-order explanation.
+const SIGNAL_LABELS: Record<string, string> = {
+  busFactor: 'Bus factor',
+  orgDiversity: 'Organizational diversity',
+  responsiveness: 'Responsiveness',
+  scorecard: 'OpenSSF Scorecard',
+  securityPractices: 'Security practices',
+  dependencyHealth: 'Dependency health',
+  releaseCadence: 'Release cadence',
+  issueResolution: 'Issue resolution',
+  prMerge: 'Pull request merge',
+};
+
+const displayLabel = (signalKey: string): string => SIGNAL_LABELS[signalKey] ?? signalKey;
+
+// Category grouping and order per the ticket copy: Maintainer health, Security & supply chain,
+// Development activity - matches the `category_key` values the pipe already returns per signal.
+const CATEGORY_LABELS: Record<string, string> = {
+  maintainerHealth: 'Maintainer health',
+  securitySupplyChain: 'Security & supply chain',
+  developmentActivity: 'Development activity',
+};
+const CATEGORY_ORDER = ['maintainerHealth', 'securitySupplyChain', 'developmentActivity'];
+
+const { data, isLoading } = fetchHealthScoreCoverageSignalScoresQuery();
+
+const signals = computed<HealthScoreCoverageSignalScore[]>(() => data.value?.signals ?? []);
+
+const isEmpty = computed(() => !isLoading.value && signals.value.length === 0);
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+interface CategoryGroup {
+  categoryKey: string;
+  label: string;
+  signals: HealthScoreCoverageSignalScore[];
+  chartConfig: ECOption;
+}
+
+// Three grouped horizontal bar charts in one card, one per category, each with two series (top
+// 20% vs median). Inline here rather than a separate chart-config module - `pnpm tsc-check`
+// doesn't parse `.vue` files, which broke a prior widget's standalone module that imported a type
+// re-exported only from a `.vue` file.
+const buildCategoryChartConfig = (categorySignals: HealthScoreCoverageSignalScore[]): ECOption => {
+  const categories = categorySignals.map((signal) => displayLabel(signal.signalKey));
+  const p80Values = categorySignals.map((signal) => round1(signal.p80Pct));
+  const medianValues = categorySignals.map((signal) => round1(signal.medianPct));
+
+  return {
+    grid: {
+      left: 170,
+      right: '5%',
+      top: 4,
+      bottom: 4,
+      containLabel: false,
+    },
+    xAxis: {
+      type: 'value',
+      max: 100,
+      axisLabel: {
+        fontSize: 10,
+        fontWeight: 'normal',
+        color: lfxColors.neutral[400],
+        formatter: '{value}%',
+      },
+      axisLine: { show: false },
+      splitLine: {
+        lineStyle: {
+          type: 'solid',
+          color: lfxColors.neutral[200],
+        },
+      },
+      axisTick: { show: false },
+    },
+    yAxis: {
+      type: 'category',
+      data: categories,
+      inverse: true,
+      axisLabel: {
+        fontSize: 13,
+        fontWeight: 500,
+        color: lfxColors.neutral[900],
+        align: 'left',
+        width: 150,
+        margin: 150,
+        overflow: 'truncate',
+      },
+      axisLine: { show: false },
+      axisTick: { show: false },
+    },
+    legend: { show: false },
+    tooltip: {
+      trigger: 'axis',
+      axisPointer: { type: 'shadow' },
+      formatter: (params: unknown) => {
+        const paramArray = params as Array<{ seriesName: string; value: number }>;
+        if (!paramArray || paramArray.length === 0) return '';
+        return paramArray.map((param) => `${param.seriesName}: ${param.value}%`).join('<br/>');
+      },
+    },
+    series: [
+      {
+        name: 'Top 20% of repositories',
+        type: 'bar',
+        data: p80Values,
+        barMaxWidth: 8,
+        itemStyle: {
+          color: lfxColors.brand[500],
+          borderRadius: [10, 10, 10, 10],
+        },
+      },
+      {
+        name: 'Typical repository, the median',
+        type: 'bar',
+        data: medianValues,
+        barMaxWidth: 8,
+        itemStyle: {
+          color: lfxColors.neutral[400],
+          borderRadius: [10, 10, 10, 10],
+        },
+      },
+    ],
+  };
+};
+
+const categoryGroups = computed(() =>
+  CATEGORY_ORDER.map((categoryKey) => {
+    const categorySignals = signals.value.filter((signal) => signal.categoryKey === categoryKey);
+
+    return {
+      categoryKey,
+      label: CATEGORY_LABELS[categoryKey] ?? categoryKey,
+      signals: categorySignals,
+      chartConfig: buildCategoryChartConfig(categorySignals),
+    } satisfies CategoryGroup;
+  }).filter((group) => group.signals.length > 0),
+);
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageSignalScores',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/signal-scores.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/signal-scores.query.ts
@@ -1,0 +1,32 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Where the strongest repositories pull ahead" widget
+// (IN-1288), written as a plain exported function rather than a method on the shared
+// HEALTH_SCORE_COVERAGE_API_SERVICE class - that class is created by IN-1285 and it isn't
+// IN-1288's turn to edit it yet. This will become a `fetchSignalScores()` method on the shared
+// service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_SIGNAL_SCORES`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { HealthScoreCoverageSignalScoresData } from '~~/types/report/health-score-coverage-signal-scores.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-signal-scores';
+
+export function fetchHealthScoreCoverageSignalScoresQuery() {
+  const queryFn: QueryFunction<HealthScoreCoverageSignalScoresData> = () =>
+    $fetch<HealthScoreCoverageSignalScoresData>('/api/report/health-score-coverage/signal-scores');
+
+  return useQuery<HealthScoreCoverageSignalScoresData>({
+    queryKey: [TANSTACK_KEY],
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/signal-scores.get.ts
+++ b/frontend/server/api/report/health-score-coverage/signal-scores.get.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Where the strongest repositories pull ahead" widget (IN-1288).
+// Not yet wired into the shared health-score-coverage report view/service - see
+// health-score-coverage-signal-scores.types.ts.
+//
+// No `scope` query param - this pipe is not scope-filtered per the ticket.
+
+import { fetchHealthScoreCoverageSignalScores } from '~~/server/data/tinybird/report/health-score-coverage-signal-scores';
+import type { HealthScoreCoverageSignalScoresData } from '~~/types/report/health-score-coverage-signal-scores.types';
+
+export default defineEventHandler(async (): Promise<HealthScoreCoverageSignalScoresData> => {
+  try {
+    return await fetchHealthScoreCoverageSignalScores();
+  } catch (error: unknown) {
+    console.error('[health-score-coverage/signal-scores] error:', error);
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch health score coverage signal scores',
+    });
+  }
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-signal-scores.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-signal-scores.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageSignalScoreRows } from './health-score-coverage-signal-scores';
+import type { HealthScoreCoverageSignalScoreRow } from '~~/types/report/health-score-coverage-signal-scores.types';
+
+describe('mapHealthScoreCoverageSignalScoreRows', () => {
+  test('maps raw rows to camelCase, preserving order', () => {
+    const rows: HealthScoreCoverageSignalScoreRow[] = [
+      {
+        signal_key: 'busFactor',
+        category_key: 'maintainerHealth',
+        p80_pct: 72.2,
+        median_pct: 38.9,
+        repos: 17776,
+      },
+      {
+        signal_key: 'scorecard',
+        category_key: 'securitySupplyChain',
+        p80_pct: 62.5,
+        median_pct: 50.0,
+        repos: 7843,
+      },
+    ];
+
+    const result = mapHealthScoreCoverageSignalScoreRows(rows);
+
+    expect(result.signals).toEqual([
+      {
+        signalKey: 'busFactor',
+        categoryKey: 'maintainerHealth',
+        p80Pct: 72.2,
+        medianPct: 38.9,
+        repos: 17776,
+      },
+      {
+        signalKey: 'scorecard',
+        categoryKey: 'securitySupplyChain',
+        p80Pct: 62.5,
+        medianPct: 50.0,
+        repos: 7843,
+      },
+    ]);
+  });
+
+  test('returns an empty result for an empty response', () => {
+    const result = mapHealthScoreCoverageSignalScoreRows([]);
+
+    expect(result.signals).toEqual([]);
+  });
+});
+
+describe('fetchHealthScoreCoverageSignalScores', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with no params and maps the rows', async () => {
+    const { fetchHealthScoreCoverageSignalScores } =
+      await import('./health-score-coverage-signal-scores');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [
+        {
+          signal_key: 'busFactor',
+          category_key: 'maintainerHealth',
+          p80_pct: 72.2,
+          median_pct: 38.9,
+          repos: 17776,
+        },
+      ],
+    });
+
+    const result = await fetchHealthScoreCoverageSignalScores();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_signal_scores.json',
+      {},
+    );
+    expect(result.signals).toHaveLength(1);
+    expect(result.signals[0]?.signalKey).toBe('busFactor');
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-signal-scores.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-signal-scores.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Where the strongest repositories pull ahead" widget (IN-1288).
+// Kept out of the shared server/data/tinybird/report/health-score-coverage.ts file for the same
+// merge-order reason as the types file next to it - see
+// health-score-coverage-signal-scores.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageSignalScore,
+  HealthScoreCoverageSignalScoreRow,
+  HealthScoreCoverageSignalScoresData,
+} from '~~/types/report/health-score-coverage-signal-scores.types';
+
+/**
+ * Maps the raw `health_score_report_signal_scores` rows into the shape the chart consumes. The
+ * pipe already returns one row per signal in a fixed order; the mapper doesn't rely on that and
+ * passes rows through as-is (unlike the availability widgets, there's no natural sort key here -
+ * display order is grouped by category in the component).
+ */
+export function mapHealthScoreCoverageSignalScoreRows(
+  rows: HealthScoreCoverageSignalScoreRow[],
+): HealthScoreCoverageSignalScoresData {
+  const signals: HealthScoreCoverageSignalScore[] = rows.map((row) => ({
+    signalKey: row.signal_key,
+    categoryKey: row.category_key,
+    p80Pct: row.p80_pct,
+    medianPct: row.median_pct,
+    repos: row.repos,
+  }));
+
+  return { signals };
+}
+
+export async function fetchHealthScoreCoverageSignalScores(): Promise<HealthScoreCoverageSignalScoresData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageSignalScoreRow[]>(
+    '/v0/pipes/health_score_report_signal_scores.json',
+    {},
+  );
+
+  return mapHealthScoreCoverageSignalScoreRows(result.data);
+}

--- a/frontend/types/report/health-score-coverage-signal-scores.types.ts
+++ b/frontend/types/report/health-score-coverage-signal-scores.types.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Where the strongest repositories pull ahead" widget (IN-1288, widget
+// 03 of the Health Score Coverage report, epic IN-1276). Kept in its own file rather than the
+// shared types/report/health-score-coverage.types.ts because that file is edited sequentially by
+// each widget ticket in merge order, and it isn't IN-1288's turn yet. Will be merged into the
+// shared types file in a follow-up.
+
+// Raw TB row from `health_score_report_signal_scores`: one row per signal.
+export interface HealthScoreCoverageSignalScoreRow {
+  signal_key: string;
+  category_key: string;
+  p80_pct: number;
+  median_pct: number;
+  repos: number;
+}
+
+// One signal's top-20%/median scores, ready for the chart.
+export interface HealthScoreCoverageSignalScore {
+  signalKey: string;
+  categoryKey: string;
+  p80Pct: number;
+  medianPct: number;
+  repos: number;
+}
+
+export interface HealthScoreCoverageSignalScoresData {
+  signals: HealthScoreCoverageSignalScore[];
+}


### PR DESCRIPTION
## Summary

Standalone widget code only - NOT yet wired into any shared file (report view, API service, TanstackKey enum, shared types, shared data). Wiring happens once this widget's turn comes up in the sequential release-branch merge order.

Widget 03 "Where the strongest repositories pull ahead" of the Health Score Coverage report (epic IN-1276): three grouped horizontal bar charts (one per category - Maintainer health, Security & supply chain, Development activity), each row comparing the 80th-percentile ("Top 20% of repositories") and median ("Typical repository") score for a signal, expressed as a percent of that signal's max points.

Files added:

- `frontend/types/report/health-score-coverage-signal-scores.types.ts`
- `frontend/server/data/tinybird/report/health-score-coverage-signal-scores.ts` (mapper + fetcher)
- `frontend/server/data/tinybird/report/health-score-coverage-signal-scores.test.ts` (Vitest mapper test)
- `frontend/server/api/report/health-score-coverage/signal-scores.get.ts`
- `frontend/app/components/modules/report/health-score-coverage/services/signal-scores.query.ts`
- `frontend/app/components/modules/report/health-score-coverage/components/signal-scores.vue`

## Data dependency

Consumes the `health_score_report_signal_scores` Tinybird pipe from crowd.dev PR [#4583](https://github.com/linuxfoundation/crowd.dev/pull/4583). Per that PR's `supervisor-state.md`, **the pipe has not been deployed to staging or production yet** (crowd.dev PR itself is also still open, not merged) - the owner explicitly held off deploying pending further instruction. This widget will not have live data until that pipe is deployed and the crowd.dev PR merges.

## Test plan

- [x] `pnpm tsc-check` - clean
- [x] `pnpm lint` - 0 errors (pre-existing unrelated warnings only)
- [x] `pnpm test` - new mapper test passes (3/3)
- [ ] Manual QA against live Tinybird data - blocked until the pipe above is deployed

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add standalone signal scores widget IN-1288** :point\_left:
