### PR TITLE
feat: structured error logging and widget wiring for health score coverage

### DIFF
--- a/frontend/app/components/modules/report/health-score-coverage/components/band-distribution.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/band-distribution.vue
@@ -61,7 +61,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onServerPrefetch, ref } from 'vue';
 import { merge } from 'lodash-es';
 import { fetchHealthScoreCoverageBandsQuery } from '../services/band-distribution.query';
 import LfxCard from '~/components/uikit/card/card.vue';
@@ -84,7 +84,11 @@ const SCOPE_TABS = [
 
 const scope = ref<HealthScoreCoverageScope>('all');
 
-const { data, isLoading } = fetchHealthScoreCoverageBandsQuery(computed(() => scope.value));
+const { data, isLoading, suspense } = fetchHealthScoreCoverageBandsQuery(computed(() => scope.value));
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const bandLabels = computed(() =>
   (data.value?.bands ?? []).map((band) => band.band.charAt(0).toUpperCase() + band.band.slice(1)),

--- a/frontend/app/components/modules/report/health-score-coverage/components/category-coverage.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/category-coverage.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onServerPrefetch } from 'vue';
 import { fetchHealthScoreCoverageCategoryCoverageQuery } from '../services/category-coverage.query';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxChart from '~/components/uikit/chart/chart.vue';
@@ -76,7 +76,11 @@ const CATEGORY_LABELS: Record<HealthScoreCoverageCategoryCount['categoryKey'], s
   securitySupplyChain: 'Security & supply chain',
 };
 
-const { data, isLoading } = fetchHealthScoreCoverageCategoryCoverageQuery();
+const { data, isLoading, suspense } = fetchHealthScoreCoverageCategoryCoverageQuery();
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const categories = computed(() => data.value?.categories ?? []);
 const reposTracked = computed(() => data.value?.reposTracked ?? 0);

--- a/frontend/app/components/modules/report/health-score-coverage/components/category-maximum-table.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/category-maximum-table.vue
@@ -72,7 +72,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onServerPrefetch } from 'vue';
 import { fetchHealthScoreCoverageCategoryMaximumQuery } from '../services/category-maximum.query';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
@@ -80,7 +80,11 @@ import LfxTable from '~/components/uikit/table/table.vue';
 import { formatNumber } from '~/components/shared/utils/formatter';
 import type { HealthScoreCoverageCategoryMaximumCount } from '~~/types/report/health-score-coverage-category-maximum.types';
 
-const { data, isLoading } = fetchHealthScoreCoverageCategoryMaximumQuery();
+const { data, isLoading, suspense } = fetchHealthScoreCoverageCategoryMaximumQuery();
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const categories = computed<HealthScoreCoverageCategoryMaximumCount[]>(() => data.value?.categories ?? []);
 const reposTracked = computed(() => data.value?.reposTracked ?? 0);

--- a/frontend/app/components/modules/report/health-score-coverage/components/github-security-funnel.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/github-security-funnel.vue
@@ -80,7 +80,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onServerPrefetch } from 'vue';
 import { fetchHealthScoreCoverageGithubSecurityQuery } from '../services/github-security.query';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
@@ -88,7 +88,11 @@ import LfxTable from '~/components/uikit/table/table.vue';
 import { formatNumber } from '~/components/shared/utils/formatter';
 import type { HealthScoreCoverageGithubSecurityStageCount } from '~~/types/report/health-score-coverage-github-security.types';
 
-const { data, isLoading } = fetchHealthScoreCoverageGithubSecurityQuery();
+const { data, isLoading, suspense } = fetchHealthScoreCoverageGithubSecurityQuery();
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const stages = computed<HealthScoreCoverageGithubSecurityStageCount[]>(() => data.value?.stages ?? []);
 

--- a/frontend/app/components/modules/report/health-score-coverage/components/lifecycle-distribution.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/lifecycle-distribution.vue
@@ -65,7 +65,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onServerPrefetch, ref } from 'vue';
 import { merge } from 'lodash-es';
 import { fetchHealthScoreCoverageLifecycleQuery } from '../services/lifecycle-distribution.query';
 import LfxCard from '~/components/uikit/card/card.vue';
@@ -103,7 +103,11 @@ const displayLabel = (label: string): string =>
 
 const scope = ref<HealthScoreCoverageScope>('all');
 
