### PR TITLE
feat: standalone widget 07 category maximum table

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/category-maximum-table.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/category-maximum-table.vue
@@ -1,0 +1,95 @@
+<!--
+Copyright (c) 2025 The Linux Foundation and each contributor.
+SPDX-License-Identifier: MIT
+-->
+<!--
+  Standalone widget 07 "Repositories scoring full marks" component for the Health Score Coverage
+  report (IN-1292, epic IN-1276). Not yet wired into health-score-coverage-report.vue - see
+  health-score-coverage-category-maximum.types.ts for why.
+
+  Named `category-maximum-table.vue` (not `category-maximum.vue`) per the ticket's own file list,
+  matching the sibling table widget's `github-security-funnel.vue` convention of suffixing the
+  component filename with its layout shape.
+-->
+<template>
+  <lfx-card class="p-4 md:p-6">
+    <div class="flex flex-col gap-4">
+      <div>
+        <p class="text-xs font-semibold text-neutral-400 uppercase tracking-wider">07 · Availability</p>
+        <h3 class="text-body-1 md:text-heading-4 font-secondary font-semibold text-neutral-900">
+          Repositories scoring full marks
+        </h3>
+      </div>
+
+      <p class="text-body-2 text-neutral-500">Repositories reaching the maximum in each category.</p>
+
+      <div v-if="isLoading">
+        <lfx-skeleton
+          height="180px"
+          width="100%"
+        />
+      </div>
+
+      <div
+        v-else-if="isEmpty"
+        class="flex items-center justify-center h-[180px]"
+      >
+        <p class="text-neutral-500">No health score data available.</p>
+      </div>
+
+      <div
+        v-else
+        class="overflow-x-auto"
+      >
+        <lfx-table>
+          <thead>
+            <tr>
+              <th>Category</th>
+              <th>Maximum</th>
+              <th>Repositories at maximum</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="category in categories"
+              :key="category.categoryKey"
+            >
+              <td>{{ category.label }}</td>
+              <td>{{ category.maximum }}</td>
+              <td>{{ formatNumber(category.reposAtMaximum) }}</td>
+            </tr>
+          </tbody>
+        </lfx-table>
+      </div>
+
+      <p class="text-xs text-neutral-400">
+        Security is the hardest to max out: it needs all four of its signals present and strong at once.
+      </p>
+
+      <p class="text-xs text-neutral-400">Category scores · all scored repositories</p>
+    </div>
+  </lfx-card>
+</template>
+
+<script setup lang="ts">
+import { computed } from 'vue';
+import { fetchHealthScoreCoverageCategoryMaximumQuery } from '../services/category-maximum.query';
+import LfxCard from '~/components/uikit/card/card.vue';
+import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
+import LfxTable from '~/components/uikit/table/table.vue';
+import { formatNumber } from '~/components/shared/utils/formatter';
+import type { HealthScoreCoverageCategoryMaximumCount } from '~~/types/report/health-score-coverage-category-maximum.types';
+
+const { data, isLoading } = fetchHealthScoreCoverageCategoryMaximumQuery();
+
+const categories = computed<HealthScoreCoverageCategoryMaximumCount[]>(() => data.value?.categories ?? []);
+const reposTracked = computed(() => data.value?.reposTracked ?? 0);
+
+const isEmpty = computed(() => !isLoading.value && reposTracked.value === 0);
+</script>
+
+<script lang="ts">
+export default {
+  name: 'LfxHealthScoreCoverageCategoryMaximumTable',
+};
+</script>

