### PR TITLE
feat: add standalone category coverage widget IN-1289

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/category-coverage.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/category-coverage.vue
@@ -1,0 +1,143 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 04 "Repositories we can score, by category" component for the Health Score
+  Coverage report (IN-1289, epic IN-1276). Not yet wired into health-score-coverage-report.vue -
+  see health-score-coverage-category-coverage.types.ts for why.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div>
+        <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">04 · Availability</p>
+        <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+          Repositories we can score, by category
+        </h3>
+      </div>
+
+      <p class="text-body-2 text-neutral-500">
+        Maintainer health and development activity are measurable for roughly two thirds of repositories. Security
+        reaches the fewest, because several of its signals only exist for repositories hosted on GitHub.
+      </p>
+
+      <div v-if="isLoading">
+        <div class="h-[280px] sm:h-[350px]">
+          <lfx-skeleton
+            height="100%"
+            width="100%"
+          />
+        </div>
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[280px] sm:h-[350px]"
+      >
+        <p class="text-neutral-500">No health score data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="h-[280px] sm:h-[350px]"
+      >
+        <client-only>
+          <lfx-chart
+            :config="chartConfig"
+            :animation="true"
+          />
+        </client-only>
+      </div>
+
+      <p class="text-xs text-neutral-400">Category scores · all tracked repositories</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { fetchHealthScoreCoverageCategoryCoverageQuery } from '../services/category-coverage.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxChart from '~/components/uikit/chart/chart.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import { getHorizontalBarChartConfig, type HorizontalBarData } from '~/components/uikit/chart/configs/bar.chart';
+import { lfxColors } from '~/config/styles/colors';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type { HealthScoreCoverageCategoryCount } from '~~/types/report/health-score-coverage-category-coverage.types';
+
+// Display labels per the design copy, keyed by the pipe-derived `categoryKey`. Duplicated here
+// rather than imported from config/signals.ts because that shared file is created by IN-1285 and
+// isn't ready for this widget to depend on yet - see the types file for the merge-order
+// explanation.
+const CATEGORY_LABELS: Record<HealthScoreCoverageCategoryCount['categoryKey'], string> = {
+  maintainerHealth: 'Maintainer health',
+  developmentActivity: 'Development activity',
+  securitySupplyChain: 'Security & supply chain',
+};
+
+const { data, isLoading } = fetchHealthScoreCoverageCategoryCoverageQuery();
+
+const categories = computed(() => data.value?.categories ?? []);
+const reposTracked = computed(() => data.value?.reposTracked ?? 0);
+
+const isEmpty = computed(() => !isLoading.value && reposTracked.value === 0);
+
+const round1 = (value: number): number => Math.round(value * 10) / 10;
+
+const percentOf = (count: number, total: number): number => (total > 0 ? round1((count / total) * 100) : 0);
+
+interface CategoryCoverageTooltipParam {
+  dataIndex: number;
+}
+
+// Single-series horizontal bar chart, bars as raw scored-repo counts against an axis capped at
+// the tracked-repo total (not a 0-100% axis) - per the ticket's own spec, which calls out "axis
+// max = repos tracked" and a "n · pct%" label on each bar, distinct from the generic percent-axis
+// pattern used by some sibling widgets.
+const chartConfig = computed<ECOption>(() => {
+  const rows: HealthScoreCoverageCategoryCount[] = categories.value;
+  const total = reposTracked.value;
+
+  const barData: HorizontalBarData[] = rows.map((row) => ({
+    category: CATEGORY_LABELS[row.categoryKey] ?? row.categoryKey,
+    value: row.scored,
+  }));
+
+  return getHorizontalBarChartConfig(barData, lfxColors.brand[500], {
+    xAxis: { max: total },
+    tooltip: {
+      formatter: (params: unknown) => {
+        const paramArray = params as CategoryCoverageTooltipParam[];
+        const item = paramArray?.[0];
+        if (!item) return '';
+        const row = rows[item.dataIndex];
+        if (!row) return '';
+        return `${CATEGORY_LABELS[row.categoryKey] ?? row.categoryKey}: ${formatNumber(row.scored)} (${percentOf(row.scored, total)}%)`;
+      },
+    },
+    series: [
+      {
+        label: {
+          show: true,
+          position: 'right',
+          color: lfxColors.neutral[900],
+          fontSize: 12,
+          fontWeight: 600,
+          formatter: (params: { dataIndex: number }) => {
+            const row = rows[params.dataIndex];
+            if (!row) return '';
+            return `${formatNumber(row.scored)} · ${percentOf(row.scored, total)}%`;
+          },
+        },
+      },
+    ],
+  });
+});
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageCategoryCoverage',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/category-coverage.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/category-coverage.query.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Repositories we can score, by category" widget (IN-1289),
+// written as a plain exported function rather than a method on the shared
+// HEALTH_SCORE_COVERAGE_API_SERVICE class - that class is created by IN-1285 and it isn't
+// IN-1289's turn to edit it yet. This will become a `fetchCategoryCoverage()` method on the
+// shared service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_CATEGORY_COVERAGE`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { HealthScoreCoverageCategoryCoverageData } from '~~/types/report/health-score-coverage-category-coverage.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-category-coverage';
+
+export function fetchHealthScoreCoverageCategoryCoverageQuery() {
+  const queryFn: QueryFunction<HealthScoreCoverageCategoryCoverageData> = () =>
+    $fetch<HealthScoreCoverageCategoryCoverageData>(
+      '/api/report/health-score-coverage/category-coverage',
+    );
+
+  return useQuery<HealthScoreCoverageCategoryCoverageData>({
+    queryKey: [TANSTACK_KEY],
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/category-coverage.get.ts
+++ b/frontend/server/api/report/health-score-coverage/category-coverage.get.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Repositories we can score, by category" widget (IN-1289). Not yet
+// wired into the shared health-score-coverage report view/service - see
+// health-score-coverage-category-coverage.types.ts.
+//
+// No `scope` query param - this pipe is not scope-filtered per the ticket.
+
+import { fetchHealthScoreCoverageCategoryCoverage } from '~~/server/data/tinybird/report/health-score-coverage-category-coverage';
+import type { HealthScoreCoverageCategoryCoverageData } from '~~/types/report/health-score-coverage-category-coverage.types';
+
+export default defineEventHandler(async (): Promise<HealthScoreCoverageCategoryCoverageData> => {
+  try {
+    return await fetchHealthScoreCoverageCategoryCoverage();
+  } catch (error: unknown) {
+    console.error('[health-score-coverage/category-coverage] error:', error);
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch health score coverage category coverage',
+    });
+  }
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-category-coverage.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-category-coverage.test.ts
@@ -1,0 +1,93 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageCategoryCoverageRow } from './health-score-coverage-category-coverage';
+import type { HealthScoreCoverageCategoryCoverageRow } from '~~/types/report/health-score-coverage-category-coverage.types';
+
+describe('mapHealthScoreCoverageCategoryCoverageRow', () => {
+  test('maps the single row into the fixed 3-category order', () => {
+    const row: HealthScoreCoverageCategoryCoverageRow = {
+      maintainer_health_scored: 20665,
+      development_activity_scored: 19908,
+      security_supply_chain_scored: 12284,
+      repos_tracked: 31593,
+    };
+
+    const result = mapHealthScoreCoverageCategoryCoverageRow(row);
+
+    expect(result).toEqual({
+      categories: [
+        { categoryKey: 'maintainerHealth', scored: 20665 },
+        { categoryKey: 'developmentActivity', scored: 19908 },
+        { categoryKey: 'securitySupplyChain', scored: 12284 },
+      ],
+      reposTracked: 31593,
+    });
+  });
+
+  test('defaults every field to 0 when the pipe returns no row', () => {
+    const result = mapHealthScoreCoverageCategoryCoverageRow(undefined);
+
+    expect(result).toEqual({
+      categories: [
+        { categoryKey: 'maintainerHealth', scored: 0 },
+        { categoryKey: 'developmentActivity', scored: 0 },
+        { categoryKey: 'securitySupplyChain', scored: 0 },
+      ],
+      reposTracked: 0,
+    });
+  });
+});
+
+describe('fetchHealthScoreCoverageCategoryCoverage', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with no params and maps the row', async () => {
+    const { fetchHealthScoreCoverageCategoryCoverage } =
+      await import('./health-score-coverage-category-coverage');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [
+        {
+          maintainer_health_scored: 20665,
+          development_activity_scored: 19908,
+          security_supply_chain_scored: 12284,
+          repos_tracked: 31593,
+        },
+      ],
+    });
+
+    const result = await fetchHealthScoreCoverageCategoryCoverage();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_category_coverage.json',
+      {},
+    );
+    expect(result.reposTracked).toBe(31593);
+    expect(result.categories).toHaveLength(3);
+  });
+
+  test('maps an empty response to all-zero categories', async () => {
+    const { fetchHealthScoreCoverageCategoryCoverage } =
+      await import('./health-score-coverage-category-coverage');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({ data: [] });
+
+    const result = await fetchHealthScoreCoverageCategoryCoverage();
+
+    expect(result.reposTracked).toBe(0);
+    expect(result.categories.every((category) => category.scored === 0)).toBe(true);
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-category-coverage.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-category-coverage.ts
@@ -1,0 +1,43 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Repositories we can score, by category" widget (IN-1289).
+// Kept out of the shared server/data/tinybird/report/health-score-coverage.ts file for the same
+// merge-order reason as the types file next to it - see
+// health-score-coverage-category-coverage.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageCategoryCount,
+  HealthScoreCoverageCategoryCoverageData,
+  HealthScoreCoverageCategoryCoverageRow,
+} from '~~/types/report/health-score-coverage-category-coverage.types';
+
+/**
+ * Maps the raw `health_score_report_category_coverage` single-row response into the fixed
+ * 3-category shape the chart consumes, in the design's display order: maintainer health,
+ * development activity, security & supply chain.
+ */
+export function mapHealthScoreCoverageCategoryCoverageRow(
+  row: HealthScoreCoverageCategoryCoverageRow | undefined,
+): HealthScoreCoverageCategoryCoverageData {
+  const categories: HealthScoreCoverageCategoryCount[] = [
+    { categoryKey: 'maintainerHealth', scored: row?.maintainer_health_scored ?? 0 },
+    { categoryKey: 'developmentActivity', scored: row?.development_activity_scored ?? 0 },
+    { categoryKey: 'securitySupplyChain', scored: row?.security_supply_chain_scored ?? 0 },
+  ];
+
+  return {
+    categories,
+    reposTracked: row?.repos_tracked ?? 0,
+  };
+}
+
+export async function fetchHealthScoreCoverageCategoryCoverage(): Promise<HealthScoreCoverageCategoryCoverageData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageCategoryCoverageRow[]>(
+    '/v0/pipes/health_score_report_category_coverage.json',
+    {},
+  );
+
+  return mapHealthScoreCoverageCategoryCoverageRow(result.data[0]);
+}