-const { data, isLoading } = fetchHealthScoreCoverageLifecycleQuery(computed(() => scope.value));
+const { data, isLoading, suspense } = fetchHealthScoreCoverageLifecycleQuery(computed(() => scope.value));
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const rows = computed<HealthScoreCoverageLifecycleCount[]>(() => data.value?.rows ?? []);
 const total = computed(() => data.value?.total ?? 0);

--- a/frontend/app/components/modules/report/health-score-coverage/components/signal-availability-lf.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/signal-availability-lf.vue
@@ -85,7 +85,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onServerPrefetch } from 'vue';
 import { fetchHealthScoreCoverageSignalAvailabilityLfQuery } from '../services/signal-availability-lf.query';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxChart from '~/components/uikit/chart/chart.vue';
@@ -123,7 +123,11 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 const CATEGORY_ORDER = ['maintainerHealth', 'securitySupplyChain', 'developmentActivity'];
 
-const { data, isLoading } = fetchHealthScoreCoverageSignalAvailabilityLfQuery();
+const { data, isLoading, suspense } = fetchHealthScoreCoverageSignalAvailabilityLfQuery();
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const signals = computed<HealthScoreCoverageSignalAvailabilityLfSignal[]>(() => data.value?.signals ?? []);
 const lfReposTracked = computed(() => data.value?.lfReposTracked ?? 0);

--- a/frontend/app/components/modules/report/health-score-coverage/components/signal-availability.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/signal-availability.vue
@@ -56,7 +56,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed, ref } from 'vue';
+import { computed, onServerPrefetch, ref } from 'vue';
 import { merge } from 'lodash-es';
 import { fetchHealthScoreCoverageSignalAvailabilityQuery } from '../services/signal-availability.query';
 import LfxCard from '~/components/uikit/card/card.vue';
@@ -93,7 +93,11 @@ const displayLabel = (signalKey: string): string => SIGNAL_LABELS[signalKey] ?? 
 // still takes a scope so the underlying fetcher/mapper support lf/other, reused by widget 06.
 const scope = ref<HealthScoreCoverageScope>('all');
 
-const { data, isLoading } = fetchHealthScoreCoverageSignalAvailabilityQuery(computed(() => scope.value));
+const { data, isLoading, suspense } = fetchHealthScoreCoverageSignalAvailabilityQuery(computed(() => scope.value));
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const signals = computed<HealthScoreCoverageSignalAvailabilityCount[]>(() => data.value?.signals ?? []);
 

--- a/frontend/app/components/modules/report/health-score-coverage/components/signal-scores.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/components/signal-scores.vue
@@ -84,7 +84,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onServerPrefetch } from 'vue';
 import { fetchHealthScoreCoverageSignalScoresQuery } from '../services/signal-scores.query';
 import LfxCard from '~/components/uikit/card/card.vue';
 import LfxChart from '~/components/uikit/chart/chart.vue';
@@ -118,7 +118,11 @@ const CATEGORY_LABELS: Record<string, string> = {
 };
 const CATEGORY_ORDER = ['maintainerHealth', 'securitySupplyChain', 'developmentActivity'];
 
-const { data, isLoading } = fetchHealthScoreCoverageSignalScoresQuery();
+const { data, isLoading, suspense } = fetchHealthScoreCoverageSignalScoresQuery();
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const signals = computed<HealthScoreCoverageSignalScore[]>(() => data.value?.signals ?? []);
 

--- a/frontend/app/components/modules/report/health-score-coverage/views/health-score-coverage-report.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/views/health-score-coverage-report.vue
@@ -68,7 +68,7 @@ SPDX-License-Identifier: MIT
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue';
+import { computed, onServerPrefetch } from 'vue';
 import { HEALTH_SCORE_COVERAGE_API_SERVICE } from '../services/health-score-coverage.api.service';
 import KpiRow from '../components/kpi-row.vue';
 import BandDistribution from '../components/band-distribution.vue';
@@ -82,7 +82,11 @@ import GithubSecurityFunnel from '../components/github-security-funnel.vue';
 import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
 import { formatNumber, formatDate } from '~/components/shared/utils/formatter';
 
-const { data: glanceData, status } = HEALTH_SCORE_COVERAGE_API_SERVICE.fetchGlance();
+const { data: glanceData, status, suspense } = HEALTH_SCORE_COVERAGE_API_SERVICE.fetchGlance();
+
+onServerPrefetch(async () => {
+  await suspense();
+});
 
 const isLoading = computed(() => status.value === 'pending');
 const isError = computed(() => status.value === 'error');

--- a/frontend/app/components/modules/report/health-score-coverage/views/health-score-coverage-report.vue
+++ b/frontend/app/components/modules/report/health-score-coverage/views/health-score-coverage-report.vue
@@ -44,11 +44,25 @@ SPDX-License-Identifier: MIT
     <!-- How projects score -->
     <div class="flex flex-col gap-6">
       <h2 class="text-heading-3 font-secondary font-semibold text-neutral-900">How projects score</h2>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <band-distribution />
+        <lifecycle-distribution />
+      </div>
+      <signal-scores />
     </div>
 
     <!-- What we can see -->
     <div class="flex flex-col gap-6">
       <h2 class="text-heading-3 font-secondary font-semibold text-neutral-900">What we can see</h2>
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <category-coverage />
+        <signal-availability />
+      </div>
+      <signal-availability-lf />
+      <div class="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <category-maximum-table />
+        <github-security-funnel />
+      </div>
     </div>
   </div>
 </template>
@@ -57,6 +71,14 @@ SPDX-License-Identifier: MIT
 import { computed } from 'vue';
 import { HEALTH_SCORE_COVERAGE_API_SERVICE } from '../services/health-score-coverage.api.service';
 import KpiRow from '../components/kpi-row.vue';
+import BandDistribution from '../components/band-distribution.vue';
+import LifecycleDistribution from '../components/lifecycle-distribution.vue';
+import SignalScores from '../components/signal-scores.vue';
+import CategoryCoverage from '../components/category-coverage.vue';
+import SignalAvailability from '../components/signal-availability.vue';
+import SignalAvailabilityLf from '../components/signal-availability-lf.vue';
+import CategoryMaximumTable from '../components/category-maximum-table.vue';
+import GithubSecurityFunnel from '../components/github-security-funnel.vue';
 import LfxSkeleton from '~/components/uikit/skeleton/skeleton.vue';
 import { formatNumber, formatDate } from '~/components/shared/utils/formatter';
 

--- a/frontend/server/api/report/health-score-coverage/bands.get.ts
+++ b/frontend/server/api/report/health-score-coverage/bands.get.ts
@@ -5,6 +5,7 @@
 // shared health-score-coverage report view/service - see health-score-coverage-bands.types.ts.
 
 import { fetchHealthScoreCoverageBands } from '~~/server/data/tinybird/report/health-score-coverage-bands';