--- a/frontend/app/components/modules/report/health-score-coverage/services/category-maximum.query.ts
+++ b/frontend/app/components/modules/report/health-score-coverage/services/category-maximum.query.ts
@@ -1,0 +1,34 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone query function for the "Repositories scoring full marks" widget (IN-1292), written
+// as a plain exported function rather than a method on the shared
+// HEALTH_SCORE_COVERAGE_API_SERVICE class - that class is created by IN-1285 and it isn't
+// IN-1292's turn to edit it yet. This will become a `fetchCategoryMaximum()` method on the shared
+// service in the wiring follow-up.
+//
+// TANSTACK_KEY below matches the value the shared TanstackKey enum will get
+// (`TanstackKey.HEALTH_SCORE_COVERAGE_CATEGORY_MAXIMUM`) once this widget is wired in.
+
+import type { QueryFunction } from '@tanstack/vue-query';
+import { useQuery } from '@tanstack/vue-query';
+import type { HealthScoreCoverageCategoryMaximumData } from '~~/types/report/health-score-coverage-category-maximum.types';
+
+const STALE_TIME = 1000 * 60 * 60; // 1 hour
+const GC_TIME = 1000 * 60 * 60 * 24; // 24 hours
+
+const TANSTACK_KEY = 'health-score-coverage-category-maximum';
+
+export function fetchHealthScoreCoverageCategoryMaximumQuery() {
+  const queryFn: QueryFunction<HealthScoreCoverageCategoryMaximumData> = () =>
+    $fetch<HealthScoreCoverageCategoryMaximumData>(
+      '/api/report/health-score-coverage/category-maximum',
+    );
+
+  return useQuery<HealthScoreCoverageCategoryMaximumData>({
+    queryKey: [TANSTACK_KEY],
+    queryFn,
+    staleTime: STALE_TIME,
+    gcTime: GC_TIME,
+  });
+}