--- a/frontend/types/report/health-score-coverage-category-coverage.types.ts
+++ b/frontend/types/report/health-score-coverage-category-coverage.types.ts
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Repositories we can score, by category" widget (IN-1289, widget 04 of
+// the Health Score Coverage report, epic IN-1276). Kept in its own file rather than the shared
+// types/report/health-score-coverage.types.ts because that file is edited sequentially by each
+// widget ticket in merge order, and it isn't IN-1289's turn yet. Will be merged into the shared
+// types file in a follow-up.
+
+// Raw TB row from `health_score_report_category_coverage`: a single row, one column per category
+// plus the shared denominator.
+export interface HealthScoreCoverageCategoryCoverageRow {
+  maintainer_health_scored: number;
+  development_activity_scored: number;
+  security_supply_chain_scored: number;
+  repos_tracked: number;
+}
+
+// One category's scored-repo count, keyed to match the pipe's column names minus the `_scored`
+// suffix. Display order is fixed per the design: maintainerHealth, developmentActivity,
+// securitySupplyChain.
+export interface HealthScoreCoverageCategoryCount {
+  categoryKey: 'maintainerHealth' | 'developmentActivity' | 'securitySupplyChain';
+  scored: number;
+}
+
+export interface HealthScoreCoverageCategoryCoverageData {
+  categories: HealthScoreCoverageCategoryCount[];
+  reposTracked: number;
+}


### PR DESCRIPTION
## Summary

Standalone widget code only for IN-1289 (widget 04 "Repositories we can score, by category" of the Health Score Coverage report, epic IN-1276) — **NOT yet wired into any shared file** (report view, API service, TanstackKey enum, shared types, shared data). Wiring happens once this widget's turn comes up in the sequential release-branch merge order (see `attachments/IN-1276/implementation-plan.md`).

Adds:

- `frontend/types/report/health-score-coverage-category-coverage.types.ts`
- `frontend/server/data/tinybird/report/health-score-coverage-category-coverage.ts` (mapper + fetcher)
- `frontend/server/data/tinybird/report/health-score-coverage-category-coverage.test.ts`
- `frontend/server/api/report/health-score-coverage/category-coverage.get.ts`
- `frontend/app/components/modules/report/health-score-coverage/services/category-coverage.query.ts`
- `frontend/app/components/modules/report/health-score-coverage/components/category-coverage.vue`

Three horizontal bars (Maintainer health, Development activity, Security & supply chain), each showing the count and percent of tracked repositories with a non-null category score, axis capped at the tracked-repo total per the ticket's own spec (not a 0-100% axis).

## Data dependency

crowd.dev pipe `health_score_report_category_coverage` — [PR #4584](https://github.com/linuxfoundation/crowd.dev/pull/4584) — is **open but not yet deployed to Tinybird**. Deploy was deliberately withheld by the owner ("dont deploy stuff to tinybird until i start work tomorrow", per `attachments/IN-1276/IN-1289/supervisor-state.md`). This PR can merge into the release branch independently of that deploy; the widget will render real data once the pipe is live in production.

## Test plan

- [x] `pnpm tsc-check` — green
- [x] `pnpm lint:fix` — 0 errors (pre-existing warnings elsewhere untouched)
- [x] `pnpm test --run` — 254/254 passing, including 6 new mapper/fetcher tests
- [x] MIT license header on every new file

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: add standalone category coverage widget IN-1289** :point\_left:
