### PR TITLE
docs: align ADR rule and skill with api/docs/arch/adr path

### DIFF
--- a/.claude/rules/adr-format.md
+++ b/.claude/rules/adr-format.md
@@ -1,12 +1,12 @@
 ---
-description: Enforce ADR structure and conventions on files written under docs/adr/
+description: Enforce ADR structure and conventions on files written under api/docs/arch/adr/
 paths:
-  - 'docs/adr/**/*.md'
+  - 'api/docs/arch/adr/**/*.md'
 ---
 
 # ADR Format Enforcement
 
-When writing or editing any `.md` file under `docs/adr/`, enforce these rules:
+When writing or editing any `.md` file under `api/docs/arch/adr/`, enforce these rules:
 
 ## Exempt files
 
@@ -15,14 +15,14 @@ and are exempt from the section requirements below.
 
 ## Required structure for ADR files
 
-Every file matching `docs/adr/[0-9]*.md` **must** have:
+Every file matching `api/docs/arch/adr/[0-9]*.md` **must** have:
 
 1. An H1 heading stating the decision as its title
 2. Body prose that covers the context, the decision itself, and the
    alternatives considered with why they were rejected
 
 The body may be short free-form prose (the style most existing ADRs use) or
-the full template in [template.md](../../docs/adr/template.md) (Date/Status/Deciders
+the full template in [template.md](../../api/docs/arch/adr/template.md) (Date/Status/Deciders
 header block, Context, Decision, Alternatives Considered, Consequences).
 The full template is recommended for new ADRs but not required. The
 `**Deciders**:` line is always optional.
@@ -34,17 +34,17 @@ Do not write an ADR that records a decision without its reasoning.
 ## Numbering
 
 - IDs are zero-padded to 4 digits: `0001`, `0002`, `0003`, …
-- Assign the next sequential number by scanning existing files with `Glob docs/adr/[0-9]*.md`.
+- Assign the next sequential number by scanning existing files with `Glob api/docs/arch/adr/[0-9]*.md`.
 - Never reuse a number, even if a previous ADR is deprecated.
 
 ## File naming
 
-`docs/adr/NNNN-kebab-case-title.md` — all lowercase, words separated by hyphens.
+`api/docs/arch/adr/NNNN-kebab-case-title.md` — all lowercase, words separated by hyphens.
 
 ## Index maintenance
 
 After writing or changing the status of an ADR, update the index table in
-`docs/adr/README.md`:
+`api/docs/arch/adr/README.md`:
 
 ```markdown
 | [ADR-NNNN](./NNNN-kebab-title.md) | Title | accepted | YYYY-MM-DD |

--- a/.claude/skills/adr/SKILL.md
+++ b/.claude/skills/adr/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: adr
 description: >
-  Record an architecture decision as an ADR in docs/adr/. Use when choosing
+  Record an architecture decision as an ADR in api/docs/arch/adr/. Use when choosing
   between frameworks, libraries, databases, or architectural patterns; stating
   a decision with reasoning ("we decided X instead of Y because..."); or
   querying past decisions ("why did we choose X?").
@@ -11,7 +11,7 @@ allowed-tools: Read, Write, Edit, Glob, Grep, AskUserQuestion
 # Architecture Decision Records
 
 You are recording or retrieving an Architecture Decision Record (ADR) for this
-project. ADRs live in `docs/adr/` at the repo root.
+project. ADRs live in `api/docs/arch/adr/` at the repo root.
 
 ## When to record
 
@@ -27,7 +27,17 @@ project. ADRs live in `docs/adr/` at the repo root.
 
 ## ADR template
 
-Every ADR file must include all of these sections:
+Every ADR must have an H1 title stating the decision, and body prose covering
+the context, the decision itself, and the alternatives considered with why
+they were rejected. `README.md` and `template.md` are index/template files,
+not ADRs, and are exempt from this requirement.
+
+The body may be short free-form prose covering those points, or the full
+template below (Date/Status/Deciders header block, Context, Decision,
+Alternatives Considered, Consequences). The full template is recommended for
+new ADRs but not required — the `**Deciders**:` line is always optional. If
+the decision, its context, or the rejected alternatives can't be stated, stop
+and ask the user for the missing information before writing the file.
 
 ```markdown
 # ADR-NNNN: [Decision Title]
@@ -68,17 +78,17 @@ Every ADR file must include all of these sections:
 
 ## Workflow — recording a new ADR
 
-1. **Scan existing ADRs** — `Glob docs/adr/[0-9]*.md` to find the highest existing number.
+1. **Scan existing ADRs** — `Glob api/docs/arch/adr/[0-9]*.md` to find the highest existing number.
 2. **Assign next ID** — next sequential 4-digit number (e.g., `0003`).
 3. **Gather context** — ask the user for any missing details: who the deciders were, what alternatives were seriously considered, and what the consequences are.
-4. **Draft the ADR** — populate all mandatory sections from the template above.
+4. **Draft the ADR** — cover the context, decision, and rejected alternatives, either as free-form prose or using the full template above.
 5. **Present the draft** — show it to the user for review before writing any file.
-6. **Write the file** — `docs/adr/NNNN-kebab-title.md` (kebab-case title, all lowercase).
-7. **Update the index** — append a new row to the `| ADR | Title | Status | Date |` table in `docs/adr/README.md`.
+6. **Write the file** — `api/docs/arch/adr/NNNN-kebab-title.md` (kebab-case title, all lowercase).
+7. **Update the index** — append a new row to the `| ADR | Title | Status | Date |` table in `api/docs/arch/adr/README.md`.
 
 ## Workflow — reading / querying ADRs
 
-1. Check if `docs/adr/README.md` exists. If not, offer to start the ADR directory.
+1. Check if `api/docs/arch/adr/README.md` exists. If not, offer to start the ADR directory.
 2. Read the README index table and find entries relevant to the user's question.
 3. Read the matching ADR file and summarise the **Context** and **Decision** sections.
 4. If no ADR matches, suggest recording one now.

--- a/.claude/skills/adr/SKILL.md
+++ b/.claude/skills/adr/SKILL.md
@@ -80,7 +80,7 @@ and ask the user for the missing information before writing the file.
 
 1. **Scan existing ADRs** — `Glob api/docs/arch/adr/[0-9]*.md` to find the highest existing number.
 2. **Assign next ID** — next sequential 4-digit number (e.g., `0003`).
-3. **Gather context** — ask the user for any missing details: who the deciders were, what alternatives were seriously considered, and what the consequences are.
+3. **Gather context** — ask the user for any missing details on the context, the decision, and the alternatives considered with why they were rejected. Only ask about deciders and consequences if the user opts into the full template.
 4. **Draft the ADR** — cover the context, decision, and rejected alternatives, either as free-form prose or using the full template above.
 5. **Present the draft** — show it to the user for review before writing any file.
 6. **Write the file** — `api/docs/arch/adr/NNNN-kebab-title.md` (kebab-case title, all lowercase).


### PR DESCRIPTION
## Summary

- Update `.claude/rules/adr-format.md` and `.claude/skills/adr/SKILL.md` to reference `api/docs/arch/adr/` instead of the old `docs/adr/`.
- Also folds in the ADR template guidance alignment (free-form prose vs. full template, exemption for README/template.md) so the skill matches the rule exactly.

## Test plan

- [x] Rule/skill content reviewed for consistency with the relocated path

* `main` <!-- branch-stack -->
  - \#2174
    - **docs: align ADR rule and skill with api/docs/arch/adr path** :point\_left:
      - \#2176
        - \#2177