--- a/frontend/server/api/report/health-score-coverage/category-maximum.get.ts
+++ b/frontend/server/api/report/health-score-coverage/category-maximum.get.ts
@@ -1,0 +1,26 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone API route for the "Repositories scoring full marks" widget (IN-1292). Not yet wired
+// into the shared health-score-coverage report view/service - see
+// health-score-coverage-category-maximum.types.ts.
+//
+// No `scope` query param - this pipe is not scope-filtered per the ticket.
+
+import { fetchHealthScoreCoverageCategoryMaximum } from '~~/server/data/tinybird/report/health-score-coverage-category-maximum';
+import type { HealthScoreCoverageCategoryMaximumData } from '~~/types/report/health-score-coverage-category-maximum.types';
+
+export default defineEventHandler(async (): Promise<HealthScoreCoverageCategoryMaximumData> => {
+  try {
+    return await fetchHealthScoreCoverageCategoryMaximum();
+  } catch (error: unknown) {
+    console.error('[health-score-coverage/category-maximum] error:', error);
+    if (error && typeof error === 'object' && 'statusCode' in error) {
+      throw error;
+    }
+    throw createError({
+      statusCode: 500,
+      statusMessage: 'Failed to fetch health score coverage category maximum',
+    });
+  }
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-category-maximum.test.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-category-maximum.test.ts
@@ -1,0 +1,123 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { describe, test, expect, vi, beforeEach } from 'vitest';
+import { mapHealthScoreCoverageCategoryMaximumRow } from './health-score-coverage-category-maximum';
+import type { HealthScoreCoverageCategoryMaximumRow } from '~~/types/report/health-score-coverage-category-maximum.types';
+
+describe('mapHealthScoreCoverageCategoryMaximumRow', () => {
+  test('maps the single row into the fixed 3-category order with label and maximum', () => {
+    const row: HealthScoreCoverageCategoryMaximumRow = {
+      maintainer_health_max: 4679,
+      development_activity_max: 1442,
+      security_supply_chain_max: 135,
+      repos_tracked: 31593,
+    };
+
+    const result = mapHealthScoreCoverageCategoryMaximumRow(row);
+
+    expect(result).toEqual({
+      categories: [
+        {
+          categoryKey: 'maintainerHealth',
+          label: 'Maintainer health',
+          maximum: 40,
+          reposAtMaximum: 4679,
+        },
+        {
+          categoryKey: 'developmentActivity',
+          label: 'Development activity',
+          maximum: 25,
+          reposAtMaximum: 1442,
+        },
+        {
+          categoryKey: 'securitySupplyChain',
+          label: 'Security & supply chain',
+          maximum: 35,
+          reposAtMaximum: 135,
+        },
+      ],
+      reposTracked: 31593,
+    });
+  });
+
+  test('defaults every count to 0 when the pipe returns no row', () => {
+    const result = mapHealthScoreCoverageCategoryMaximumRow(undefined);
+
+    expect(result).toEqual({
+      categories: [
+        {
+          categoryKey: 'maintainerHealth',
+          label: 'Maintainer health',
+          maximum: 40,
+          reposAtMaximum: 0,
+        },
+        {
+          categoryKey: 'developmentActivity',
+          label: 'Development activity',
+          maximum: 25,
+          reposAtMaximum: 0,
+        },
+        {
+          categoryKey: 'securitySupplyChain',
+          label: 'Security & supply chain',
+          maximum: 35,
+          reposAtMaximum: 0,
+        },
+      ],
+      reposTracked: 0,
+    });
+  });
+});
+
+describe('fetchHealthScoreCoverageCategoryMaximum', () => {
+  const mockFetchFromTinybird = vi.fn();
+
+  beforeEach(() => {
+    mockFetchFromTinybird.mockClear();
+
+    // vi.doMock is not hoisted, and the top-level `import` of this module above (for the mapper
+    // tests) already cached a copy wired to the real '../tinybird'. Reset the module registry so
+    // the dynamic re-import below picks up the mock.
+    vi.resetModules();
+    vi.doMock(import('../tinybird'), () => ({
+      fetchFromTinybird: mockFetchFromTinybird,
+    }));
+  });
+
+  test('fetches the pipe with no params and maps the row', async () => {
+    const { fetchHealthScoreCoverageCategoryMaximum } =
+      await import('./health-score-coverage-category-maximum');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({
+      data: [
+        {
+          maintainer_health_max: 4679,
+          development_activity_max: 1442,
+          security_supply_chain_max: 135,
+          repos_tracked: 31593,
+        },
+      ],
+    });
+
+    const result = await fetchHealthScoreCoverageCategoryMaximum();
+
+    expect(mockFetchFromTinybird).toHaveBeenCalledWith(
+      '/v0/pipes/health_score_report_category_maximum.json',
+      {},
+    );
+    expect(result.reposTracked).toBe(31593);
+    expect(result.categories).toHaveLength(3);
+  });
+
+  test('maps an empty response to all-zero counts', async () => {
+    const { fetchHealthScoreCoverageCategoryMaximum } =
+      await import('./health-score-coverage-category-maximum');
+
+    mockFetchFromTinybird.mockResolvedValueOnce({ data: [] });
+
+    const result = await fetchHealthScoreCoverageCategoryMaximum();
+
+    expect(result.reposTracked).toBe(0);
+    expect(result.categories.every((category) => category.reposAtMaximum === 0)).toBe(true);
+  });
+});

--- a/frontend/server/data/tinybird/report/health-score-coverage-category-maximum.ts
+++ b/frontend/server/data/tinybird/report/health-score-coverage-category-maximum.ts
@@ -1,0 +1,78 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone data-fetcher for the "Repositories scoring full marks" widget (IN-1292). Kept out of
+// the shared server/data/tinybird/report/health-score-coverage.ts file for the same merge-order
+// reason as the types file next to it - see health-score-coverage-category-maximum.types.ts.
+
+import { fetchFromTinybird } from '../tinybird';
+import type {
+  HealthScoreCoverageCategoryMaximumCategoryKey,
+  HealthScoreCoverageCategoryMaximumCount,
+  HealthScoreCoverageCategoryMaximumData,
+  HealthScoreCoverageCategoryMaximumRow,
+} from '~~/types/report/health-score-coverage-category-maximum.types';
+
+// Fixed category order, label and exact-maximum score per the design copy. The maximum values
+// (40 / 25 / 35) are the pipe's own thresholds (`countIf(... = 40)` etc.), not derived from the
+// response, so they are declared here rather than read off a row.
+const CATEGORY_ORDER: {
+  categoryKey: HealthScoreCoverageCategoryMaximumCategoryKey;
+  label: string;
+  maximum: number;
+  key: keyof Pick<
+    HealthScoreCoverageCategoryMaximumRow,
+    'maintainer_health_max' | 'development_activity_max' | 'security_supply_chain_max'
+  >;
+}[] = [
+  {
+    categoryKey: 'maintainerHealth',
+    label: 'Maintainer health',
+    maximum: 40,
+    key: 'maintainer_health_max',
+  },
+  {
+    categoryKey: 'developmentActivity',
+    label: 'Development activity',
+    maximum: 25,
+    key: 'development_activity_max',
+  },
+  {
+    categoryKey: 'securitySupplyChain',
+    label: 'Security & supply chain',
+    maximum: 35,
+    key: 'security_supply_chain_max',
+  },
+];
+
+/**
+ * Maps the raw `health_score_report_category_maximum` single-row response into the fixed
+ * 3-category shape the table consumes, in the design's display order: maintainer health,
+ * development activity, security & supply chain.
+ */
+export function mapHealthScoreCoverageCategoryMaximumRow(
+  row: HealthScoreCoverageCategoryMaximumRow | undefined,
+): HealthScoreCoverageCategoryMaximumData {
+  const categories: HealthScoreCoverageCategoryMaximumCount[] = CATEGORY_ORDER.map(
+    ({ categoryKey, label, maximum, key }) => ({
+      categoryKey,
+      label,
+      maximum,
+      reposAtMaximum: row?.[key] ?? 0,
+    }),
+  );
+
+  return {
+    categories,
+    reposTracked: row?.repos_tracked ?? 0,
+  };
+}
+
+export async function fetchHealthScoreCoverageCategoryMaximum(): Promise<HealthScoreCoverageCategoryMaximumData> {
+  const result = await fetchFromTinybird<HealthScoreCoverageCategoryMaximumRow[]>(
+    '/v0/pipes/health_score_report_category_maximum.json',
+    {},
+  );
+
+  return mapHealthScoreCoverageCategoryMaximumRow(result.data[0]);
+}

--- a/frontend/types/report/health-score-coverage-category-maximum.types.ts
+++ b/frontend/types/report/health-score-coverage-category-maximum.types.ts
@@ -1,0 +1,35 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+// Standalone types for the "Repositories scoring full marks" widget (IN-1292, widget 07 of the
+// Health Score Coverage report, epic IN-1276). Kept in its own file rather than the shared
+// types/report/health-score-coverage.types.ts because that file is edited sequentially by each
+// widget ticket in merge order, and it isn't IN-1292's turn yet. Will be merged into the shared
+// types file in a follow-up.
+
+// Raw TB row from `health_score_report_category_maximum`: a single row, one column per category
+// plus the shared denominator.
+export interface HealthScoreCoverageCategoryMaximumRow {
+  maintainer_health_max: number;
+  development_activity_max: number;
+  security_supply_chain_max: number;
+  repos_tracked: number;
+}
+
+// Display order is fixed per the design: maintainerHealth, developmentActivity,
+// securitySupplyChain.
+export type HealthScoreCoverageCategoryMaximumCategoryKey =
+  'maintainerHealth' | 'developmentActivity' | 'securitySupplyChain';
+
+// One category's row for the table: its exact-maximum score and how many tracked repos hit it.
+export interface HealthScoreCoverageCategoryMaximumCount {
+  categoryKey: HealthScoreCoverageCategoryMaximumCategoryKey;
+  label: string;
+  maximum: number;
+  reposAtMaximum: number;
+}
+
+export interface HealthScoreCoverageCategoryMaximumData {
+  categories: HealthScoreCoverageCategoryMaximumCount[];
+  reposTracked: number;
+}


### PR DESCRIPTION
## Summary

Standalone widget code only for IN-1292, widget 07 "Repositories scoring full marks" (Health Score Coverage report, epic IN-1276) — NOT yet wired into any shared file (report view, API service, TanstackKey enum, shared types, shared data). Wiring happens once this widget's turn comes up in the sequential release-branch merge order (matches the pattern of the prior seven widget PRs on this epic, e.g. #2168, #2171).

Adds:

- `types/report/health-score-coverage-category-maximum.types.ts`
- `server/data/tinybird/report/health-score-coverage-category-maximum.ts` (mapper + fetcher) and its Vitest test
- `server/api/report/health-score-coverage/category-maximum.get.ts`
- `app/components/modules/report/health-score-coverage/services/category-maximum.query.ts`
- `app/components/modules/report/health-score-coverage/components/category-maximum-table.vue` (table, per the ticket's own file name — matches the sibling table widget's `github-security-funnel.vue` convention of a layout-shape suffix)

Table columns: Category, Maximum, Repositories at maximum. Rows: Maintainer health (40), Development activity (25), Security & supply chain (35). Copy is verbatim from the design (eyebrow, title, text, footnote, caption).

## crowd.dev pipe dependency

Consumes `health_score_report_category_maximum` from crowd.dev PR <https://github.com/linuxfoundation/crowd.dev/pull/4585>. **That pipe is not yet deployed to Tinybird** — per the ticket-supervisor state file, the deploy was deliberately withheld by the owner pending their own review pass. This insights PR cannot be QA'd against live data until the pipe is deployed.

## Test plan

- [x] `pnpm test --run` — new mapper/fetcher test passes (4 tests)
- [x] `pnpm tsc-check` — clean
- [x] `pnpm lint` — clean (auto-fixed formatting)
- [ ] Manual QA against live Tinybird data — blocked until pipe #4585 is deployed

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: standalone widget 07 category maximum table** :point\_left:
