### PR TITLE
fix: improve seo metadata and correct collections sitemap urls

### DIFF
--- a/frontend/app/components/modules/leaderboards/config/small-teams-massive-output.config.ts
+++ b/frontend/app/components/modules/leaderboards/config/small-teams-massive-output.config.ts
@@ -7,7 +7,7 @@ import type { LeaderboardConfig } from './types/leaderboard.types';
 
 export const smallTeamsMassiveOutputConfig: LeaderboardConfig = {
   key: 'small-teams-massive-output',
-  name: 'Small teams, massive output ',
+  name: 'Small teams, massive output',
   description:
     'These projects demonstrate exceptional productivity, achieving the highest commit volumes with 50 or fewer contributors.',
   icon: 'arrow-up-big-small',

--- a/frontend/app/pages/collection/details/[slug].vue
+++ b/frontend/app/pages/collection/details/[slug].vue
@@ -230,8 +230,9 @@ const description = computed(() => {
   if (!desc) {
     const name = data.value?.name;
     if (!name) return '';
-    const projectCount = data.value?.projectCount;
-    const scope = projectCount ? `${projectCount} open source projects` : 'open source projects';
+    // Collections can contain standalone repositories too - the UI counts both as the collection total
+    const totalCount = (data.value?.projectCount ?? 0) + (data.value?.repositoryCount ?? 0);
+    const scope = totalCount > 0 ? `${totalCount} open source projects` : 'open source projects';
     return `Explore the ${name} collection on LFX Insights: health, contributor, and security metrics for ${scope}.`;
   }
 

--- a/frontend/app/pages/collection/details/[slug].vue
+++ b/frontend/app/pages/collection/details/[slug].vue
@@ -223,11 +223,17 @@ const handleCollectionUpdated = (collection: Collection) => {
   queryClient.setQueryData(queryKey.value, collection);
 };
 
-const title = computed(() => `${data.value?.name || 'Collection'} Insights`);
+const title = computed(() => `${data.value?.name || 'Collection'} – Open Source Project Collection | LFX Insights`);
 
 const description = computed(() => {
   const desc = data.value?.description || '';
-  if (!desc) return '';
+  if (!desc) {
+    const name = data.value?.name;
+    if (!name) return '';
+    const projectCount = data.value?.projectCount;
+    const scope = projectCount ? `${projectCount} open source projects` : 'open source projects';
+    return `Explore the ${name} collection on LFX Insights: health, contributor, and security metrics for ${scope}.`;
+  }
 
   const sentences = desc.match(/[^.!?]+[.!?]+/g) || [desc];
 

--- a/frontend/app/pages/collection/details/[slug]/contributors.vue
+++ b/frontend/app/pages/collection/details/[slug]/contributors.vue
@@ -19,11 +19,14 @@ const route = useRoute();
 const { slug } = route.params;
 const requestFetch = useRequestFetch();
 
-// Same query key as the parent [slug].vue, so this resolves from the cache without refetching
+// Same query key as the parent [slug].vue - this observer only reads the parent's cached
+// data for metadata; enabled: false keeps it from ever firing a duplicate request
+// (the global 30s staleTime + refetchOnMount would otherwise refetch on tab open)
 const { data: collection } = useQuery<Collection>({
   queryKey: computed(() => [TanstackKey.COLLECTION, slug]),
   queryFn: COLLECTIONS_API_SERVICE.fetchCollection(slug as string, requestFetch),
   retry: false,
+  enabled: false,
 });
 
 const title = computed(() =>

--- a/frontend/app/pages/collection/details/[slug]/contributors.vue
+++ b/frontend/app/pages/collection/details/[slug]/contributors.vue
@@ -8,10 +8,35 @@ SPDX-License-Identifier: MIT
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useRoute, useRequestFetch } from 'nuxt/app';
+import { useQuery } from '@tanstack/vue-query';
+import type { Collection } from '~~/types/collection';
 import LfxCollectionContributorsView from '~/components/modules/collection/views/collection-contributors.vue';
+import { TanstackKey } from '~/components/shared/types/tanstack';
+import { COLLECTIONS_API_SERVICE } from '~/components/modules/collection/services/collections.api.service';
 
-const title = computed(() => 'Collection Contributors Insights');
-const description = computed(() => 'See who contributes across every project in this collection.');
+const route = useRoute();
+const { slug } = route.params;
+const requestFetch = useRequestFetch();
+
+// Same query key as the parent [slug].vue, so this resolves from the cache without refetching
+const { data: collection } = useQuery<Collection>({
+  queryKey: computed(() => [TanstackKey.COLLECTION, slug]),
+  queryFn: COLLECTIONS_API_SERVICE.fetchCollection(slug as string, requestFetch),
+  retry: false,
+});
+
+const title = computed(() =>
+  collection.value?.name
+    ? `${collection.value.name} Contributors – Collection Insights | LFX Insights`
+    : 'Collection Contributors Insights',
+);
+const description = computed(() =>
+  collection.value?.name
+    ? `See who contributes across every project in the ${collection.value.name} collection, ` +
+      'with insights on maintainers, top contributors, and organizations.'
+    : 'See who contributes across every project in this collection.',
+);
 
 useSeoMeta({
   title,

--- a/frontend/app/pages/collection/details/[slug]/development.vue
+++ b/frontend/app/pages/collection/details/[slug]/development.vue
@@ -19,11 +19,14 @@ const route = useRoute();
 const { slug } = route.params;
 const requestFetch = useRequestFetch();
 
-// Same query key as the parent [slug].vue, so this resolves from the cache without refetching
+// Same query key as the parent [slug].vue - this observer only reads the parent's cached
+// data for metadata; enabled: false keeps it from ever firing a duplicate request
+// (the global 30s staleTime + refetchOnMount would otherwise refetch on tab open)
 const { data: collection } = useQuery<Collection>({
   queryKey: computed(() => [TanstackKey.COLLECTION, slug]),
   queryFn: COLLECTIONS_API_SERVICE.fetchCollection(slug as string, requestFetch),
   retry: false,
+  enabled: false,
 });
 
 const title = computed(() =>

--- a/frontend/app/pages/collection/details/[slug]/development.vue
+++ b/frontend/app/pages/collection/details/[slug]/development.vue
@@ -8,11 +8,33 @@ SPDX-License-Identifier: MIT
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useRoute, useRequestFetch } from 'nuxt/app';
+import { useQuery } from '@tanstack/vue-query';
+import type { Collection } from '~~/types/collection';
 import LfxCollectionDevelopmentView from '~/components/modules/collection/views/collection-development.vue';
+import { TanstackKey } from '~/components/shared/types/tanstack';
+import { COLLECTIONS_API_SERVICE } from '~/components/modules/collection/services/collections.api.service';
 
-const title = computed(() => 'Collection Development Insights');
-const description = computed(
-  () => 'See active contributors and organizations aggregated across every project in this collection.',
+const route = useRoute();
+const { slug } = route.params;
+const requestFetch = useRequestFetch();
+
+// Same query key as the parent [slug].vue, so this resolves from the cache without refetching
+const { data: collection } = useQuery<Collection>({
+  queryKey: computed(() => [TanstackKey.COLLECTION, slug]),
+  queryFn: COLLECTIONS_API_SERVICE.fetchCollection(slug as string, requestFetch),
+  retry: false,
+});
+
+const title = computed(() =>
+  collection.value?.name
+    ? `${collection.value.name} Development Activity – Collection Insights | LFX Insights`
+    : 'Collection Development Insights',
+);
+const description = computed(() =>
+  collection.value?.name
+    ? `See development activity aggregated across every project in the ${collection.value.name} collection.`
+    : 'See active contributors and organizations aggregated across every project in this collection.',
 );
 
 useSeoMeta({

--- a/frontend/app/pages/collection/details/[slug]/popularity.vue
+++ b/frontend/app/pages/collection/details/[slug]/popularity.vue
@@ -19,11 +19,14 @@ const route = useRoute();
 const { slug } = route.params;
 const requestFetch = useRequestFetch();
 
-// Same query key as the parent [slug].vue, so this resolves from the cache without refetching
+// Same query key as the parent [slug].vue - this observer only reads the parent's cached
+// data for metadata; enabled: false keeps it from ever firing a duplicate request
+// (the global 30s staleTime + refetchOnMount would otherwise refetch on tab open)
 const { data: collection } = useQuery<Collection>({
   queryKey: computed(() => [TanstackKey.COLLECTION, slug]),
   queryFn: COLLECTIONS_API_SERVICE.fetchCollection(slug as string, requestFetch),
   retry: false,
+  enabled: false,
 });
 
 const title = computed(() =>

--- a/frontend/app/pages/collection/details/[slug]/popularity.vue
+++ b/frontend/app/pages/collection/details/[slug]/popularity.vue
@@ -8,10 +8,34 @@ SPDX-License-Identifier: MIT
 
 <script setup lang="ts">
 import { computed } from 'vue';
+import { useRoute, useRequestFetch } from 'nuxt/app';
+import { useQuery } from '@tanstack/vue-query';
+import type { Collection } from '~~/types/collection';
 import LfxCollectionPopularityView from '~/components/modules/collection/views/collection-popularity.vue';
+import { TanstackKey } from '~/components/shared/types/tanstack';
+import { COLLECTIONS_API_SERVICE } from '~/components/modules/collection/services/collections.api.service';
 
-const title = computed(() => 'Collection Popularity Insights');
-const description = computed(() => 'See stars and forks aggregated across every project in this collection.');
+const route = useRoute();
+const { slug } = route.params;
+const requestFetch = useRequestFetch();
+
+// Same query key as the parent [slug].vue, so this resolves from the cache without refetching
+const { data: collection } = useQuery<Collection>({
+  queryKey: computed(() => [TanstackKey.COLLECTION, slug]),
+  queryFn: COLLECTIONS_API_SERVICE.fetchCollection(slug as string, requestFetch),
+  retry: false,
+});
+
+const title = computed(() =>
+  collection.value?.name
+    ? `${collection.value.name} Popularity – Collection Insights | LFX Insights`
+    : 'Collection Popularity Insights',
+);
+const description = computed(() =>
+  collection.value?.name
+    ? `See stars and forks aggregated across every project in the ${collection.value.name} collection.`
+    : 'See stars and forks aggregated across every project in this collection.',
+);
 
 useSeoMeta({
   title,

--- a/frontend/app/pages/index.vue
+++ b/frontend/app/pages/index.vue
@@ -9,8 +9,10 @@ SPDX-License-Identifier: MIT
 <script setup lang="ts">
 import LfxExplore from '~/components/modules/explore/views/explore.vue';
 
-const title = 'LFX Insights';
-const description = "Insights into the world's most critical open source software. By the Linux Foundation.";
+const title = 'LFX Insights – Open Source Project Health & Trust Analytics';
+const description =
+  'Evaluate the health and trustworthiness of 13,000+ open source projects with contributor, ' +
+  'security, and activity metrics. Free, by the Linux Foundation.';
 
 useSeoMeta({
   title,

--- a/frontend/app/pages/leaderboards/[key].vue
+++ b/frontend/app/pages/leaderboards/[key].vue
@@ -19,6 +19,26 @@ const leaderboardKey = computed<string>(() => route.params.key as string);
 const config = computed(() => leaderboardConfigs.find((c) => c.key === leaderboardKey.value));
 const title = computed(() => config.value?.name || 'Leaderboard');
 
+const seoTitle = computed(() =>
+  config.value?.name
+    ? `${config.value.name} Leaderboard – Top Open Source Projects | LFX Insights`
+    : 'Leaderboard | LFX Insights',
+);
+const seoDescription = computed(
+  () =>
+    config.value?.description ||
+    'Explore leaderboards for the world’s most critical open source projects. Powered by the Linux Foundation.',
+);
+
+useSeoMeta({
+  title: seoTitle,
+  description: seoDescription,
+  ogTitle: seoTitle,
+  ogDescription: seoDescription,
+  twitterTitle: seoTitle,
+  twitterDescription: seoDescription,
+});
+
 defineOgImage('Leaderboard', {
   leaderboardTitle: title,
 });

--- a/frontend/app/pages/project/[slug]/contributors.vue
+++ b/frontend/app/pages/project/[slug]/contributors.vue
@@ -22,14 +22,17 @@ const { project } = storeToRefs(useProjectStore());
 const widget = route.query?.widget;
 
 const title = computed(() => {
+  const name = project.value?.name;
+  if (!name) return 'LFX Insights';
   const widgetName =
     widget && lfxWidgets[widget as Widget]?.name?.length ? lfxWidgets[widget as Widget]?.name : 'Contributors Insights';
-  return widget ? `${project.value?.name} ${widgetName}` : `${project.value?.name} Contributors Insights`;
+  return widget ? `${name} ${widgetName} | LFX Insights` : `${name} Contributors & Organizations | LFX Insights`;
 });
-const description = computed(
-  () =>
-    `See who contributes to ${project.value?.name}, ` +
-    `with insights on maintainers, top contributors, and organizations in open source.`,
+const description = computed(() =>
+  project.value?.name
+    ? `See who contributes to ${project.value.name}, ` +
+      `with insights on maintainers, top contributors, and organizations in open source.`
+    : 'See who contributes to this project, with insights on maintainers, top contributors, and organizations.',
 );
 
 const imageAlt = computed(() => `${project.value?.name} Contributors Insights - LFX Insights`);

--- a/frontend/app/pages/project/[slug]/contributors.vue
+++ b/frontend/app/pages/project/[slug]/contributors.vue
@@ -16,7 +16,6 @@ import { lfxWidgets } from '~/components/modules/widget/config/widget.config';
 import type { Widget } from '~/components/modules/widget/types/widget';
 
 const route = useRoute();
-const config = useRuntimeConfig();
 const { project } = storeToRefs(useProjectStore());
 
 const widget = route.query?.widget;
@@ -36,7 +35,6 @@ const description = computed(() =>
 );
 
 const imageAlt = computed(() => `${project.value?.name} Contributors Insights - LFX Insights`);
-const url = computed(() => `${config.public.appUrl}${route.fullPath}`);
 
 const projectName = computed(() => project.value?.name || '');
 const projectDescription = computed(() => project.value?.description || '');
@@ -53,7 +51,6 @@ useSeoMeta({
   title,
   description,
   ogType: 'website',
-  ogUrl: url,
   ogTitle: title,
   ogDescription: description,
   ogImageAlt: imageAlt,

--- a/frontend/app/pages/project/[slug]/development.vue
+++ b/frontend/app/pages/project/[slug]/development.vue
@@ -23,14 +23,17 @@ const { project } = storeToRefs(useProjectStore());
 const widget = route.query?.widget;
 
 const title = computed(() => {
+  const name = project.value?.name;
+  if (!name) return 'LFX Insights';
   const widgetName =
     widget && lfxWidgets[widget as Widget]?.name?.length ? lfxWidgets[widget as Widget]?.name : 'Development Insights';
-  return widget ? `${project.value?.name} ${widgetName}` : `${project.value?.name} Development Insights`;
+  return widget ? `${name} ${widgetName} | LFX Insights` : `${name} Development Activity | LFX Insights`;
 });
-const description = computed(
-  () =>
-    `Track ${project.value?.name} development activity, ` +
-    `including commits, releases, pull requests, and issues over time.`,
+const description = computed(() =>
+  project.value?.name
+    ? `Track ${project.value.name} development activity, ` +
+      `including commits, releases, pull requests, and issues over time.`
+    : 'Track development activity, including commits, releases, pull requests, and issues over time.',
 );
 
 const imageAlt = computed(() => `${project.value?.name} Development Insights - LFX Insights`);

--- a/frontend/app/pages/project/[slug]/development.vue
+++ b/frontend/app/pages/project/[slug]/development.vue
@@ -17,7 +17,6 @@ import { lfxWidgets } from '~/components/modules/widget/config/widget.config';
 import type { Widget } from '~/components/modules/widget/types/widget';
 
 const route = useRoute();
-const config = useRuntimeConfig();
 const { project } = storeToRefs(useProjectStore());
 
 const widget = route.query?.widget;
@@ -37,7 +36,6 @@ const description = computed(() =>
 );
 
 const imageAlt = computed(() => `${project.value?.name} Development Insights - LFX Insights`);
-const url = computed(() => `${config.public.appUrl}${route.fullPath}`);
 
 const projectName = computed(() => project.value?.name || '');
 const projectDescription = computed(() => project.value?.description || '');
@@ -54,7 +52,6 @@ useSeoMeta({
   title,
   description,
   ogType: 'website',
-  ogUrl: url,
   ogTitle: title,
   ogDescription: description,
   ogImageAlt: imageAlt,

--- a/frontend/app/pages/project/[slug]/index.vue
+++ b/frontend/app/pages/project/[slug]/index.vue
@@ -14,7 +14,6 @@ import LfxProjectOverviewView from '~/components/modules/project/views/overview.
 
 const route = useRoute();
 const { project } = storeToRefs(useProjectStore());
-const config = useRuntimeConfig();
 
 const title = computed(() =>
   project.value ? `${project.value.name} – Health Score, Contributors & Security | LFX Insights` : 'LFX Insights',
@@ -25,7 +24,6 @@ const description = computed(() =>
     : 'Explore LFX Project insights',
 );
 const imageAlt = computed(() => (project.value ? `${project.value.name} insights` : 'LFX Project insights'));
-const url = computed(() => `${config.public.appUrl}${route.fullPath}`);
 
 // Check for badge query parameter
 const badgeKey = computed(() => route.query.badge as string | undefined);
@@ -43,7 +41,6 @@ useSeoMeta({
   title,
   description,
   ogType: 'website',
-  ogUrl: url,
   ogTitle: title,
   ogDescription: description,
   ogImageAlt: imageAlt,

--- a/frontend/app/pages/project/[slug]/index.vue
+++ b/frontend/app/pages/project/[slug]/index.vue
@@ -16,7 +16,9 @@ const route = useRoute();
 const { project } = storeToRefs(useProjectStore());
 const config = useRuntimeConfig();
 
-const title = computed(() => (project.value ? `${project.value.name} Insights` : 'LFX Insights'));
+const title = computed(() =>
+  project.value ? `${project.value.name} – Health Score, Contributors & Security | LFX Insights` : 'LFX Insights',
+);
 const description = computed(() =>
   project.value
     ? project.value.description || `Explore ${project.value.name} insights`

--- a/frontend/app/pages/project/[slug]/popularity.vue
+++ b/frontend/app/pages/project/[slug]/popularity.vue
@@ -22,14 +22,17 @@ const { project } = storeToRefs(useProjectStore());
 const widget = route.query?.widget;
 
 const title = computed(() => {
+  const name = project.value?.name;
+  if (!name) return 'LFX Insights';
   const widgetName =
     widget && lfxWidgets[widget as Widget]?.name?.length ? lfxWidgets[widget as Widget]?.name : 'Popularity Insights';
-  return widget ? `${project.value?.name} ${widgetName}` : `${project.value?.name} Popularity Insights`;
+  return widget ? `${name} ${widgetName} | LFX Insights` : `${name} Popularity & Adoption | LFX Insights`;
 });
-const description = computed(
-  () =>
-    `Explore ${project.value?.name} popularity with data on stars, forks, watchers, ` +
-    `and adoption across the open source ecosystem.`,
+const description = computed(() =>
+  project.value?.name
+    ? `Explore ${project.value.name} popularity with data on stars, forks, watchers, ` +
+      `and adoption across the open source ecosystem.`
+    : 'Explore project popularity with data on stars, forks, watchers, and adoption across the open source ecosystem.',
 );
 
 const imageAlt = computed(() => `${project.value?.name} Popularity Insights - LFX Insights`);

--- a/frontend/app/pages/project/[slug]/popularity.vue
+++ b/frontend/app/pages/project/[slug]/popularity.vue
@@ -16,7 +16,6 @@ import { lfxWidgets } from '~/components/modules/widget/config/widget.config';
 import type { Widget } from '~/components/modules/widget/types/widget';
 
 const route = useRoute();
-const config = useRuntimeConfig();
 const { project } = storeToRefs(useProjectStore());
 
 const widget = route.query?.widget;
@@ -36,7 +35,6 @@ const description = computed(() =>
 );
 
 const imageAlt = computed(() => `${project.value?.name} Popularity Insights - LFX Insights`);
-const url = computed(() => `${config.public.appUrl}${route.fullPath}`);
 
 const projectName = computed(() => project.value?.name || '');
 const projectDescription = computed(() => project.value?.description || '');
@@ -53,7 +51,6 @@ useSeoMeta({
   title,
   description,
   ogType: 'website',
-  ogUrl: url,
   ogTitle: title,
   ogDescription: description,
   ogImageAlt: imageAlt,

--- a/frontend/app/pages/project/[slug]/security.vue
+++ b/frontend/app/pages/project/[slug]/security.vue
@@ -11,8 +11,6 @@ import { storeToRefs } from 'pinia';
 import { useProjectStore } from '~/components/modules/project/store/project.store';
 import LfxProjectSecurityView from '~/components/modules/project/views/security.vue';
 
-const route = useRoute();
-const config = useRuntimeConfig();
 const { project } = storeToRefs(useProjectStore());
 
 const title = computed(() =>
@@ -26,7 +24,6 @@ const description = computed(() =>
 );
 
 const imageAlt = computed(() => `${project.value?.name} Security Insights - LFX Insights`);
-const url = computed(() => `${config.public.appUrl}${route.fullPath}`);
 
 const projectName = computed(() => project.value?.name || '');
 const projectDescription = computed(() => project.value?.description || '');
@@ -43,7 +40,6 @@ useSeoMeta({
   title,
   description,
   ogType: 'website',
-  ogUrl: url,
   ogTitle: title,
   ogDescription: description,
   ogImageAlt: imageAlt,

--- a/frontend/app/pages/project/[slug]/security.vue
+++ b/frontend/app/pages/project/[slug]/security.vue
@@ -15,11 +15,14 @@ const route = useRoute();
 const config = useRuntimeConfig();
 const { project } = storeToRefs(useProjectStore());
 
-const title = computed(() => `${project.value?.name} Security Insights`);
-const description = computed(
-  () =>
-    `Check ${project.value?.name} security and best practices, ` +
-    `including vulnerabilities, dependencies, licensing, and governance compliance.`,
+const title = computed(() =>
+  project.value?.name ? `${project.value.name} Security & Best Practices | LFX Insights` : 'LFX Insights',
+);
+const description = computed(() =>
+  project.value?.name
+    ? `Check ${project.value.name} security and best practices, ` +
+      `including vulnerabilities, dependencies, licensing, and governance compliance.`
+    : 'Check project security and best practices, including vulnerabilities, dependencies, and governance.',
 );
 
 const imageAlt = computed(() => `${project.value?.name} Security Insights - LFX Insights`);

--- a/frontend/app/plugins/canonical.ts
+++ b/frontend/app/plugins/canonical.ts
@@ -17,7 +17,9 @@ export default defineNuxtPlugin(() => {
 
   // Watch for route changes and update canonical URL and og:url together,
   // so social crawlers always see the same URL search engines canonicalize to.
-  // Pages that pass ogUrl to useSeoMeta (e.g. project pages) override the meta tag.
+  // Repository and repository-group pages still pass ogUrl to useSeoMeta and
+  // override this tag with the full path including query params - those
+  // overrides should be removed when their metadata gets the same treatment.
   useHead({
     link: [
       {

--- a/frontend/app/plugins/canonical.ts
+++ b/frontend/app/plugins/canonical.ts
@@ -8,17 +8,27 @@ export default defineNuxtPlugin(() => {
 
   const baseUrl = config.public.appUrl as string;
 
-  // Watch for route changes and update canonical URL
+  // Get the current path and remove trailing slashes for consistency,
+  // combining base URL with path without double slashes
+  const canonicalUrl = () => {
+    const path = route.path.replace(/\/$/, '') || '';
+    return `${baseUrl}${path}`;
+  };
+
+  // Watch for route changes and update canonical URL and og:url together,
+  // so social crawlers always see the same URL search engines canonicalize to.
+  // Pages that pass ogUrl to useSeoMeta (e.g. project pages) override the meta tag.
   useHead({
     link: [
       {
         rel: 'canonical',
-        href: () => {
-          // Get the current path and remove trailing slashes for consistency
-          const path = route.path.replace(/\/$/, '') || '';
-          // Combine base URL with path, ensuring no double slashes
-          return `${baseUrl}${path}`;
-        },
+        href: canonicalUrl,
+      },
+    ],
+    meta: [
+      {
+        property: 'og:url',
+        content: canonicalUrl,
       },
     ],
   });

--- a/frontend/server/api/seo/sitemap/collections.ts
+++ b/frontend/server/api/seo/sitemap/collections.ts
@@ -5,6 +5,6 @@ import { fetchFromTinybird } from '~~/server/data/tinybird/tinybird';
 export default defineSitemapEventHandler(async () => {
   const res = await fetchFromTinybird<{ slug: string }[]>('/v0/pipes/sitemap_collections.json', {});
   return res.data.map((item) => ({
-    loc: `/collection/${item.slug}`,
+    loc: `/collection/details/${item.slug}`,
   }));
 });

--- a/frontend/setup/head.ts
+++ b/frontend/setup/head.ts
@@ -42,7 +42,7 @@ export default {
     { hid: 'og:type', property: 'og:type', content: 'website' },
     // Static fallback; pages calling defineOgImage() override it (nuxt-og-image injects with high priority)
     { hid: 'og:image', property: 'og:image', content: '/og-image.png', tagPriority: 'low' },
-    { hid: 'og:url', property: 'og:url', content: 'https://insights.lfx.org' },
+    // og:url is set per-page by plugins/canonical.ts so it always matches the canonical URL
     { hid: 'twitter:card', name: 'twitter:card', content: 'summary_large_image' },
     {
       hid: 'twitter:title',


### PR DESCRIPTION
## Summary

Implements five findings from the September 2026 SEO audit (epic [IN-1294](https://linuxfoundation.atlassian.net/browse/IN-1294)):

- **[IN-1295](https://linuxfoundation.atlassian.net/browse/IN-1295) – Collections sitemap & metadata.** The collections sitemap emitted `/collection/{slug}` URLs, which 301-redirect to `/collection/details/{slug}` — every entry was a redirect hop for crawlers. Now emits the final URLs. Collection tab pages (contributors/development/popularity) previously shared static titles like "Collection Contributors Insights" across all 675 collections; they now include the collection name (resolved from the parent's TanStack Query cache, no extra fetch). Collections without a description now get a generated meta description (name + project count) instead of an empty tag.
- **[IN-1298](https://linuxfoundation.atlassian.net/browse/IN-1298) – Homepage metadata.** Title was just "LFX Insights"; now keyword-bearing with a fuller ~150-char description.
- **[IN-1299](https://linuxfoundation.atlassian.net/browse/IN-1299) – og:url pointed to the wrong domain.** `setup/head.ts` hardcoded `https://insights.lfx.org` site-wide. Removed; the canonical plugin now emits a per-page `og:url` that always matches the canonical URL. Pages passing `ogUrl` via `useSeoMeta` (project pages) still override it.
- **[IN-1301](https://linuxfoundation.atlassian.net/browse/IN-1301) – Project page titles.** `{Project} Insights` → keyword-bearing templates, e.g. `Kubernetes – Health Score, Contributors & Security | LFX Insights`, with per-tab variants. Also guards against `undefined` in titles/descriptions when project data is unavailable (tab pages previously rendered "undefined Contributors Insights").
- **[IN-1302](https://linuxfoundation.atlassian.net/browse/IN-1302) – Leaderboard detail metadata.** `/leaderboards/{key}` pages had no `useSeoMeta` at all and fell back to the generic site title. Now derive title/description from the static leaderboard config.

## Testing

- `pnpm lint` (0 errors), `pnpm tsc-check`, `pnpm test` (250/250 pass)
- Verified SSR output on the dev server: unique `<title>` on `/leaderboards/stars`, new homepage meta, and `og:url` matching the canonical on every page

## Follow-ups (out of scope)

- Repository and repository-group pages (~19 files) use the same thin `{Project} {Tab} Insights` title pattern and could get the same treatment in a follow-up PR
- The `/collection/{slug}` → `/collection/details/{slug}` 301s are Cloudflare bulk redirects (not in-repo); they remain in place for old links


[IN-1294]: https://linuxfoundation.atlassian.net/browse/IN-1294?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1295]: https://linuxfoundation.atlassian.net/browse/IN-1295?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1298]: https://linuxfoundation.atlassian.net/browse/IN-1298?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[IN-1299]: https://linuxfoundation.atlassian.net/browse/IN-1299?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