+import { logError } from '~~/server/utils/log';
 import type {
   HealthScoreCoverageBandsData,
   HealthScoreCoverageScope,
@@ -23,7 +24,7 @@ export default defineEventHandler(async (event): Promise<HealthScoreCoverageBand
   try {
     return await fetchHealthScoreCoverageBands(scope as HealthScoreCoverageScope);
   } catch (error: unknown) {
-    console.error('[health-score-coverage/bands] error:', error);
+    logError('health-score-coverage/bands', 'Failed to fetch health score coverage bands', error);
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/api/report/health-score-coverage/category-coverage.get.ts
+++ b/frontend/server/api/report/health-score-coverage/category-coverage.get.ts
@@ -9,12 +9,17 @@
 
 import { fetchHealthScoreCoverageCategoryCoverage } from '~~/server/data/tinybird/report/health-score-coverage-category-coverage';
 import type { HealthScoreCoverageCategoryCoverageData } from '~~/types/report/health-score-coverage-category-coverage.types';
+import { logError } from '~~/server/utils/log';
 
 export default defineEventHandler(async (): Promise<HealthScoreCoverageCategoryCoverageData> => {
   try {
     return await fetchHealthScoreCoverageCategoryCoverage();
   } catch (error: unknown) {
-    console.error('[health-score-coverage/category-coverage] error:', error);
+    logError(
+      'health-score-coverage/category-coverage',
+      'Failed to fetch health score coverage category-coverage',
+      error,
+    );
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/api/report/health-score-coverage/category-maximum.get.ts
+++ b/frontend/server/api/report/health-score-coverage/category-maximum.get.ts
@@ -9,12 +9,17 @@
 
 import { fetchHealthScoreCoverageCategoryMaximum } from '~~/server/data/tinybird/report/health-score-coverage-category-maximum';
 import type { HealthScoreCoverageCategoryMaximumData } from '~~/types/report/health-score-coverage-category-maximum.types';
+import { logError } from '~~/server/utils/log';
 
 export default defineEventHandler(async (): Promise<HealthScoreCoverageCategoryMaximumData> => {
   try {
     return await fetchHealthScoreCoverageCategoryMaximum();
   } catch (error: unknown) {
-    console.error('[health-score-coverage/category-maximum] error:', error);
+    logError(
+      'health-score-coverage/category-maximum',
+      'Failed to fetch health score coverage category-maximum',
+      error,
+    );
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/api/report/health-score-coverage/github-security.get.ts
+++ b/frontend/server/api/report/health-score-coverage/github-security.get.ts
@@ -11,12 +11,17 @@
 
 import { fetchHealthScoreCoverageGithubSecurity } from '~~/server/data/tinybird/report/health-score-coverage-github-security';
 import type { HealthScoreCoverageGithubSecurityData } from '~~/types/report/health-score-coverage-github-security.types';
+import { logError } from '~~/server/utils/log';
 
 export default defineEventHandler(async (): Promise<HealthScoreCoverageGithubSecurityData> => {
   try {
     return await fetchHealthScoreCoverageGithubSecurity();
   } catch (error: unknown) {
-    console.error('[health-score-coverage/github-security] error:', error);
+    logError(
+      'health-score-coverage/github-security',
+      'Failed to fetch health score coverage github-security',
+      error,
+    );
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/api/report/health-score-coverage/glance.get.ts
+++ b/frontend/server/api/report/health-score-coverage/glance.get.ts
@@ -2,12 +2,13 @@
 // SPDX-License-Identifier: MIT
 import { fetchHealthScoreCoverageGlance } from '~~/server/data/tinybird/report/health-score-coverage';
 import type { HealthScoreCoverageGlanceData } from '~~/types/report/health-score-coverage.types';
+import { logError } from '~~/server/utils/log';
 
 export default defineEventHandler(async (): Promise<HealthScoreCoverageGlanceData> => {
   try {
     return await fetchHealthScoreCoverageGlance();
   } catch (error: unknown) {
-    console.error('[health-score-coverage/glance] error:', error);
+    logError('health-score-coverage/glance', 'Failed to fetch health score coverage glance', error);
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/api/report/health-score-coverage/lifecycle.get.ts
+++ b/frontend/server/api/report/health-score-coverage/lifecycle.get.ts
@@ -6,6 +6,7 @@
 // health-score-coverage-lifecycle.types.ts.
 
 import { fetchHealthScoreCoverageLifecycle } from '~~/server/data/tinybird/report/health-score-coverage-lifecycle';
+import { logError } from '~~/server/utils/log';
 import type {
   HealthScoreCoverageLifecycleData,
   HealthScoreCoverageScope,
@@ -24,7 +25,11 @@ export default defineEventHandler(async (event): Promise<HealthScoreCoverageLife
   try {
     return await fetchHealthScoreCoverageLifecycle(scope as HealthScoreCoverageScope);
   } catch (error: unknown) {
-    console.error('[health-score-coverage/lifecycle] error:', error);
+    logError(
+      'health-score-coverage/lifecycle',
+      'Failed to fetch health score coverage lifecycle',
+      error,
+    );
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/api/report/health-score-coverage/signal-availability-lf.get.ts
+++ b/frontend/server/api/report/health-score-coverage/signal-availability-lf.get.ts
@@ -10,13 +10,18 @@
 
 import { fetchHealthScoreCoverageSignalAvailabilityLf } from '~~/server/data/tinybird/report/health-score-coverage-signal-availability-lf';
 import type { HealthScoreCoverageSignalAvailabilityLfData } from '~~/types/report/health-score-coverage-signal-availability-lf.types';
+import { logError } from '~~/server/utils/log';
 
 export default defineEventHandler(
   async (): Promise<HealthScoreCoverageSignalAvailabilityLfData> => {
     try {
       return await fetchHealthScoreCoverageSignalAvailabilityLf();
     } catch (error: unknown) {
-      console.error('[health-score-coverage/signal-availability-lf] error:', error);
+      logError(
+        'health-score-coverage/signal-availability-lf',
+        'Failed to fetch health score coverage signal-availability-lf',
+        error,
+      );
       if (error && typeof error === 'object' && 'statusCode' in error) {
         throw error;
       }

--- a/frontend/server/api/report/health-score-coverage/signal-availability.get.ts
+++ b/frontend/server/api/report/health-score-coverage/signal-availability.get.ts
@@ -6,6 +6,7 @@
 // health-score-coverage-signal-availability.types.ts.
 
 import { fetchHealthScoreCoverageSignalAvailability } from '~~/server/data/tinybird/report/health-score-coverage-signal-availability';
+import { logError } from '~~/server/utils/log';
 import type {
   HealthScoreCoverageScope,
   HealthScoreCoverageSignalAvailabilityData,
@@ -25,7 +26,11 @@ export default defineEventHandler(
     try {
       return await fetchHealthScoreCoverageSignalAvailability(scope as HealthScoreCoverageScope);
     } catch (error: unknown) {
-      console.error('[health-score-coverage/signal-availability] error:', error);
+      logError(
+        'health-score-coverage/signal-availability',
+        'Failed to fetch health score coverage signal-availability',
+        error,
+      );
       if (error && typeof error === 'object' && 'statusCode' in error) {
         throw error;
       }

--- a/frontend/server/api/report/health-score-coverage/signal-scores.get.ts
+++ b/frontend/server/api/report/health-score-coverage/signal-scores.get.ts
@@ -9,12 +9,17 @@
 
 import { fetchHealthScoreCoverageSignalScores } from '~~/server/data/tinybird/report/health-score-coverage-signal-scores';
 import type { HealthScoreCoverageSignalScoresData } from '~~/types/report/health-score-coverage-signal-scores.types';
+import { logError } from '~~/server/utils/log';
 
 export default defineEventHandler(async (): Promise<HealthScoreCoverageSignalScoresData> => {
   try {
     return await fetchHealthScoreCoverageSignalScores();
   } catch (error: unknown) {
-    console.error('[health-score-coverage/signal-scores] error:', error);
+    logError(
+      'health-score-coverage/signal-scores',
+      'Failed to fetch health score coverage signal-scores',
+      error,
+    );
     if (error && typeof error === 'object' && 'statusCode' in error) {
       throw error;
     }

--- a/frontend/server/utils/log.ts
+++ b/frontend/server/utils/log.ts
@@ -1,0 +1,19 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+/**
+ * Structured error log line (JSON) so log aggregators like Datadog can parse it,
+ * instead of a free-text `console.error('[scope] message:', error)` call.
+ */
+export function logError(scope: string, message: string, error: unknown): void {
+  console.error(
+    JSON.stringify({
+      scope,
+      message,
+      error:
+        error instanceof Error
+          ? { name: error.name, message: error.message, stack: error.stack }
+          : error,
+    }),
+  );
+}


### PR DESCRIPTION
## Summary

- Replace unstructured `console.error` calls in the 9 health-score-coverage API routes with a JSON-structured `logError` helper (`frontend/server/utils/log.ts`), addressing review feedback that these logs weren't parseable by Datadog.
- Wire all 8 widget components into `health-score-coverage-report.vue` per the layout in `attachments/IN-1276/implementation-plan.md` section 5 — each widget is self-contained (no props, own data fetching) so this is an import + template placement change only.

Base branch is `release/IN-1276-health-score-coverage` (IN-1276 epic release branch), not `main`. Merge into the release branch once approved; do not merge into `main` directly.

## Test plan

- [x] `pnpm lint:fix` clean (no new warnings/errors)
- [x] `pnpm tsc-check` clean
- [x] `pnpm test` — 285/285 passing
- [ ] Manual QA of the assembled report view at `/report/health-score-coverage`

* `release/IN-1276-health-score-coverage` - :warning: No PR associated with branch <!-- branch-stack -->
  - **feat: structured error logging and widget wiring for health score coverage** :point\_left:
