### PR TITLE
feat: add @lfx-insights/tinybird-client shared client package

### DIFF
--- a/libs/tinybird-client/eslint.config.mjs
+++ b/libs/tinybird-client/eslint.config.mjs
@@ -1,0 +1,58 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import typescriptEslint from 'typescript-eslint';
+import prettier from 'eslint-config-prettier';
+import pluginPrettier from 'eslint-plugin-prettier';
+import pluginImport from 'eslint-plugin-import';
+
+export default [
+  {
+    ignores: ['dist/**', 'coverage/**', 'node_modules/**'],
+  },
+  ...typescriptEslint.configs.recommended,
+  prettier,
+  {
+    files: ['**/*.ts'],
+    plugins: {
+      import: pluginImport,
+      prettier: pluginPrettier,
+    },
+    settings: {
+      'import/resolver': {
+        typescript: {
+          alwaysTryTypes: true,
+          project: './tsconfig.json',
+        },
+        node: {
+          extensions: ['.js', '.ts'],
+        },
+      },
+    },
+    rules: {
+      'prettier/prettier': 'error',
+      'no-console': ['error', { allow: ['warn', 'error'] }],
+      'no-debugger': 'error',
+      'no-unused-vars': 'off',
+      '@typescript-eslint/no-unused-vars': [
+        'error',
+        {
+          argsIgnorePattern: '^_',
+          varsIgnorePattern: '^_',
+          destructuredArrayIgnorePattern: '^_',
+        },
+      ],
+      '@typescript-eslint/no-explicit-any': 'warn',
+      'import/order': 'warn',
+      'import/prefer-default-export': 'off',
+      'import/extensions': [
+        'error',
+        'ignorePackages',
+        { js: 'always', ts: 'never' },
+      ],
+      'max-len': 'off',
+      'class-methods-use-this': 'off',
+      'no-shadow': 'off',
+      'func-names': 'off',
+    },
+  },
+];

--- a/libs/tinybird-client/package.json
+++ b/libs/tinybird-client/package.json
@@ -1,0 +1,34 @@
+{
+  "name": "@lfx-insights/tinybird-client",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.js"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "lint": "eslint src tests --max-warnings=0",
+    "lint:fix": "eslint src tests --fix",
+    "format": "prettier --write \"{src,tests}/**/*.ts\"",
+    "format:check": "prettier --check \"{src,tests}/**/*.ts\"",
+    "tsc-check": "tsc --noEmit",
+    "test": "vitest run"
+  },
+  "devDependencies": {
+    "@types/node": "^22.0.0",
+    "eslint": "^9.0.0",
+    "eslint-config-prettier": "^10.0.0",
+    "eslint-import-resolver-typescript": "^4.0.0",
+    "eslint-plugin-import": "^2.31.0",
+    "eslint-plugin-prettier": "^5.0.0",
+    "prettier": "^3.0.0",
+    "typescript": "^5.0.0",
+    "typescript-eslint": "^8.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/libs/tinybird-client/package.json
+++ b/libs/tinybird-client/package.json
@@ -2,6 +2,7 @@
   "name": "@lfx-insights/tinybird-client",
   "version": "0.1.0",
   "private": true,
+  "license": "MIT",
   "type": "module",
   "types": "./dist/index.d.ts",
   "exports": {

--- a/libs/tinybird-client/prettier.config.mjs
+++ b/libs/tinybird-client/prettier.config.mjs
@@ -1,0 +1,30 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+/** @type {import("prettier").Config} */
+export default {
+  semi: true,
+  trailingComma: 'all',
+  singleQuote: true,
+  printWidth: 100,
+  tabWidth: 2,
+  useTabs: false,
+  bracketSpacing: true,
+  bracketSameLine: false,
+  arrowParens: 'always',
+  endOfLine: 'lf',
+  overrides: [
+    {
+      files: ['*.json', '*.jsonc'],
+      options: { trailingComma: 'none' },
+    },
+    {
+      files: ['*.md', '*.mdx'],
+      options: { proseWrap: 'preserve' },
+    },
+    {
+      files: ['*.yaml', '*.yml'],
+      options: { tabWidth: 2, singleQuote: false },
+    },
+  ],
+};

--- a/libs/tinybird-client/src/adaptive-semaphore.ts
+++ b/libs/tinybird-client/src/adaptive-semaphore.ts
@@ -57,7 +57,10 @@ export class AdaptiveSemaphore {
 
   reportTinybirdRateLimit(): void {
     const previousLimit = this.effectiveLimit;
-    this.effectiveLimit = Math.max(Math.floor(this.limit * this.backoffFactor), this.minLimit);
+    this.effectiveLimit = Math.min(
+      this.limit,
+      Math.max(Math.floor(this.limit * this.backoffFactor), this.minLimit),
+    );
 
     this.logger.warn(
       JSON.stringify({

--- a/libs/tinybird-client/src/adaptive-semaphore.ts
+++ b/libs/tinybird-client/src/adaptive-semaphore.ts
@@ -1,0 +1,153 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { TinybirdQueueFullError, TinybirdQueueTimeoutError } from './errors.js';
+import type { TinybirdLogger } from './types.js';
+
+/**
+ * Concurrency limiter for outbound Tinybird requests.
+ *
+ * Caps in-flight requests to `limit`. Excess requests queue up to `maxQueueSize`
+ * with a per-item timeout, rejecting with 503 when the queue is full or a queued
+ * request times out.
+ *
+ * Includes adaptive backoff: when Tinybird returns 429, the effective concurrency
+ * limit is halved for 30 seconds to reduce pressure, then auto-recovers.
+ */
+export class AdaptiveSemaphore {
+  private count = 0;
+
+  /**
+   * The concurrency ceiling currently in force. Starts equal to `limit`.
+   * On 429, reportTinybirdRateLimit() lowers it so active requests drain and
+   * pressure on Tinybird decreases. After recoveryMs it restores to `limit`.
+   */
+  private effectiveLimit: number;
+
+  private recoveryTimer: ReturnType<typeof setTimeout> | null = null;
+  private readonly recoveryMs = 30_000;
+  private readonly backoffFactor = 0.5;
+  private readonly minLimit = 5;
+  private readonly statusLogIntervalMs = 8_000;
+
+  private queue: Array<{
+    resolve: () => void;
+    reject: (err: unknown) => void;
+    timer: ReturnType<typeof setTimeout>;
+  }> = [];
+
+  constructor(
+    private limit: number,
+    private maxQueueSize: number,
+    private logger: TinybirdLogger = console,
+  ) {
+    this.effectiveLimit = limit;
+    setInterval(() => {
+      this.logger.warn(
+        JSON.stringify({
+          message: 'tinybird_queue_status',
+          active: this.count,
+          queued: this.queue.length,
+          effectiveLimit: this.effectiveLimit,
+          limit: this.limit,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    }, this.statusLogIntervalMs).unref();
+  }
+
+  reportTinybirdRateLimit(): void {
+    const previousLimit = this.effectiveLimit;
+    this.effectiveLimit = Math.max(Math.floor(this.limit * this.backoffFactor), this.minLimit);
+
+    this.logger.warn(
+      JSON.stringify({
+        message: 'tinybird_adaptive_throttle',
+        event: 'backoff',
+        previousLimit,
+        newLimit: this.effectiveLimit,
+        active: this.count,
+        queued: this.queue.length,
+        timestamp: new Date().toISOString(),
+      }),
+    );
+
+    if (this.recoveryTimer) {
+      clearTimeout(this.recoveryTimer);
+    }
+
+    this.recoveryTimer = setTimeout(() => {
+      this.effectiveLimit = this.limit;
+      this.recoveryTimer = null;
+      this.logger.warn(
+        JSON.stringify({
+          message: 'tinybird_adaptive_throttle',
+          event: 'recovery',
+          restoredLimit: this.limit,
+          active: this.count,
+          queued: this.queue.length,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+    }, this.recoveryMs);
+  }
+
+  acquire(timeoutMs: number): Promise<boolean> {
+    if (this.count < this.effectiveLimit) {
+      this.count++;
+      return Promise.resolve(false);
+    }
+    if (this.queue.length >= this.maxQueueSize) {
+      return Promise.reject(new TinybirdQueueFullError());
+    }
+    return new Promise<boolean>((resolve, reject) => {
+      const entry: (typeof this.queue)[number] = {
+        resolve: () => resolve(true),
+        reject,
+        timer: setTimeout(() => {
+          const idx = this.queue.indexOf(entry);
+          if (idx !== -1) this.queue.splice(idx, 1);
+          this.logger.warn(
+            JSON.stringify({
+              message: 'tinybird_throttle',
+              queueDepth: this.queue.length,
+              effectiveLimit: this.effectiveLimit,
+              limit: this.limit,
+              timeoutMs,
+              timestamp: new Date().toISOString(),
+            }),
+          );
+          reject(new TinybirdQueueTimeoutError());
+        }, timeoutMs),
+      };
+      this.queue.push(entry);
+    });
+  }
+
+  getActive(): number {
+    return this.count;
+  }
+
+  getQueueLength(): number {
+    return this.queue.length;
+  }
+
+  getEffectiveLimit(): number {
+    return this.effectiveLimit;
+  }
+
+  /**
+   * Called when a request finishes. Transfers the freed slot to the next queued
+   * waiter, or decrements count. During backoff (count > effectiveLimit) it just
+   * decrements, letting active concurrency drain toward the new ceiling before
+   * serving the queue again.
+   */
+  release(): void {
+    if (this.queue.length > 0 && this.count <= this.effectiveLimit) {
+      const next = this.queue.shift()!;
+      clearTimeout(next.timer);
+      next.resolve();
+    } else {
+      this.count--;
+    }
+  }
+}

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -1,0 +1,180 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { TinybirdUnavailableError } from './errors.js';
+import type {
+  TinybirdLogger,
+  TinybirdQuery,
+  TinybirdResponse,
+  BucketCacheStorage,
+} from './types.js';
+
+interface ProjectBucketResponse {
+  bucketId: number;
+}
+
+type Fetcher = <T>(path: string, query: TinybirdQuery) => Promise<TinybirdResponse<T>>;
+
+function isClassifiedTinybirdError(error: unknown): boolean {
+  return Boolean(error && typeof error === 'object' && 'statusCode' in error);
+}
+
+/**
+ * Rethrows classified Tinybird errors as-is; wraps everything else (network/DNS
+ * failures, malformed responses) so callers never mistake "lookup unavailable"
+ * for "project doesn't exist" — an unclassified error must never resolve to null.
+ */
+function classifyBucketLookupError(error: unknown, projectValue: string): never {
+  if (isClassifiedTinybirdError(error)) {
+    throw error;
+  }
+  throw new TinybirdUnavailableError(
+    `Failed to fetch bucketId for project ${projectValue}: ${error}`,
+  );
+}
+
+export function createBucketCache(storage: BucketCacheStorage | undefined, logger: TinybirdLogger) {
+  /** In-memory map preventing cache stampede for concurrent requests on the same project. */
+  const inFlightRequests = new Map<string, Promise<number | null>>();
+  /** Per-key invalidation counters so a stale in-flight write can't repopulate a just-cleared cache entry. */
+  const invalidationGenerations = new Map<string, number>();
+  let globalInvalidationGeneration = 0;
+
+  function currentGeneration(cacheKey: string): number {
+    return (invalidationGenerations.get(cacheKey) ?? 0) + globalInvalidationGeneration;
+  }
+
+  async function fetchFromTinybird(project: string, fetcher: Fetcher): Promise<number | null> {
+    const response = await fetcher<ProjectBucketResponse[]>('/v0/pipes/project_buckets.json', {
+      project,
+    });
+
+    if (!response?.data || !Array.isArray(response.data) || response.data.length === 0) {
+      logger.warn(
+        JSON.stringify({
+          message: 'tinybird_bucket_not_found',
+          project,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return null;
+    }
+
+    const bucketId = response.data[0]?.bucketId;
+
+    if (typeof bucketId !== 'number') {
+      logger.warn(
+        JSON.stringify({
+          message: 'tinybird_bucket_invalid_type',
+          project,
+          bucketIdType: typeof bucketId,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return null;
+    }
+
+    return bucketId;
+  }
+
+  async function getBucketIdForProject(project: string, fetcher: Fetcher): Promise<number | null> {
+    const projectValue = project?.toString().trim();
+    if (!projectValue) {
+      logger.warn(
+        JSON.stringify({
+          message: 'tinybird_bucket_invalid_project',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return null;
+    }
+
+    // No storage configured — always fetch fresh (local dev path)
+    if (!storage) {
+      try {
+        return await fetchFromTinybird(projectValue, fetcher);
+      } catch (error: unknown) {
+        classifyBucketLookupError(error, projectValue);
+      }
+    }
+
+    // Prevent cache stampede: reuse any in-flight request for the same project.
+    // Its `finally` clause already removes it from the map, and every waiter must
+    // observe the same rejection rather than each starting its own replacement fetch.
+    if (inFlightRequests.has(projectValue)) {
+      return inFlightRequests.get(projectValue)!;
+    }
+
+    const cacheKey = `project_bucket:${projectValue}`;
+    const generation = currentGeneration(cacheKey);
+
+    const fetchPromise = (async () => {
+      try {
+        const cached = await storage.getItem(cacheKey);
+        if (cached !== null && cached !== undefined) {
+          return cached;
+        }
+      } catch (err) {
+        logger.error(`Failed to read from bucket cache for project ${projectValue}: ${err}`);
+      }
+
+      try {
+        const bucketId = await fetchFromTinybird(projectValue, fetcher);
+        if (bucketId === null) return null;
+
+        if (currentGeneration(cacheKey) === generation) {
+          try {
+            await storage.setItem(cacheKey, bucketId, { ttl: 86400 });
+          } catch (err) {
+            logger.error(`Failed to cache bucketId for project ${projectValue}: ${err}`);
+          }
+        }
+
+        return bucketId;
+      } catch (error: unknown) {
+        // Propagate all classified Tinybird errors (401/403/404/429/5xx), and wrap
+        // unclassified failures (network/DNS) instead of masking either as a false
+        // "project not found" via a `null` return.
+        classifyBucketLookupError(error, projectValue);
+      } finally {
+        inFlightRequests.delete(projectValue);
+      }
+    })();
+
+    inFlightRequests.set(projectValue, fetchPromise);
+    return fetchPromise;
+  }
+
+  async function clearBucketCache(project: string): Promise<void> {
+    const projectValue = project?.toString().trim();
+    if (!projectValue) return;
+
+    inFlightRequests.delete(projectValue);
+
+    const cacheKey = `project_bucket:${projectValue}`;
+    invalidationGenerations.set(cacheKey, (invalidationGenerations.get(cacheKey) ?? 0) + 1);
+
+    if (!storage) return;
+
+    try {
+      await storage.removeItem(cacheKey);
+    } catch (err) {
+      logger.error(`Failed to clear bucket cache for project ${projectValue}: ${err}`);
+    }
+  }
+
+  async function clearAllBucketCaches(): Promise<void> {
+    inFlightRequests.clear();
+    globalInvalidationGeneration += 1;
+
+    if (!storage) return;
+
+    try {
+      const keys = await storage.getKeys('project_bucket:');
+      await Promise.all(keys.map((key) => storage.removeItem(key)));
+    } catch (err) {
+      logger.error(`Failed to clear all bucket caches: ${err}`);
+    }
+  }
+
+  return { getBucketIdForProject, clearBucketCache, clearAllBucketCaches };
+}

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -124,6 +124,12 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
         if (currentGeneration(cacheKey) === generation) {
           try {
             await storage.setItem(cacheKey, bucketId, { ttl: 86400 });
+            // A concurrent clearBucketCache()/clearAllBucketCaches() may have bumped the
+            // generation while the write above was in flight; remove the just-written
+            // value so it doesn't outlive the invalidation that raced it.
+            if (currentGeneration(cacheKey) !== generation) {
+              await storage.removeItem(cacheKey);
+            }
           } catch (err) {
             logger.error(`Failed to cache bucketId for project ${projectValue}: ${err}`);
           }

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -250,26 +250,29 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
 
     const fetchPromise = (async () => {
       try {
-        const cached = await storage.getItem(cacheKey);
-        if (cached !== null && cached !== undefined) {
-          return cached;
+        try {
+          const cached = await storage.getItem(cacheKey);
+          if (cached !== null && cached !== undefined) {
+            return cached;
+          }
+        } catch (err) {
+          logger.error(`Failed to read from bucket cache for collection ${slugValue}: ${err}`);
         }
-      } catch (err) {
-        logger.error(`Failed to read from bucket cache for collection ${slugValue}: ${err}`);
+
+        const bucketId = await fetchCollectionSafely(slugValue, fetcher);
+        if (bucketId === null) return null;
+
+        if (currentGeneration(cacheKey) === generation) {
+          await writeToCache(cacheKey, bucketId, `collection ${slugValue}`);
+        }
+
+        return bucketId;
+      } finally {
+        collectionInFlightRequests.delete(slugValue);
       }
-
-      const bucketId = await fetchCollectionSafely(slugValue, fetcher);
-      if (bucketId === null) return null;
-
-      if (currentGeneration(cacheKey) === generation) {
-        await writeToCache(cacheKey, bucketId, `collection ${slugValue}`);
-      }
-
-      return bucketId;
     })();
 
     collectionInFlightRequests.set(slugValue, fetchPromise);
-    fetchPromise.finally(() => collectionInFlightRequests.delete(slugValue));
     return fetchPromise;
   }
 

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -1,6 +1,6 @@
 // Copyright (c) 2025 The Linux Foundation and each contributor.
 // SPDX-License-Identifier: MIT
-import { TinybirdUnavailableError } from './errors.js';
+import { TinybirdInvalidResponseError, TinybirdUnavailableError } from './errors.js';
 import type {
   TinybirdLogger,
   TinybirdQuery,
@@ -48,7 +48,13 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
       project,
     });
 
-    if (!response?.data || !Array.isArray(response.data) || response.data.length === 0) {
+    if (!response?.data || !Array.isArray(response.data)) {
+      throw new TinybirdInvalidResponseError(
+        `Malformed project_buckets response for project ${project}`,
+      );
+    }
+
+    if (response.data.length === 0) {
       logger.warn(
         JSON.stringify({
           message: 'tinybird_bucket_not_found',
@@ -62,15 +68,9 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
     const bucketId = response.data[0]?.bucketId;
 
     if (typeof bucketId !== 'number') {
-      logger.warn(
-        JSON.stringify({
-          message: 'tinybird_bucket_invalid_type',
-          project,
-          bucketIdType: typeof bucketId,
-          timestamp: new Date().toISOString(),
-        }),
+      throw new TinybirdInvalidResponseError(
+        `Malformed bucketId (type ${typeof bucketId}) for project ${project}`,
       );
-      return null;
     }
 
     return bucketId;

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -46,8 +46,41 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
   /** Same stampede-prevention strategy as above, kept separate since collection lookups are nonfatal on failure. */
   const collectionInFlightRequests = new Map<string, Promise<number | null>>();
 
+  /**
+   * Tracks the in-flight storage write for each cache key. A clear must await the
+   * matching entry (if any) before it removes the key, so a write that was already
+   * underway when the clear started cannot land afterward and outlive it — closing
+   * the window where a reader could observe a stale value after invalidation.
+   */
+  const pendingWrites = new Map<string, Promise<void>>();
+
   function currentGeneration(cacheKey: string): number {
     return (invalidationGenerations.get(cacheKey) ?? 0) + globalInvalidationGeneration;
+  }
+
+  async function writeToCache(cacheKey: string, bucketId: number, label: string): Promise<void> {
+    const writePromise = (async () => {
+      try {
+        await storage!.setItem(cacheKey, bucketId, { ttl: 86400 });
+      } catch (err) {
+        logger.error(`Failed to cache bucketId for ${label}: ${err}`);
+      }
+    })();
+    pendingWrites.set(cacheKey, writePromise);
+    try {
+      await writePromise;
+    } finally {
+      if (pendingWrites.get(cacheKey) === writePromise) {
+        pendingWrites.delete(cacheKey);
+      }
+    }
+  }
+
+  async function waitForPendingWrite(cacheKey: string): Promise<void> {
+    const pending = pendingWrites.get(cacheKey);
+    if (pending) {
+      await pending.catch(() => {});
+    }
   }
 
   async function fetchFromTinybird(project: string, fetcher: Fetcher): Promise<number | null> {
@@ -129,17 +162,7 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
         if (bucketId === null) return null;
 
         if (currentGeneration(cacheKey) === generation) {
-          try {
-            await storage.setItem(cacheKey, bucketId, { ttl: 86400 });
-            // A concurrent clearBucketCache()/clearAllBucketCaches() may have bumped the
-            // generation while the write above was in flight; remove the just-written
-            // value so it doesn't outlive the invalidation that raced it.
-            if (currentGeneration(cacheKey) !== generation) {
-              await storage.removeItem(cacheKey);
-            }
-          } catch (err) {
-            logger.error(`Failed to cache bucketId for project ${projectValue}: ${err}`);
-          }
+          await writeToCache(cacheKey, bucketId, `project ${projectValue}`);
         }
 
         return bucketId;
@@ -239,14 +262,7 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
       if (bucketId === null) return null;
 
       if (currentGeneration(cacheKey) === generation) {
-        try {
-          await storage.setItem(cacheKey, bucketId, { ttl: 86400 });
-          if (currentGeneration(cacheKey) !== generation) {
-            await storage.removeItem(cacheKey);
-          }
-        } catch (err) {
-          logger.error(`Failed to cache bucketId for collection ${slugValue}: ${err}`);
-        }
+        await writeToCache(cacheKey, bucketId, `collection ${slugValue}`);
       }
 
       return bucketId;
@@ -287,6 +303,10 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
 
     if (!storage) return;
 
+    // Wait for any write already underway for this key before clearing it, so that
+    // write cannot land after we've cleared and leave a stale value behind.
+    await waitForPendingWrite(cacheKey);
+
     try {
       await storage.removeItem(cacheKey);
     } catch (err) {
@@ -300,6 +320,9 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
     globalInvalidationGeneration += 1;
 
     if (!storage) return;
+
+    // Wait for every write already underway before clearing, for the same reason as above.
+    await Promise.all([...pendingWrites.values()].map((p) => p.catch(() => {})));
 
     try {
       const [projectKeys, collectionKeys] = await Promise.all([

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -12,6 +12,10 @@ interface ProjectBucketResponse {
   bucketId: number;
 }
 
+interface CollectionBucketResponse {
+  bucketId: number;
+}
+
 type Fetcher = <T>(path: string, query: TinybirdQuery) => Promise<TinybirdResponse<T>>;
 
 function isClassifiedTinybirdError(error: unknown): boolean {
@@ -38,6 +42,9 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
   /** Per-key invalidation counters so a stale in-flight write can't repopulate a just-cleared cache entry. */
   const invalidationGenerations = new Map<string, number>();
   let globalInvalidationGeneration = 0;
+
+  /** Same stampede-prevention strategy as above, kept separate since collection lookups are nonfatal on failure. */
+  const collectionInFlightRequests = new Map<string, Promise<number | null>>();
 
   function currentGeneration(cacheKey: string): number {
     return (invalidationGenerations.get(cacheKey) ?? 0) + globalInvalidationGeneration;
@@ -150,6 +157,125 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
     return fetchPromise;
   }
 
+  async function fetchCollectionFromTinybird(
+    collectionSlug: string,
+    fetcher: Fetcher,
+  ): Promise<number | null> {
+    const response = await fetcher<CollectionBucketResponse[]>(
+      '/v0/pipes/collection_buckets.json',
+      { collectionSlug },
+    );
+
+    if (!response?.data || !Array.isArray(response.data) || response.data.length === 0) {
+      logger.warn(
+        JSON.stringify({
+          message: 'tinybird_bucket_not_found',
+          collectionSlug,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return null;
+    }
+
+    const bucketId = response.data[0]?.bucketId;
+    if (typeof bucketId !== 'number') {
+      logger.warn(
+        JSON.stringify({
+          message: 'tinybird_bucket_invalid_type',
+          collectionSlug,
+          bucketIdType: typeof bucketId,
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return null;
+    }
+
+    return bucketId;
+  }
+
+  /**
+   * Unlike project routing, a failed or missing collection lookup is nonfatal: callers
+   * fall back to the multi-bucket union pipe, so this never throws for a 404/empty result.
+   * Rate-limit and server errors still propagate so they aren't silently swallowed as
+   * "no collection bucket".
+   */
+  async function getBucketIdForCollection(
+    collectionSlug: string,
+    fetcher: Fetcher,
+  ): Promise<number | null> {
+    const slugValue = collectionSlug?.toString().trim();
+    if (!slugValue) {
+      logger.warn(
+        JSON.stringify({
+          message: 'tinybird_bucket_invalid_collection',
+          timestamp: new Date().toISOString(),
+        }),
+      );
+      return null;
+    }
+
+    if (!storage) {
+      return fetchCollectionSafely(slugValue, fetcher);
+    }
+
+    if (collectionInFlightRequests.has(slugValue)) {
+      return collectionInFlightRequests.get(slugValue)!;
+    }
+
+    const cacheKey = `collection_bucket:${slugValue}`;
+    const generation = currentGeneration(cacheKey);
+
+    const fetchPromise = (async () => {
+      try {
+        const cached = await storage.getItem(cacheKey);
+        if (cached !== null && cached !== undefined) {
+          return cached;
+        }
+      } catch (err) {
+        logger.error(`Failed to read from bucket cache for collection ${slugValue}: ${err}`);
+      }
+
+      const bucketId = await fetchCollectionSafely(slugValue, fetcher);
+      if (bucketId === null) return null;
+
+      if (currentGeneration(cacheKey) === generation) {
+        try {
+          await storage.setItem(cacheKey, bucketId, { ttl: 86400 });
+          if (currentGeneration(cacheKey) !== generation) {
+            await storage.removeItem(cacheKey);
+          }
+        } catch (err) {
+          logger.error(`Failed to cache bucketId for collection ${slugValue}: ${err}`);
+        }
+      }
+
+      return bucketId;
+    })();
+
+    collectionInFlightRequests.set(slugValue, fetchPromise);
+    fetchPromise.finally(() => collectionInFlightRequests.delete(slugValue));
+    return fetchPromise;
+  }
+
+  /** Fetches without throwing: propagates only rate-limit/server errors, otherwise logs and returns null. */
+  async function fetchCollectionSafely(
+    slugValue: string,
+    fetcher: Fetcher,
+  ): Promise<number | null> {
+    try {
+      return await fetchCollectionFromTinybird(slugValue, fetcher);
+    } catch (error: unknown) {
+      if (error && typeof error === 'object' && 'statusCode' in error) {
+        const status = (error as { statusCode: number }).statusCode;
+        if (status === 429 || status >= 500) {
+          throw error;
+        }
+      }
+      logger.warn(`Failed to fetch bucketId for collection ${slugValue}: ${error}`);
+      return null;
+    }
+  }
+
   async function clearBucketCache(project: string): Promise<void> {
     const projectValue = project?.toString().trim();
     if (!projectValue) return;
@@ -170,17 +296,26 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
 
   async function clearAllBucketCaches(): Promise<void> {
     inFlightRequests.clear();
+    collectionInFlightRequests.clear();
     globalInvalidationGeneration += 1;
 
     if (!storage) return;
 
     try {
-      const keys = await storage.getKeys('project_bucket:');
-      await Promise.all(keys.map((key) => storage.removeItem(key)));
+      const [projectKeys, collectionKeys] = await Promise.all([
+        storage.getKeys('project_bucket:'),
+        storage.getKeys('collection_bucket:'),
+      ]);
+      await Promise.all([...projectKeys, ...collectionKeys].map((key) => storage.removeItem(key)));
     } catch (err) {
       logger.error(`Failed to clear all bucket caches: ${err}`);
     }
   }
 
-  return { getBucketIdForProject, clearBucketCache, clearAllBucketCaches };
+  return {
+    getBucketIdForProject,
+    getBucketIdForCollection,
+    clearBucketCache,
+    clearAllBucketCaches,
+  };
 }

--- a/libs/tinybird-client/src/bucket-cache.ts
+++ b/libs/tinybird-client/src/bucket-cache.ts
@@ -149,28 +149,30 @@ export function createBucketCache(storage: BucketCacheStorage | undefined, logge
 
     const fetchPromise = (async () => {
       try {
-        const cached = await storage.getItem(cacheKey);
-        if (cached !== null && cached !== undefined) {
-          return cached;
-        }
-      } catch (err) {
-        logger.error(`Failed to read from bucket cache for project ${projectValue}: ${err}`);
-      }
-
-      try {
-        const bucketId = await fetchFromTinybird(projectValue, fetcher);
-        if (bucketId === null) return null;
-
-        if (currentGeneration(cacheKey) === generation) {
-          await writeToCache(cacheKey, bucketId, `project ${projectValue}`);
+        try {
+          const cached = await storage.getItem(cacheKey);
+          if (cached !== null && cached !== undefined) {
+            return cached;
+          }
+        } catch (err) {
+          logger.error(`Failed to read from bucket cache for project ${projectValue}: ${err}`);
         }
 
-        return bucketId;
-      } catch (error: unknown) {
-        // Propagate all classified Tinybird errors (401/403/404/429/5xx), and wrap
-        // unclassified failures (network/DNS) instead of masking either as a false
-        // "project not found" via a `null` return.
-        classifyBucketLookupError(error, projectValue);
+        try {
+          const bucketId = await fetchFromTinybird(projectValue, fetcher);
+          if (bucketId === null) return null;
+
+          if (currentGeneration(cacheKey) === generation) {
+            await writeToCache(cacheKey, bucketId, `project ${projectValue}`);
+          }
+
+          return bucketId;
+        } catch (error: unknown) {
+          // Propagate all classified Tinybird errors (401/403/404/429/5xx), and wrap
+          // unclassified failures (network/DNS) instead of masking either as a false
+          // "project not found" via a `null` return.
+          classifyBucketLookupError(error, projectValue);
+        }
       } finally {
         inFlightRequests.delete(projectValue);
       }

--- a/libs/tinybird-client/src/client.ts
+++ b/libs/tinybird-client/src/client.ts
@@ -1,0 +1,235 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { AdaptiveSemaphore } from './adaptive-semaphore.js';
+import { createBucketCache } from './bucket-cache.js';
+import {
+  TinybirdClientError,
+  TinybirdInvalidResponseError,
+  TinybirdProjectNotFoundError,
+} from './errors.js';
+import type {
+  TinybirdClient,
+  TinybirdClientConfig,
+  TinybirdLogger,
+  TinybirdQuery,
+  TinybirdQueryValue,
+  TinybirdResponse,
+} from './types.js';
+
+const DEFAULT_BASE_URL = 'https://api.us-west-2.aws.tinybird.co';
+const DEFAULT_MAX_CONCURRENT = 35;
+const DEFAULT_MAX_QUEUE_SIZE = 500;
+const DEFAULT_QUEUE_TIMEOUT_MS = 10_000;
+const DEFAULT_SLOW_REQUEST_THRESHOLD_MS = 5_000;
+
+/** Paths that bypass the semaphore so they don't compete with real data queries. */
+const SKIP_THROTTLE_PATHS = new Set([
+  '/v0/pipes/ping.json',
+  '/v0/pipes/project_buckets.json',
+  '/v0/pipes/collection_buckets.json',
+]);
+
+function stripTrailingSlashes(url: string): string {
+  let end = url.length;
+  while (end > 0 && url[end - 1] === '/') end--;
+  return url.slice(0, end);
+}
+
+function buildQueryString(query: TinybirdQuery): string {
+  const parts: string[] = [];
+  for (const [key, value] of Object.entries(query)) {
+    if (value === undefined || value === null || value === '' || Number.isNaN(value)) continue;
+    if (Array.isArray(value)) {
+      // Arrays use raw commas (not URL-encoded) for Tinybird Array() parameters
+      parts.push(
+        `${encodeURIComponent(key)}=${value.map((v) => encodeURIComponent(String(v))).join(',')}`,
+      );
+    } else {
+      parts.push(`${encodeURIComponent(key)}=${encodeURIComponent(String(value))}`);
+    }
+  }
+  return parts.join('&');
+}
+
+function buildBodyString(params: TinybirdQuery): string {
+  return buildQueryString(params);
+}
+
+async function parseResponse<T>(response: Response): Promise<TinybirdResponse<T>> {
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    const detail = body ? ` — ${body.slice(0, 300)}` : '';
+    throw new TinybirdClientError(
+      response.status,
+      `Tinybird request failed: ${response.statusText}${detail}`,
+    );
+  }
+  const data = (await response.json()) as TinybirdResponse<T>;
+  if (!data || !data.data) {
+    throw new TinybirdInvalidResponseError();
+  }
+  return data;
+}
+
+export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClient {
+  if (!config.token) {
+    throw new Error('createTinybirdClient: token is required');
+  }
+
+  const {
+    baseUrl: rawBaseUrl = DEFAULT_BASE_URL,
+    token,
+    maxConcurrent = DEFAULT_MAX_CONCURRENT,
+    maxQueueSize = DEFAULT_MAX_QUEUE_SIZE,
+    queueTimeoutMs = DEFAULT_QUEUE_TIMEOUT_MS,
+    slowRequestThresholdMs = DEFAULT_SLOW_REQUEST_THRESHOLD_MS,
+    bucketCache: bucketCacheStorage,
+  } = config;
+
+  const baseUrl = stripTrailingSlashes(rawBaseUrl);
+  const logger: TinybirdLogger = config.logger ?? console;
+  const semaphore = new AdaptiveSemaphore(maxConcurrent, maxQueueSize, logger);
+  const bucketCache = createBucketCache(bucketCacheStorage, logger);
+
+  const authHeaders = { Authorization: `Bearer ${token}` };
+
+  async function fetchFromTinybird<T>(
+    path: string,
+    query: TinybirdQuery,
+  ): Promise<TinybirdResponse<T>> {
+    // Resolve bucket routing for project queries
+    if (
+      query.project &&
+      typeof query.project === 'string' &&
+      query.bucketId == null &&
+      path !== '/v0/pipes/project_buckets.json'
+    ) {
+      try {
+        const bucketId = await bucketCache.getBucketIdForProject(
+          query.project as string,
+          fetchFromTinybird,
+        );
+        if (bucketId !== null) {
+          query = { ...query, bucketId };
+        } else {
+          throw new TinybirdProjectNotFoundError(query.project as string);
+        }
+      } catch (error: unknown) {
+        // Re-throw all classified Tinybird errors (401/403/404/429/5xx) instead of
+        // masking auth/permission failures as a missing project.
+        if (error && typeof error === 'object' && 'statusCode' in error) {
+          throw error;
+        }
+        logger.warn(`Failed to fetch bucketId for project ${query.project as string}: ${error}`);
+      }
+    }
+
+    const qs = buildQueryString(query);
+    const url = qs ? `${baseUrl}${path}?${qs}` : `${baseUrl}${path}`;
+    const skipThrottle = SKIP_THROTTLE_PATHS.has(path);
+
+    let acquired = false;
+    let wasQueued = false;
+    const fetchStart = Date.now();
+
+    try {
+      if (!skipThrottle) {
+        wasQueued = await semaphore.acquire(queueTimeoutMs);
+        acquired = true;
+      }
+
+      const response = await fetch(url, { headers: authHeaders });
+      const data = await parseResponse<T>(response);
+
+      const durationMs = Date.now() - fetchStart;
+      if (durationMs > slowRequestThresholdMs) {
+        logger.warn(
+          JSON.stringify({
+            message: 'tinybird_slow_request',
+            pipe: path,
+            params: query,
+            durationMs,
+            wasQueued,
+            active: semaphore.getActive(),
+            queued: semaphore.getQueueLength(),
+            timestamp: new Date().toISOString(),
+          }),
+        );
+      }
+
+      return data;
+    } catch (error: unknown) {
+      // Only TinybirdClientError carries statusCode; plain network failures (DNS, TCP reset)
+      // will log status: undefined and will NOT trigger rate-limit backoff.
+      const status =
+        error && typeof error === 'object' && 'statusCode' in error
+          ? (error as { statusCode: number }).statusCode
+          : undefined;
+
+      logger.error(
+        JSON.stringify({
+          message: 'tinybird_request_error',
+          pipe: path,
+          params: query,
+          status,
+          durationMs: Date.now() - fetchStart,
+          wasQueued,
+          active: semaphore.getActive(),
+          queued: semaphore.getQueueLength(),
+          timestamp: new Date().toISOString(),
+        }),
+      );
+
+      if (status === 429) {
+        semaphore.reportTinybirdRateLimit();
+      }
+      throw error;
+    } finally {
+      if (acquired) {
+        semaphore.release();
+      }
+    }
+  }
+
+  async function postToTinybird<T>(
+    path: string,
+    params: TinybirdQuery,
+  ): Promise<TinybirdResponse<T>> {
+    const url = `${baseUrl}${path}`;
+    const body = buildBodyString(params);
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { ...authHeaders, 'Content-Type': 'application/x-www-form-urlencoded' },
+      body,
+    });
+    return parseResponse<T>(response);
+  }
+
+  async function ingest(datasource: string, data: object): Promise<boolean> {
+    const url = `${baseUrl}/v0/events?name=${encodeURIComponent(datasource)}`;
+    const response = await fetch(url, {
+      method: 'POST',
+      headers: { ...authHeaders, 'Content-Type': 'application/json' },
+      body: JSON.stringify(data),
+    });
+    if (!response.ok) {
+      throw new TinybirdClientError(
+        response.status,
+        `Tinybird ingest failed: ${response.statusText}`,
+      );
+    }
+    return true;
+  }
+
+  return {
+    fetch: fetchFromTinybird,
+    post: postToTinybird,
+    ingest,
+    getBucketIdForProject: (project: string) =>
+      bucketCache.getBucketIdForProject(project, fetchFromTinybird),
+    clearBucketCache: bucketCache.clearBucketCache,
+    clearAllBucketCaches: bucketCache.clearAllBucketCaches,
+  };
+}
+
+export type { TinybirdQueryValue };

--- a/libs/tinybird-client/src/client.ts
+++ b/libs/tinybird-client/src/client.ts
@@ -64,7 +64,12 @@ async function parseResponse<T>(response: Response): Promise<TinybirdResponse<T>
       `Tinybird request failed: ${response.statusText}${detail}`,
     );
   }
-  const data = (await response.json()) as TinybirdResponse<T>;
+  let data: TinybirdResponse<T>;
+  try {
+    data = (await response.json()) as TinybirdResponse<T>;
+  } catch {
+    throw new TinybirdInvalidResponseError('Tinybird response was not valid JSON');
+  }
   if (!data || !data.data) {
     throw new TinybirdInvalidResponseError();
   }
@@ -92,6 +97,75 @@ export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClie
   const bucketCache = createBucketCache(bucketCacheStorage, logger);
 
   const authHeaders = { Authorization: `Bearer ${token}` };
+
+  async function withThrottle<T>(
+    path: string,
+    params: TinybirdQuery,
+    skipThrottle: boolean,
+    send: () => Promise<Response>,
+  ): Promise<TinybirdResponse<T>> {
+    let acquired = false;
+    let wasQueued = false;
+    const fetchStart = Date.now();
+
+    try {
+      if (!skipThrottle) {
+        wasQueued = await semaphore.acquire(queueTimeoutMs);
+        acquired = true;
+      }
+
+      const response = await send();
+      const data = await parseResponse<T>(response);
+
+      const durationMs = Date.now() - fetchStart;
+      if (durationMs > slowRequestThresholdMs) {
+        logger.warn(
+          JSON.stringify({
+            message: 'tinybird_slow_request',
+            pipe: path,
+            params,
+            durationMs,
+            wasQueued,
+            active: semaphore.getActive(),
+            queued: semaphore.getQueueLength(),
+            timestamp: new Date().toISOString(),
+          }),
+        );
+      }
+
+      return data;
+    } catch (error: unknown) {
+      // Only TinybirdClientError carries statusCode; plain network failures (DNS, TCP reset)
+      // will log status: undefined and will NOT trigger rate-limit backoff.
+      const status =
+        error && typeof error === 'object' && 'statusCode' in error
+          ? (error as { statusCode: number }).statusCode
+          : undefined;
+
+      logger.error(
+        JSON.stringify({
+          message: 'tinybird_request_error',
+          pipe: path,
+          params,
+          status,
+          durationMs: Date.now() - fetchStart,
+          wasQueued,
+          active: semaphore.getActive(),
+          queued: semaphore.getQueueLength(),
+          timestamp: new Date().toISOString(),
+        }),
+      );
+
+      if (status === 429) {
+        semaphore.reportTinybirdRateLimit();
+      }
+      throw error;
+    } finally {
+      if (acquired) {
+        semaphore.release();
+      }
+    }
+  }
 
   async function fetchFromTinybird<T>(
     path: string,
@@ -128,67 +202,7 @@ export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClie
     const url = qs ? `${baseUrl}${path}?${qs}` : `${baseUrl}${path}`;
     const skipThrottle = SKIP_THROTTLE_PATHS.has(path);
 
-    let acquired = false;
-    let wasQueued = false;
-    const fetchStart = Date.now();
-
-    try {
-      if (!skipThrottle) {
-        wasQueued = await semaphore.acquire(queueTimeoutMs);
-        acquired = true;
-      }
-
-      const response = await fetch(url, { headers: authHeaders });
-      const data = await parseResponse<T>(response);
-
-      const durationMs = Date.now() - fetchStart;
-      if (durationMs > slowRequestThresholdMs) {
-        logger.warn(
-          JSON.stringify({
-            message: 'tinybird_slow_request',
-            pipe: path,
-            params: query,
-            durationMs,
-            wasQueued,
-            active: semaphore.getActive(),
-            queued: semaphore.getQueueLength(),
-            timestamp: new Date().toISOString(),
-          }),
-        );
-      }
-
-      return data;
-    } catch (error: unknown) {
-      // Only TinybirdClientError carries statusCode; plain network failures (DNS, TCP reset)
-      // will log status: undefined and will NOT trigger rate-limit backoff.
-      const status =
-        error && typeof error === 'object' && 'statusCode' in error
-          ? (error as { statusCode: number }).statusCode
-          : undefined;
-
-      logger.error(
-        JSON.stringify({
-          message: 'tinybird_request_error',
-          pipe: path,
-          params: query,
-          status,
-          durationMs: Date.now() - fetchStart,
-          wasQueued,
-          active: semaphore.getActive(),
-          queued: semaphore.getQueueLength(),
-          timestamp: new Date().toISOString(),
-        }),
-      );
-
-      if (status === 429) {
-        semaphore.reportTinybirdRateLimit();
-      }
-      throw error;
-    } finally {
-      if (acquired) {
-        semaphore.release();
-      }
-    }
+    return withThrottle<T>(path, query, skipThrottle, () => fetch(url, { headers: authHeaders }));
   }
 
   async function postToTinybird<T>(
@@ -197,12 +211,14 @@ export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClie
   ): Promise<TinybirdResponse<T>> {
     const url = `${baseUrl}${path}`;
     const body = buildBodyString(params);
-    const response = await fetch(url, {
-      method: 'POST',
-      headers: { ...authHeaders, 'Content-Type': 'application/x-www-form-urlencoded' },
-      body,
-    });
-    return parseResponse<T>(response);
+
+    return withThrottle<T>(path, params, false, () =>
+      fetch(url, {
+        method: 'POST',
+        headers: { ...authHeaders, 'Content-Type': 'application/x-www-form-urlencoded' },
+        body,
+      }),
+    );
   }
 
   async function ingest(datasource: string, data: object): Promise<boolean> {

--- a/libs/tinybird-client/src/client.ts
+++ b/libs/tinybird-client/src/client.ts
@@ -198,6 +198,24 @@ export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClie
       }
     }
 
+    // Resolve bucket routing for collection queries. Unlike project routing, a missing
+    // or failed lookup is nonfatal — bucketId is simply left unset so the request falls
+    // back to the (more expensive) multi-bucket union pipe instead of erroring out.
+    if (
+      query.collectionSlug &&
+      typeof query.collectionSlug === 'string' &&
+      query.bucketId == null &&
+      path !== '/v0/pipes/collection_buckets.json'
+    ) {
+      const bucketId = await bucketCache.getBucketIdForCollection(
+        query.collectionSlug as string,
+        fetchFromTinybird,
+      );
+      if (bucketId !== null) {
+        query = { ...query, bucketId };
+      }
+    }
+
     const qs = buildQueryString(query);
     const url = qs ? `${baseUrl}${path}?${qs}` : `${baseUrl}${path}`;
     const skipThrottle = SKIP_THROTTLE_PATHS.has(path);
@@ -243,6 +261,8 @@ export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClie
     ingest,
     getBucketIdForProject: (project: string) =>
       bucketCache.getBucketIdForProject(project, fetchFromTinybird),
+    getBucketIdForCollection: (collectionSlug: string) =>
+      bucketCache.getBucketIdForCollection(collectionSlug, fetchFromTinybird),
     clearBucketCache: bucketCache.clearBucketCache,
     clearAllBucketCaches: bucketCache.clearAllBucketCaches,
   };

--- a/libs/tinybird-client/src/client.ts
+++ b/libs/tinybird-client/src/client.ts
@@ -29,6 +29,28 @@ const SKIP_THROTTLE_PATHS = new Set([
   '/v0/pipes/collection_buckets.json',
 ]);
 
+/**
+ * Matches ofetch's default retry behavior (which the previous `ofetch`-based implementation
+ * relied on): GET requests get one retry on a network error or one of these transient status
+ * codes, so a request that used to recover after one retry doesn't now fail immediately.
+ */
+const RETRYABLE_STATUS_CODES = new Set([408, 409, 425, 429, 500, 502, 503, 504]);
+const GET_RETRY_COUNT = 1;
+
+async function fetchWithRetry(url: string, init: RequestInit, retries: number): Promise<Response> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      const response = await fetch(url, init);
+      if (!response.ok && RETRYABLE_STATUS_CODES.has(response.status) && attempt < retries) {
+        continue;
+      }
+      return response;
+    } catch (error) {
+      if (attempt >= retries) throw error;
+    }
+  }
+}
+
 function stripTrailingSlashes(url: string): string {
   let end = url.length;
   while (end > 0 && url[end - 1] === '/') end--;
@@ -220,7 +242,9 @@ export function createTinybirdClient(config: TinybirdClientConfig): TinybirdClie
     const url = qs ? `${baseUrl}${path}?${qs}` : `${baseUrl}${path}`;
     const skipThrottle = SKIP_THROTTLE_PATHS.has(path);
 
-    return withThrottle<T>(path, query, skipThrottle, () => fetch(url, { headers: authHeaders }));
+    return withThrottle<T>(path, query, skipThrottle, () =>
+      fetchWithRetry(url, { headers: authHeaders }, GET_RETRY_COUNT),
+    );
   }
 
   async function postToTinybird<T>(

--- a/libs/tinybird-client/src/errors.ts
+++ b/libs/tinybird-client/src/errors.ts
@@ -1,0 +1,48 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+export class TinybirdClientError extends Error {
+  constructor(
+    public readonly statusCode: number,
+    message: string,
+    options?: ErrorOptions,
+  ) {
+    super(message, options);
+    this.name = 'TinybirdClientError';
+  }
+}
+
+export class TinybirdQueueFullError extends TinybirdClientError {
+  constructor() {
+    super(503, 'Tinybird request queue full — try again shortly');
+    this.name = 'TinybirdQueueFullError';
+  }
+}
+
+export class TinybirdQueueTimeoutError extends TinybirdClientError {
+  constructor() {
+    super(503, 'Tinybird request queue timeout — try again shortly');
+    this.name = 'TinybirdQueueTimeoutError';
+  }
+}
+
+export class TinybirdProjectNotFoundError extends TinybirdClientError {
+  constructor(project: string) {
+    super(404, `Project not found: ${project}`);
+    this.name = 'TinybirdProjectNotFoundError';
+  }
+}
+
+export class TinybirdInvalidResponseError extends TinybirdClientError {
+  constructor(message = 'Invalid response from Tinybird') {
+    super(502, message);
+    this.name = 'TinybirdInvalidResponseError';
+  }
+}
+
+export class TinybirdUnavailableError extends TinybirdClientError {
+  constructor(message = 'Tinybird is currently unavailable') {
+    super(503, message);
+    this.name = 'TinybirdUnavailableError';
+  }
+}

--- a/libs/tinybird-client/src/index.ts
+++ b/libs/tinybird-client/src/index.ts
@@ -1,0 +1,21 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+export { createTinybirdClient } from './client.js';
+export { AdaptiveSemaphore } from './adaptive-semaphore.js';
+export {
+  TinybirdClientError,
+  TinybirdQueueFullError,
+  TinybirdQueueTimeoutError,
+  TinybirdProjectNotFoundError,
+  TinybirdInvalidResponseError,
+  TinybirdUnavailableError,
+} from './errors.js';
+export type {
+  TinybirdClient,
+  TinybirdClientConfig,
+  TinybirdResponse,
+  TinybirdQueryValue,
+  TinybirdQuery,
+  BucketCacheStorage,
+  TinybirdLogger,
+} from './types.js';

--- a/libs/tinybird-client/src/types.ts
+++ b/libs/tinybird-client/src/types.ts
@@ -1,0 +1,61 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+
+export interface TinybirdResponse<T> {
+  data: T;
+  meta: {
+    name: string;
+    type: string;
+  }[];
+  rows: number;
+  rows_before_limit_at_least?: number;
+  statistics: {
+    elapsed: number;
+    rows_read: number;
+    bytes_read: number;
+  };
+}
+
+/** Scalar or array values accepted in a Tinybird query. No framework types (e.g. no Luxon DateTime). */
+export type TinybirdQueryValue = string | number | boolean | string[] | number[] | undefined | null;
+
+export type TinybirdQuery = Record<string, TinybirdQueryValue>;
+
+export interface TinybirdLogger {
+  warn(message: string): void;
+  error(message: string): void;
+}
+
+/**
+ * Minimal storage interface for the bucket-ID cache.
+ * Implementors can wrap Redis, an in-memory map, or anything else.
+ */
+export interface BucketCacheStorage {
+  getItem(key: string): Promise<number | null | undefined>;
+  setItem(key: string, value: number, options?: { ttl?: number }): Promise<void>;
+  removeItem(key: string): Promise<void>;
+  getKeys(prefix: string): Promise<string[]>;
+}
+
+export interface TinybirdClientConfig {
+  /** Defaults to https://api.us-west-2.aws.tinybird.co */
+  baseUrl?: string;
+  token: string;
+  maxConcurrent?: number;
+  maxQueueSize?: number;
+  queueTimeoutMs?: number;
+  slowRequestThresholdMs?: number;
+  /** Optional persistent cache for project → bucketId lookups. Omit to always fetch fresh. */
+  bucketCache?: BucketCacheStorage;
+  /** Defaults to console */
+  logger?: TinybirdLogger;
+}
+
+export interface TinybirdClient {
+  fetch<T>(path: string, query: TinybirdQuery): Promise<TinybirdResponse<T>>;
+  post<T>(path: string, params: TinybirdQuery): Promise<TinybirdResponse<T>>;
+  ingest(datasource: string, data: object): Promise<boolean>;
+  getBucketIdForProject(project: string): Promise<number | null>;
+  clearBucketCache(project: string): Promise<void>;
+  clearAllBucketCaches(): Promise<void>;
+}

--- a/libs/tinybird-client/src/types.ts
+++ b/libs/tinybird-client/src/types.ts
@@ -56,6 +56,7 @@ export interface TinybirdClient {
   post<T>(path: string, params: TinybirdQuery): Promise<TinybirdResponse<T>>;
   ingest(datasource: string, data: object): Promise<boolean>;
   getBucketIdForProject(project: string): Promise<number | null>;
+  getBucketIdForCollection(collectionSlug: string): Promise<number | null>;
   clearBucketCache(project: string): Promise<void>;
   clearAllBucketCaches(): Promise<void>;
 }

--- a/libs/tinybird-client/tests/adaptive-semaphore.test.ts
+++ b/libs/tinybird-client/tests/adaptive-semaphore.test.ts
@@ -1,0 +1,141 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { AdaptiveSemaphore } from '../src/adaptive-semaphore.js';
+import { TinybirdQueueFullError, TinybirdQueueTimeoutError } from '../src/errors.js';
+
+describe('AdaptiveSemaphore', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  describe('acquire()', () => {
+    it('returns false when a slot is immediately available', async () => {
+      const sem = new AdaptiveSemaphore(2, 10);
+      expect(await sem.acquire(1000)).toBe(false);
+    });
+
+    it('returns true when the request was queued', async () => {
+      const sem = new AdaptiveSemaphore(1, 10);
+      await sem.acquire(5000);
+
+      const promise = sem.acquire(5000);
+      sem.release();
+
+      expect(await promise).toBe(true);
+    });
+
+    it('blocks when all slots are taken', async () => {
+      const sem = new AdaptiveSemaphore(2, 10);
+      await sem.acquire(1000);
+      await sem.acquire(1000);
+
+      let resolved = false;
+      const promise = sem.acquire(5000).then(() => {
+        resolved = true;
+      });
+
+      await vi.advanceTimersByTimeAsync(0);
+      expect(resolved).toBe(false);
+
+      sem.release();
+      await promise;
+      expect(resolved).toBe(true);
+    });
+
+    it('rejects with TinybirdQueueFullError when queue is full', async () => {
+      const sem = new AdaptiveSemaphore(1, 1);
+      await sem.acquire(5000);
+      sem.acquire(5000); // fills queue
+
+      await expect(sem.acquire(5000)).rejects.toBeInstanceOf(TinybirdQueueFullError);
+      await expect(sem.acquire(5000)).rejects.toMatchObject({ statusCode: 503 });
+
+      // cleanup
+      sem.release();
+    });
+
+    it('rejects with TinybirdQueueTimeoutError on queue timeout', async () => {
+      const sem = new AdaptiveSemaphore(1, 10);
+      await sem.acquire(1000);
+
+      const promise = sem.acquire(100);
+      vi.advanceTimersByTime(101);
+
+      await expect(promise).rejects.toBeInstanceOf(TinybirdQueueTimeoutError);
+      await expect(promise).rejects.toMatchObject({ statusCode: 503 });
+    });
+  });
+
+  describe('release()', () => {
+    it('serves queued waiters in FIFO order', async () => {
+      const sem = new AdaptiveSemaphore(1, 10);
+      await sem.acquire(5000);
+
+      const order: number[] = [];
+      const p1 = sem.acquire(5000).then(() => order.push(1));
+      const p2 = sem.acquire(5000).then(() => order.push(2));
+
+      sem.release();
+      await p1;
+      sem.release();
+      await p2;
+
+      expect(order).toEqual([1, 2]);
+    });
+
+    it('drains count during backoff instead of serving queue', async () => {
+      const sem = new AdaptiveSemaphore(10, 10);
+      for (let i = 0; i < 10; i++) await sem.acquire(5000);
+
+      let queuedResolved = false;
+      const queuedPromise = sem.acquire(5000).then(() => {
+        queuedResolved = true;
+      });
+
+      // Trigger backoff: effectiveLimit drops to 5
+      sem.reportTinybirdRateLimit();
+      expect(sem.getEffectiveLimit()).toBe(5);
+
+      // Release 5 times: count drains 10 → 5, queue NOT served
+      for (let i = 0; i < 5; i++) sem.release();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sem.getActive()).toBe(5);
+      expect(queuedResolved).toBe(false);
+
+      // Next release: count(5) <= effectiveLimit(5), queue served
+      sem.release();
+      await queuedPromise;
+      expect(queuedResolved).toBe(true);
+    });
+  });
+
+  describe('reportTinybirdRateLimit()', () => {
+    it('halves the effective limit', () => {
+      const sem = new AdaptiveSemaphore(20, 10);
+      sem.reportTinybirdRateLimit();
+      expect(sem.getEffectiveLimit()).toBe(10);
+    });
+
+    it('does not go below minLimit (5)', () => {
+      const sem = new AdaptiveSemaphore(8, 10);
+      sem.reportTinybirdRateLimit();
+      expect(sem.getEffectiveLimit()).toBe(5);
+    });
+
+    it('recovers after 30 seconds', () => {
+      const sem = new AdaptiveSemaphore(20, 10);
+      sem.reportTinybirdRateLimit();
+      expect(sem.getEffectiveLimit()).toBe(10);
+
+      vi.advanceTimersByTime(30_000);
+      expect(sem.getEffectiveLimit()).toBe(20);
+    });
+  });
+});

--- a/libs/tinybird-client/tests/bucket-cache.test.ts
+++ b/libs/tinybird-client/tests/bucket-cache.test.ts
@@ -1,0 +1,189 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { createBucketCache } from '../src/bucket-cache.js';
+import { TinybirdClientError, TinybirdUnavailableError } from '../src/errors.js';
+import type { BucketCacheStorage, TinybirdLogger, TinybirdResponse } from '../src/types.js';
+
+const logger: TinybirdLogger = { warn: vi.fn(), error: vi.fn() };
+
+function bucketResponse(bucketId: number): TinybirdResponse<{ bucketId: number }[]> {
+  return {
+    data: [{ bucketId }],
+    meta: [{ name: 'bucketId', type: 'Int32' }],
+    rows: 1,
+    statistics: { elapsed: 0.1, rows_read: 1, bytes_read: 10 },
+  };
+}
+
+function createMemoryStorage(): BucketCacheStorage {
+  const store = new Map<string, number>();
+  return {
+    async getItem(key) {
+      return store.has(key) ? store.get(key)! : null;
+    },
+    async setItem(key, value) {
+      store.set(key, value);
+    },
+    async removeItem(key) {
+      store.delete(key);
+    },
+    async getKeys(prefix) {
+      return [...store.keys()].filter((k) => k.startsWith(prefix));
+    },
+  };
+}
+
+describe('createBucketCache — getBucketIdForProject', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('fetches fresh every time when no storage is configured', async () => {
+    const cache = createBucketCache(undefined, logger);
+    const fetcher = vi.fn().mockResolvedValue(bucketResponse(7));
+
+    const first = await cache.getBucketIdForProject('k8s', fetcher);
+    const second = await cache.getBucketIdForProject('k8s', fetcher);
+
+    expect(first).toBe(7);
+    expect(second).toBe(7);
+    expect(fetcher).toHaveBeenCalledTimes(2);
+  });
+
+  it('caches the bucketId in storage after a successful fetch', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    const fetcher = vi.fn().mockResolvedValue(bucketResponse(9));
+
+    await cache.getBucketIdForProject('k8s', fetcher);
+    const second = await cache.getBucketIdForProject('k8s', fetcher);
+
+    expect(second).toBe(9);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent in-flight requests for the same project', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    let resolveFetch: (value: TinybirdResponse<{ bucketId: number }[]>) => void = () => {};
+    const fetcher = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const p1 = cache.getBucketIdForProject('k8s', fetcher);
+    const p2 = cache.getBucketIdForProject('k8s', fetcher);
+    resolveFetch(bucketResponse(3));
+
+    expect(await p1).toBe(3);
+    expect(await p2).toBe(3);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates the same rejection to every coalesced waiter instead of each retrying its own fetch', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    let rejectFetch: (error: unknown) => void = () => {};
+    const fetcher = vi.fn().mockReturnValue(
+      new Promise((_resolve, reject) => {
+        rejectFetch = reject;
+      }),
+    );
+
+    const p1 = cache.getBucketIdForProject('k8s', fetcher);
+    const p2 = cache.getBucketIdForProject('k8s', fetcher);
+    rejectFetch(new Error('network blip'));
+
+    await expect(p1).rejects.toThrow(TinybirdUnavailableError);
+    await expect(p2).rejects.toThrow(TinybirdUnavailableError);
+    // Only the original in-flight fetch should have run — a coalesced waiter must
+    // never start a replacement fetch of its own after the shared one rejects.
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('propagates a 401 error instead of masking it as a missing project', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    const fetcher = vi.fn().mockRejectedValue(new TinybirdClientError(401, 'Unauthorized'));
+
+    await expect(cache.getBucketIdForProject('k8s', fetcher)).rejects.toThrow('Unauthorized');
+  });
+
+  it('propagates a 403 error instead of masking it as a missing project', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    const fetcher = vi.fn().mockRejectedValue(new TinybirdClientError(403, 'Forbidden'));
+
+    await expect(cache.getBucketIdForProject('k8s', fetcher)).rejects.toThrow('Forbidden');
+  });
+
+  it('wraps unclassified errors as TinybirdUnavailableError instead of a false "not found"', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    const fetcher = vi.fn().mockRejectedValue(new Error('network blip'));
+
+    await expect(cache.getBucketIdForProject('k8s', fetcher)).rejects.toThrow(
+      TinybirdUnavailableError,
+    );
+  });
+
+  it('wraps unclassified errors as TinybirdUnavailableError when no storage is configured', async () => {
+    const cache = createBucketCache(undefined, logger);
+    const fetcher = vi.fn().mockRejectedValue(new Error('network blip'));
+
+    await expect(cache.getBucketIdForProject('k8s', fetcher)).rejects.toThrow(
+      TinybirdUnavailableError,
+    );
+  });
+
+  it('does not repopulate the cache from a stale in-flight write after clearBucketCache', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+
+    let resolveFetch: (value: TinybirdResponse<{ bucketId: number }[]>) => void = () => {};
+    const slowFetcher = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const inFlight = cache.getBucketIdForProject('k8s', slowFetcher);
+    // Cache is cleared while the lookup above is still in flight.
+    await cache.clearBucketCache('k8s');
+    resolveFetch(bucketResponse(5));
+    await inFlight;
+
+    const freshFetcher = vi.fn().mockResolvedValue(bucketResponse(11));
+    const afterClear = await cache.getBucketIdForProject('k8s', freshFetcher);
+
+    // The stale write from the in-flight lookup must not have won; the cache should
+    // have been empty, forcing a fresh fetch that returns the new value.
+    expect(afterClear).toBe(11);
+    expect(freshFetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not repopulate any cache entry from a stale in-flight write after clearAllBucketCaches', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+
+    let resolveFetch: (value: TinybirdResponse<{ bucketId: number }[]>) => void = () => {};
+    const slowFetcher = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const inFlight = cache.getBucketIdForProject('k8s', slowFetcher);
+    await cache.clearAllBucketCaches();
+    resolveFetch(bucketResponse(5));
+    await inFlight;
+
+    const freshFetcher = vi.fn().mockResolvedValue(bucketResponse(13));
+    const afterClear = await cache.getBucketIdForProject('k8s', freshFetcher);
+
+    expect(afterClear).toBe(13);
+    expect(freshFetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/tinybird-client/tests/bucket-cache.test.ts
+++ b/libs/tinybird-client/tests/bucket-cache.test.ts
@@ -235,6 +235,29 @@ describe('createBucketCache — getBucketIdForProject', () => {
     expect(afterClear).toBe(13);
     expect(freshFetcher).toHaveBeenCalledTimes(1);
   });
+
+  it('clears the in-flight entry on a cache hit so a later clearBucketCache + refetch is not stuck on the stale resolved promise', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    const fetcher = vi.fn().mockResolvedValue(bucketResponse(7));
+
+    // First call populates storage.
+    await cache.getBucketIdForProject('k8s', fetcher);
+    // Second call is a cache hit — this must not leave a stale resolved promise
+    // parked in the in-flight map once it returns.
+    const cacheHit = await cache.getBucketIdForProject('k8s', fetcher);
+    expect(cacheHit).toBe(7);
+
+    await cache.clearBucketCache('k8s');
+
+    const freshFetcher = vi.fn().mockResolvedValue(bucketResponse(21));
+    const afterClear = await cache.getBucketIdForProject('k8s', freshFetcher);
+
+    // If the cache-hit path had left its entry in inFlightRequests, this call would
+    // reuse that stale resolved promise (still 7) instead of checking storage again.
+    expect(afterClear).toBe(21);
+    expect(freshFetcher).toHaveBeenCalledTimes(1);
+  });
 });
 
 describe('createBucketCache — getBucketIdForCollection', () => {

--- a/libs/tinybird-client/tests/bucket-cache.test.ts
+++ b/libs/tinybird-client/tests/bucket-cache.test.ts
@@ -187,3 +187,102 @@ describe('createBucketCache — getBucketIdForProject', () => {
     expect(freshFetcher).toHaveBeenCalledTimes(1);
   });
 });
+
+describe('createBucketCache — getBucketIdForCollection', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('caches the bucketId in storage after a successful fetch', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    const fetcher = vi.fn().mockResolvedValue(bucketResponse(9));
+
+    await cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher);
+    const second = await cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher);
+
+    expect(second).toBe(9);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('coalesces concurrent in-flight requests for the same collection', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+    let resolveFetch: (value: TinybirdResponse<{ bucketId: number }[]>) => void = () => {};
+    const fetcher = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const p1 = cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher);
+    const p2 = cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher);
+    resolveFetch(bucketResponse(3));
+
+    expect(await p1).toBe(3);
+    expect(await p2).toBe(3);
+    expect(fetcher).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns null instead of throwing when no collection bucket is found', async () => {
+    const cache = createBucketCache(undefined, logger);
+    const fetcher = vi.fn().mockResolvedValue({
+      data: [],
+      meta: [],
+      rows: 0,
+      statistics: { elapsed: 0, rows_read: 0, bytes_read: 0 },
+    });
+
+    await expect(cache.getBucketIdForCollection('unknown', fetcher)).resolves.toBeNull();
+  });
+
+  it('returns null instead of throwing on an unclassified fetch error', async () => {
+    const cache = createBucketCache(undefined, logger);
+    const fetcher = vi.fn().mockRejectedValue(new Error('network blip'));
+
+    await expect(
+      cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher),
+    ).resolves.toBeNull();
+  });
+
+  it('propagates a 429 error instead of masking it as a missing collection', async () => {
+    const cache = createBucketCache(undefined, logger);
+    const fetcher = vi.fn().mockRejectedValue(new TinybirdClientError(429, 'Too Many Requests'));
+
+    await expect(cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher)).rejects.toThrow(
+      'Too Many Requests',
+    );
+  });
+
+  it('propagates a 5xx error instead of masking it as a missing collection', async () => {
+    const cache = createBucketCache(undefined, logger);
+    const fetcher = vi.fn().mockRejectedValue(new TinybirdClientError(503, 'Unavailable'));
+
+    await expect(cache.getBucketIdForCollection('kubernetes-ecosystem', fetcher)).rejects.toThrow(
+      'Unavailable',
+    );
+  });
+
+  it('does not repopulate the cache from a stale in-flight write after clearAllBucketCaches', async () => {
+    const storage = createMemoryStorage();
+    const cache = createBucketCache(storage, logger);
+
+    let resolveFetch: (value: TinybirdResponse<{ bucketId: number }[]>) => void = () => {};
+    const slowFetcher = vi.fn().mockReturnValue(
+      new Promise((resolve) => {
+        resolveFetch = resolve;
+      }),
+    );
+
+    const inFlight = cache.getBucketIdForCollection('kubernetes-ecosystem', slowFetcher);
+    await cache.clearAllBucketCaches();
+    resolveFetch(bucketResponse(5));
+    await inFlight;
+
+    const freshFetcher = vi.fn().mockResolvedValue(bucketResponse(13));
+    const afterClear = await cache.getBucketIdForCollection('kubernetes-ecosystem', freshFetcher);
+
+    expect(afterClear).toBe(13);
+    expect(freshFetcher).toHaveBeenCalledTimes(1);
+  });
+});

--- a/libs/tinybird-client/tests/bucket-cache.test.ts
+++ b/libs/tinybird-client/tests/bucket-cache.test.ts
@@ -164,6 +164,55 @@ describe('createBucketCache — getBucketIdForProject', () => {
     expect(freshFetcher).toHaveBeenCalledTimes(1);
   });
 
+  it('clearBucketCache waits for an already-started write so no stale value can be read once it resolves', async () => {
+    const storage = createMemoryStorage();
+    let setItemStarted!: () => void;
+    const setItemStartedPromise = new Promise<void>((resolve) => {
+      setItemStarted = resolve;
+    });
+    let resolveSetItem: () => void = () => {};
+    let firstSetItem = true;
+    const slowStorage: BucketCacheStorage = {
+      ...storage,
+      async setItem(key, value, options) {
+        if (firstSetItem) {
+          firstSetItem = false;
+          setItemStarted();
+          await new Promise<void>((resolve) => {
+            resolveSetItem = resolve;
+          });
+        }
+        await storage.setItem(key, value, options);
+      },
+    };
+    const cache = createBucketCache(slowStorage, logger);
+    const fetcher = vi.fn().mockResolvedValue(bucketResponse(7));
+
+    const lookup = cache.getBucketIdForProject('k8s', fetcher);
+    // Wait for the write to actually start (setItem is now blocked on resolveSetItem).
+    await setItemStartedPromise;
+
+    const clearPromise = cache.clearBucketCache('k8s');
+    let clearResolved = false;
+    void clearPromise.then(() => {
+      clearResolved = true;
+    });
+
+    // clearBucketCache must not resolve while the write it raced is still pending.
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    expect(clearResolved).toBe(false);
+
+    resolveSetItem();
+    await lookup;
+    await clearPromise;
+
+    expect(clearResolved).toBe(true);
+    // No stale value should be observable once the clear has resolved.
+    const freshFetcher = vi.fn().mockResolvedValue(bucketResponse(9));
+    const afterClear = await cache.getBucketIdForProject('k8s', freshFetcher);
+    expect(afterClear).toBe(9);
+  });
+
   it('does not repopulate any cache entry from a stale in-flight write after clearAllBucketCaches', async () => {
     const storage = createMemoryStorage();
     const cache = createBucketCache(storage, logger);

--- a/libs/tinybird-client/tests/client.test.ts
+++ b/libs/tinybird-client/tests/client.test.ts
@@ -1,0 +1,119 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { createTinybirdClient } from '../src/client.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const BASE_URL = 'https://tb.test';
+const TOKEN = 'test-token';
+
+const mockResult = {
+  data: [{ key: 'value' }],
+  meta: [{ name: 'key', type: 'String' }],
+  rows: 1,
+  statistics: { elapsed: 0.1, rows_read: 100, bytes_read: 1000 },
+};
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('createTinybirdClient — fetch()', () => {
+  beforeEach(() => {
+    mockFetch.mockReset();
+    mockFetch.mockResolvedValue(okResponse(mockResult));
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it('makes a GET request with correct URL and auth header', async () => {
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    const result = await client.fetch('/mock-path', { key: 'value' });
+
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe(`${BASE_URL}/mock-path?key=value`);
+    expect((init.headers as Record<string, string>)['Authorization']).toBe(`Bearer ${TOKEN}`);
+    expect(result).toEqual(mockResult);
+  });
+
+  it('strips trailing slashes from baseUrl to avoid double slashes in the request URL', async () => {
+    const client = createTinybirdClient({ baseUrl: `${BASE_URL}/`, token: TOKEN });
+
+    await client.fetch('/mock-path', { key: 'value' });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe(`${BASE_URL}/mock-path?key=value`);
+  });
+
+  it('omits undefined, null, and empty-string query values', async () => {
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await client.fetch('/mock-path', {
+      param1: 'value1',
+      param2: '',
+      param3: undefined,
+      param4: null,
+    });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe(`${BASE_URL}/mock-path?param1=value1`);
+  });
+
+  it('encodes array values with raw commas (required by Tinybird Array() params)', async () => {
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await client.fetch('/mock-path', { ids: ['a', 'b', 'c'] });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    // Tinybird expects raw commas between array elements, not %2C
+    expect(url).toContain('ids=a,b,c');
+  });
+
+  it('uses default base URL when none provided', async () => {
+    const client = createTinybirdClient({
+      token: TOKEN,
+    });
+
+    await client.fetch('/mock-path', { key: 'value' });
+
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toBe('https://api.us-west-2.aws.tinybird.co/mock-path?key=value');
+  });
+
+  it('does not perform a bucket lookup when bucketId is explicitly 0', async () => {
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await client.fetch('/mock-path', { project: 'k8s', bucketId: 0 });
+
+    // A falsy-but-valid bucketId of 0 must be treated as already resolved —
+    // only the real query should fire, never an extra project_buckets lookup.
+    expect(mockFetch).toHaveBeenCalledOnce();
+    const [url] = mockFetch.mock.calls[0] as [string];
+    expect(url).toContain('bucketId=0');
+  });
+
+  it('throws TinybirdClientError on non-2xx response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Internal Server Error',
+      text: () => Promise.resolve('Internal Server Error'),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await expect(client.fetch('/mock-path', {})).rejects.toMatchObject({ statusCode: 500 });
+  });
+});

--- a/libs/tinybird-client/tests/client.test.ts
+++ b/libs/tinybird-client/tests/client.test.ts
@@ -116,4 +116,81 @@ describe('createTinybirdClient — fetch()', () => {
 
     await expect(client.fetch('/mock-path', {})).rejects.toMatchObject({ statusCode: 500 });
   });
+
+  it('retries once on a transient 503 response, then succeeds', async () => {
+    mockFetch
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 503,
+        statusText: 'Service Unavailable',
+        text: () => Promise.resolve(''),
+        json: () => Promise.resolve({}),
+      } as unknown as Response)
+      .mockResolvedValueOnce(okResponse(mockResult));
+
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    const result = await client.fetch('/mock-path', {});
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(mockResult);
+  });
+
+  it('retries once on a network error, then succeeds', async () => {
+    mockFetch
+      .mockRejectedValueOnce(new Error('network error'))
+      .mockResolvedValueOnce(okResponse(mockResult));
+
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    const result = await client.fetch('/mock-path', {});
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(result).toEqual(mockResult);
+  });
+
+  it('gives up after exhausting the single retry on repeated 429s', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await expect(client.fetch('/mock-path', {})).rejects.toMatchObject({ statusCode: 429 });
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('does not retry a non-retryable 400 response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 400,
+      statusText: 'Bad Request',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await expect(client.fetch('/mock-path', {})).rejects.toMatchObject({ statusCode: 400 });
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
+
+  it('does not retry POST requests on a transient 503', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 503,
+      statusText: 'Service Unavailable',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const client = createTinybirdClient({ baseUrl: BASE_URL, token: TOKEN });
+
+    await expect(client.post('/mock-path', {})).rejects.toMatchObject({ statusCode: 503 });
+    expect(mockFetch).toHaveBeenCalledOnce();
+  });
 });

--- a/libs/tinybird-client/tests/throttle.test.ts
+++ b/libs/tinybird-client/tests/throttle.test.ts
@@ -1,0 +1,145 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { afterAll, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TinybirdQueueFullError } from '../src/errors.js';
+
+const mockFetch = vi.fn();
+vi.stubGlobal('fetch', mockFetch);
+
+const mockAcquire = vi.fn().mockResolvedValue(false);
+const mockRelease = vi.fn();
+const mockReportRateLimit = vi.fn();
+
+vi.mock('../src/adaptive-semaphore.js', () => ({
+  AdaptiveSemaphore: class {
+    acquire = mockAcquire;
+    release = mockRelease;
+    reportTinybirdRateLimit = mockReportRateLimit;
+    getActive = vi.fn().mockReturnValue(0);
+    getQueueLength = vi.fn().mockReturnValue(0);
+  },
+}));
+
+const mockResult = {
+  data: [{ key: 'value' }],
+  meta: [],
+  rows: 1,
+  statistics: { elapsed: 0.1, rows_read: 100, bytes_read: 1000 },
+};
+
+function okResponse(body: unknown) {
+  return {
+    ok: true,
+    status: 200,
+    statusText: 'OK',
+    json: () => Promise.resolve(body),
+  } as unknown as Response;
+}
+
+describe('fetchFromTinybird throttle behavior', () => {
+  beforeEach(async () => {
+    mockFetch.mockReset().mockResolvedValue(okResponse(mockResult));
+    mockAcquire.mockReset().mockResolvedValue(false);
+    mockRelease.mockReset();
+    mockReportRateLimit.mockReset();
+    vi.spyOn(console, 'warn').mockImplementation(() => {});
+    vi.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    vi.unstubAllGlobals();
+    vi.restoreAllMocks();
+  });
+
+  it('calls release() after a successful request', async () => {
+    const { createTinybirdClient } = await import('../src/client.js');
+    const client = createTinybirdClient({ baseUrl: 'https://tb.test', token: 'tok' });
+
+    await client.fetch('/v0/pipes/test.json', { key: 'value' });
+
+    expect(mockAcquire).toHaveBeenCalledOnce();
+    expect(mockRelease).toHaveBeenCalledOnce();
+  });
+
+  it('calls release() even when the request fails', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const { createTinybirdClient } = await import('../src/client.js');
+    const client = createTinybirdClient({ baseUrl: 'https://tb.test', token: 'tok' });
+
+    await expect(client.fetch('/v0/pipes/test.json', { key: 'value' })).rejects.toBeDefined();
+
+    expect(mockRelease).toHaveBeenCalledOnce();
+  });
+
+  it('calls reportTinybirdRateLimit() on 429 response', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 429,
+      statusText: 'Too Many Requests',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const { createTinybirdClient } = await import('../src/client.js');
+    const client = createTinybirdClient({ baseUrl: 'https://tb.test', token: 'tok' });
+
+    await expect(client.fetch('/v0/pipes/test.json', { key: 'value' })).rejects.toBeDefined();
+
+    expect(mockReportRateLimit).toHaveBeenCalledOnce();
+    expect(mockRelease).toHaveBeenCalledOnce();
+  });
+
+  it('does not call reportTinybirdRateLimit() on non-429 errors', async () => {
+    mockFetch.mockResolvedValue({
+      ok: false,
+      status: 500,
+      statusText: 'Server Error',
+      text: () => Promise.resolve(''),
+      json: () => Promise.resolve({}),
+    } as unknown as Response);
+
+    const { createTinybirdClient } = await import('../src/client.js');
+    const client = createTinybirdClient({ baseUrl: 'https://tb.test', token: 'tok' });
+
+    await expect(client.fetch('/v0/pipes/test.json', { key: 'value' })).rejects.toBeDefined();
+
+    expect(mockReportRateLimit).not.toHaveBeenCalled();
+  });
+
+  it('propagates 503 when acquire rejects (queue full)', async () => {
+    mockAcquire.mockRejectedValue(new TinybirdQueueFullError());
+
+    const { createTinybirdClient } = await import('../src/client.js');
+    const client = createTinybirdClient({ baseUrl: 'https://tb.test', token: 'tok' });
+
+    await expect(client.fetch('/v0/pipes/test.json', { key: 'value' })).rejects.toMatchObject({
+      statusCode: 503,
+    });
+
+    // release() must NOT be called — no slot was acquired
+    expect(mockRelease).not.toHaveBeenCalled();
+  });
+
+  it('skips semaphore for ping and bucket lookup paths', async () => {
+    const { createTinybirdClient } = await import('../src/client.js');
+    const client = createTinybirdClient({ baseUrl: 'https://tb.test', token: 'tok' });
+
+    await client.fetch('/v0/pipes/ping.json', {});
+    expect(mockAcquire).not.toHaveBeenCalled();
+    expect(mockRelease).not.toHaveBeenCalled();
+
+    mockAcquire.mockClear();
+    mockRelease.mockClear();
+
+    await client.fetch('/v0/pipes/project_buckets.json', {});
+    expect(mockAcquire).not.toHaveBeenCalled();
+    expect(mockRelease).not.toHaveBeenCalled();
+  });
+});

--- a/libs/tinybird-client/tsconfig.build.json
+++ b/libs/tinybird-client/tsconfig.build.json
@@ -1,0 +1,10 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "src",
+    "module": "ESNext",
+    "moduleResolution": "bundler"
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["tests/**/*"]
+}

--- a/libs/tinybird-client/tsconfig.json
+++ b/libs/tinybird-client/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "outDir": "dist",
+    "declaration": true
+  },
+  "include": ["src/**/*.ts", "tests/**/*.ts"]
+}

--- a/libs/tinybird-client/vitest.config.ts
+++ b/libs/tinybird-client/vitest.config.ts
@@ -1,0 +1,10 @@
+// Copyright (c) 2025 The Linux Foundation and each contributor.
+// SPDX-License-Identifier: MIT
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    include: ['tests/**/*.test.ts'],
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -356,6 +356,39 @@ importers:
         specifier: ^10.4.1
         version: 10.4.1(eslint@10.10.0(jiti@2.7.0))
 
+  libs/tinybird-client:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.0.0
+        version: 22.20.2
+      eslint:
+        specifier: ^9.0.0
+        version: 9.39.5(jiti@2.7.0)
+      eslint-config-prettier:
+        specifier: ^10.0.0
+        version: 10.1.8(eslint@9.39.5(jiti@2.7.0))
+      eslint-import-resolver-typescript:
+        specifier: ^4.0.0
+        version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import:
+        specifier: ^2.31.0
+        version: 2.32.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-prettier:
+        specifier: ^5.0.0
+        version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.6)
+      prettier:
+        specifier: ^3.0.0
+        version: 3.9.6
+      typescript:
+        specifier: ^5.0.0
+        version: 5.9.3
+      typescript-eslint:
+        specifier: ^8.0.0
+        version: 8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.7(@types/debug@4.1.12)(@types/node@22.20.2)(happy-dom@20.14.0)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+
   libs/types:
     devDependencies:
       eslint:
@@ -369,7 +402,7 @@ importers:
         version: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import:
         specifier: ^2.31.0
-        version: 2.32.0(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
+        version: 2.32.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-prettier:
         specifier: ^5.0.0
         version: 5.5.6(@types/eslint@9.6.1)(eslint-config-prettier@10.1.8(eslint@9.39.5(jiti@2.7.0)))(eslint@9.39.5(jiti@2.7.0))(prettier@3.9.6)
@@ -5532,6 +5565,9 @@ packages:
   '@types/node@20.17.57':
     resolution: {integrity: sha512-f3T4y6VU4fVQDKVqJV4Uppy8c1p/sVvS3peyqxyWnzkqXFJLRU7Y1Bl7rMS1Qe9z0v4M6McY0Fp9yBsgHJUsWQ==}
 
+  '@types/node@22.20.2':
+    resolution: {integrity: sha512-xlvWf4Vs9n1PEVYwP1n4vvG07M6y8WgvJ2t0vbrWTmijsIHp1cS+uJ2kMIRdY3nHZK0nCYKrPeD171+SzF4/zw==}
+
   '@types/node@24.13.3':
     resolution: {integrity: sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==}
 
@@ -5847,11 +5883,25 @@ packages:
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
 
+  '@vitest/expect@3.2.7':
+    resolution: {integrity: sha512-E8eBXaKibuvH2pSZErOjdVb5vF4PbKYcrnluBTYxEk1l/VhhwZg1kZQsdtjq+CsF5CFydf2Rdkz7jDHKSisi3w==}
+
   '@vitest/expect@4.1.11':
     resolution: {integrity: sha512-VX2x5vNJXET47KAFzwERI+KRMtTTCSWTfSMKsW7JsUsXV4psq++e3DvZpuTDOpHcxytiDs6p2nhVb2tVDiiUYw==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/mocker@3.2.7':
+    resolution: {integrity: sha512-Trr0hYO9CM3Wj6ksWHRhK9IZpIY6wTMO5u/MqXurMxT57sWBaOPEtP3Oq60ihZuh5JsiagKfz95OcxdEP6dBrA==}
     peerDependencies:
       msw: ^2.4.9
       vite: ^5.0.0 || ^6.0.0 || ^7.0.0-0
@@ -5875,11 +5925,20 @@ packages:
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
+  '@vitest/pretty-format@3.2.7':
+    resolution: {integrity: sha512-KUHlwqVu0sRlhCdyPdQ/wBoTfRahjUky1MubOmYw9fWfIZy1gNoHpuaaQBPAaMaVYdQYHJLurzj8ECCj5OwTqA==}
+
   '@vitest/pretty-format@4.1.11':
     resolution: {integrity: sha512-yiZzPbGTS9Sr/JpFl8zHrcIkAofNbFV6k21vIgQN/cY/oxZeXhJv5sc/MBJ5jFKWmWs+oJHw0UXLZjmf931+Vw==}
 
+  '@vitest/runner@3.2.7':
+    resolution: {integrity: sha512-sB9y4ovltoQP+WaUPwmSxO9WIg9Ig694Di5PalVPsYHklAdE027mehpWF2SQSVq+k6sFgaivbTjTJwZLSHbedA==}
+
   '@vitest/runner@4.1.11':
     resolution: {integrity: sha512-LztvUgdwMNJMIkj3hQnnxiC2Xy1zNxq928W/xhjCLaNCzqTZOudjwbQf6v9IntZGPw132i2Lq2rgTRZHD3JHNw==}
+
+  '@vitest/snapshot@3.2.7':
+    resolution: {integrity: sha512-7C+MwShwtBSI5Buwoyg3s/iY1eHL9PKAf+O1wVh/TdnjXUtkoL/9YQtre90i4MtNXM6edP1wJ2zOBpfCyhIS7g==}
 
   '@vitest/snapshot@4.1.11':
     resolution: {integrity: sha512-pN7ikn1ON7h8ee4gIAp4AzyK+zBtJPzVbqOgu5LCEh4VaJVbPQcgYQYJIMGQPXVeJJq1fnfazis7a5pFNPahog==}
@@ -5887,11 +5946,17 @@ packages:
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
+  '@vitest/spy@3.2.7':
+    resolution: {integrity: sha512-Q2eQGI6d2L/hBtZ0qNuKcAGid68XK6cv1xsoaIma6PaJhHPoqcEJhYpXZ/5myCMqkNgtP6UKuBhbc0nHKnrkuQ==}
+
   '@vitest/spy@4.1.11':
     resolution: {integrity: sha512-apNa/prQy2qCeywhnixOHPRCgGNhvg7T4Dapfl1GahLp/R+uhBm5cPyFoNVyqsNd2h1nJxL6BqqdIjiABL60YA==}
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@3.2.7':
+    resolution: {integrity: sha512-x6BDOd7dyo3PFLY3I9/HJ25X/6OurhGXk2/B9gOZNPF7XDVjeBK4k01lQE5uvDpbuheErh91qYuE1E2OEjK3Rw==}
 
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
@@ -7460,6 +7525,9 @@ packages:
     resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
     engines: {node: '>= 0.4'}
 
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
   es-module-lexer@2.3.2:
     resolution: {integrity: sha512-poHGpORABojJJucnV9KbOavETW8lBVnphkW77ER5/BQ5Fz7oXSoCNek7IH3vR5nRjdsEz926ibFYX8KtLQmdyw==}
 
@@ -8819,6 +8887,9 @@ packages:
 
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  js-tokens@9.0.1:
+    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.3.2:
     resolution: {integrity: sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==}
@@ -11444,6 +11515,9 @@ packages:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
 
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
   std-env@4.2.0:
     resolution: {integrity: sha512-oCUKSupKTHX53EyjDtuZQ64pjLJ6yYCtpmEw0goYxtjG9KpbRe8KAsl2tBUGU9DyMcJ0RwJ8GqJAFzMXcXW1Rw==}
 
@@ -11540,6 +11614,9 @@ packages:
   strip-json-comments@3.1.1:
     resolution: {integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==}
     engines: {node: '>=8'}
+
+  strip-literal@3.1.0:
+    resolution: {integrity: sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==}
 
   strip-literal@4.0.0:
     resolution: {integrity: sha512-PaqAvfUZKBwc/SLmNZtHmzK+v19Z4O4eS3cKPeGvbIv/U3pnyEq4Tuw3/4v/FwfM8VQaEawsyCcOQ0P+kpwWWw==}
@@ -11716,6 +11793,9 @@ packages:
     resolution: {integrity: sha512-uo33abH+Ays0xYaDysoBt494Hb3hsEczMpcC0MwFl773pazORx4fmvKhclhR1wonUbB6vvpRsvVMwnhfqeMc+A==}
     engines: {node: ^16.14.0 || >= 17.3.0}
 
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
   tinyexec@1.3.1:
     resolution: {integrity: sha512-GCvB3aoys96IuDFBMcTB46JOR6mdMtAToqwiW8JlWhsoh1mhHi/xn9ss/Dg7N555GiJyEt2qzoG/NHCwM6h1EA==}
     engines: {node: '>=18'}
@@ -11723,6 +11803,10 @@ packages:
   tinyglobby@0.2.17:
     resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
     engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
 
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
@@ -11955,6 +12039,9 @@ packages:
 
   undici-types@6.19.8:
     resolution: {integrity: sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==}
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
   undici-types@7.18.2:
     resolution: {integrity: sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==}
@@ -12249,6 +12336,11 @@ packages:
     peerDependencies:
       vite: ^2.6.0 || ^3.0.0 || ^4.0.0 || ^5.0.0-0 || ^6.0.0-0 || ^7.0.0-0 || ^8.0.0
 
+  vite-node@3.2.4:
+    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+
   vite-node@5.3.0:
     resolution: {integrity: sha512-8f20COPYJujc3OKPX6OuyBy3ZIv2det4eRRU4GY1y2MjbeGSUmPjedxg1b72KnTagCofwvZ65ThzjxDW2AtQFQ==}
     engines: {node: ^20.19.0 || >=22.12.0}
@@ -12441,6 +12533,34 @@ packages:
 
   vitest-environment-nuxt@2.0.0:
     resolution: {integrity: sha512-zEGFRiCAaRR3fHnqISHKMNTRvCzkQEI1XyFeqNgR2IBD0oYkfZ1rUHwi7C+h3Cns3KPykfB0av1B3MtLEbChDw==}
+
+  vitest@3.2.7:
+    resolution: {integrity: sha512-KrxIJ62Fd89gfysR4WotlgZABiz2dqFPgqGzX7s+CwsqLFomRH7777ZcrOD6+WVAh7khPQP41A+BKbpcJFrdEg==}
+    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/debug': ^4.1.12
+      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
+      '@vitest/browser': 3.2.7
+      '@vitest/ui': 3.2.7
+      happy-dom: '>=20.8.9 <21'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/debug':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
 
   vitest@4.1.11:
     resolution: {integrity: sha512-fhACrNXUidIbGSBr5FlbuBkO7VWC1ZyLl0DO4CU2DrQoAPxX84Ysxs+HeGQpii5lZWV1Q4gBZTTu49mF+A6Edw==}
@@ -17591,7 +17711,7 @@ snapshots:
   '@slack/webhook@6.1.0':
     dependencies:
       '@slack/types': 1.10.0
-      '@types/node': 20.17.57
+      '@types/node': 24.13.3
       axios: 0.21.4
     transitivePeerDependencies:
       - debug
@@ -18586,11 +18706,11 @@ snapshots:
 
   '@types/bunyan-format@0.2.9':
     dependencies:
-      '@types/node': 20.17.57
+      '@types/node': 24.13.3
 
   '@types/bunyan@1.8.11':
     dependencies:
-      '@types/node': 20.17.57
+      '@types/node': 24.13.3
 
   '@types/caseless@0.12.5': {}
 
@@ -18653,7 +18773,7 @@ snapshots:
   '@types/jsonwebtoken@9.0.10':
     dependencies:
       '@types/ms': 2.1.0
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
 
   '@types/linkify-it@5.0.0': {}
 
@@ -18688,6 +18808,10 @@ snapshots:
     dependencies:
       undici-types: 6.19.8
 
+  '@types/node@22.20.2':
+    dependencies:
+      undici-types: 6.21.0
+
   '@types/node@24.13.3':
     dependencies:
       undici-types: 7.18.2
@@ -18698,7 +18822,7 @@ snapshots:
 
   '@types/pg@8.23.1':
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       pg-protocol: 1.16.0
       pg-types: 2.2.0
 
@@ -18743,7 +18867,7 @@ snapshots:
 
   '@types/ws@8.18.1':
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
 
   '@types/yargs-parser@21.0.3':
     optional: true
@@ -19126,6 +19250,14 @@ snapshots:
       chai: 5.3.3
       tinyrainbow: 2.0.0
 
+  '@vitest/expect@3.2.7':
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      tinyrainbow: 2.0.0
+
   '@vitest/expect@4.1.11':
     dependencies:
       '@standard-schema/spec': 1.1.0
@@ -19143,6 +19275,14 @@ snapshots:
     optionalDependencies:
       vite: 8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
 
+  '@vitest/mocker@3.2.7(vite@7.3.6(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
+    dependencies:
+      '@vitest/spy': 3.2.7
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 7.3.6(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+
   '@vitest/mocker@4.1.11(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))':
     dependencies:
       '@vitest/spy': 4.1.11
@@ -19155,13 +19295,29 @@ snapshots:
     dependencies:
       tinyrainbow: 2.0.0
 
+  '@vitest/pretty-format@3.2.7':
+    dependencies:
+      tinyrainbow: 2.0.0
+
   '@vitest/pretty-format@4.1.11':
     dependencies:
       tinyrainbow: 3.1.1
 
+  '@vitest/runner@3.2.7':
+    dependencies:
+      '@vitest/utils': 3.2.7
+      pathe: 2.0.3
+      strip-literal: 3.1.0
+
   '@vitest/runner@4.1.11':
     dependencies:
       '@vitest/utils': 4.1.11
+      pathe: 2.0.3
+
+  '@vitest/snapshot@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/snapshot@4.1.11':
@@ -19175,11 +19331,21 @@ snapshots:
     dependencies:
       tinyspy: 4.0.6
 
+  '@vitest/spy@3.2.7':
+    dependencies:
+      tinyspy: 4.0.6
+
   '@vitest/spy@4.1.11': {}
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
+      loupe: 3.2.1
+      tinyrainbow: 2.0.0
+
+  '@vitest/utils@3.2.7':
+    dependencies:
+      '@vitest/pretty-format': 3.2.7
       loupe: 3.2.1
       tinyrainbow: 2.0.0
 
@@ -19956,7 +20122,7 @@ snapshots:
 
   buffer-image-size@0.6.4:
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
 
   buffer@6.0.3:
     dependencies:
@@ -20110,7 +20276,7 @@ snapshots:
 
   chrome-launcher@1.2.1:
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       escape-string-regexp: 4.0.0
       is-wsl: 2.2.0
       lighthouse-logger: 2.0.2
@@ -20859,6 +21025,8 @@ snapshots:
 
   es-errors@1.3.0: {}
 
+  es-module-lexer@1.7.0: {}
+
   es-module-lexer@2.3.2: {}
 
   es-object-atoms@1.1.2:
@@ -21108,7 +21276,7 @@ snapshots:
       tinyglobby: 0.2.17
       unrs-resolver: 1.12.2
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
       eslint-plugin-import-x: 4.17.1(@typescript-eslint/utils@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
@@ -21128,10 +21296,11 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-module-utils@2.14.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
+      '@typescript-eslint/parser': 8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
       eslint-import-resolver-typescript: 4.4.5(eslint-plugin-import-x@4.17.1(@typescript-eslint/utils@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint@9.39.5(jiti@2.7.0)))(eslint-plugin-import@2.32.0)(eslint@9.39.5(jiti@2.7.0))
@@ -21208,7 +21377,7 @@ snapshots:
       - eslint-import-resolver-webpack
       - supports-color
 
-  eslint-plugin-import@2.32.0(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -21219,7 +21388,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.5(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.10
-      eslint-module-utils: 2.14.0(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
+      eslint-module-utils: 2.14.0(@typescript-eslint/parser@8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3))(eslint-import-resolver-node@0.3.10)(eslint-import-resolver-typescript@4.4.5)(eslint@9.39.5(jiti@2.7.0))
       hasown: 2.0.4
       is-core-module: 2.16.2
       is-glob: 4.0.3
@@ -21230,6 +21399,8 @@ snapshots:
       semver: 6.3.1
       string.prototype.trimend: 1.0.10
       tsconfig-paths: 3.15.0
+    optionalDependencies:
+      '@typescript-eslint/parser': 8.69.0(eslint@9.39.5(jiti@2.7.0))(typescript@5.9.3)
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
@@ -22103,7 +22274,7 @@ snapshots:
 
   happy-dom@20.14.0:
     dependencies:
-      '@types/node': 26.4.1
+      '@types/node': 24.13.3
       '@types/whatwg-mimetype': 3.0.2
       '@types/ws': 8.18.1
       buffer-image-size: 0.6.4
@@ -22668,6 +22839,8 @@ snapshots:
   js-tokens@10.0.0: {}
 
   js-tokens@4.0.0: {}
+
+  js-tokens@9.0.1: {}
 
   js-yaml@4.3.2:
     dependencies:
@@ -24827,7 +25000,7 @@ snapshots:
       '@protobufjs/path': 1.1.2
       '@protobufjs/pool': 1.1.0
       '@protobufjs/utf8': 1.1.2
-      '@types/node': 18.19.110
+      '@types/node': 24.13.3
       long: 5.3.2
 
   protobufjs@7.6.6:
@@ -25783,6 +25956,8 @@ snapshots:
 
   statuses@2.0.2: {}
 
+  std-env@3.10.0: {}
+
   std-env@4.2.0: {}
 
   stop-iteration-iterator@1.1.0:
@@ -25912,6 +26087,10 @@ snapshots:
   strip-indent@4.1.1: {}
 
   strip-json-comments@3.1.1: {}
+
+  strip-literal@3.1.0:
+    dependencies:
+      js-tokens: 9.0.1
 
   strip-literal@4.0.0:
     dependencies:
@@ -26139,12 +26318,16 @@ snapshots:
 
   tinyclip@0.1.15: {}
 
+  tinyexec@0.3.2: {}
+
   tinyexec@1.3.1: {}
 
   tinyglobby@0.2.17:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.7)
       picomatch: 4.0.7
+
+  tinypool@1.1.1: {}
 
   tinyrainbow@2.0.0: {}
 
@@ -26369,6 +26552,8 @@ snapshots:
   undici-types@5.26.5: {}
 
   undici-types@6.19.8: {}
+
+  undici-types@6.21.0: {}
 
   undici-types@7.18.2: {}
 
@@ -26697,6 +26882,27 @@ snapshots:
     dependencies:
       vite: 8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
 
+  vite-node@3.2.4(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3(supports-color@5.5.0)
+      es-module-lexer: 1.7.0
+      pathe: 2.0.3
+      vite: 7.3.6(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+    transitivePeerDependencies:
+      - '@types/node'
+      - jiti
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
+
   vite-node@5.3.0(@types/node@26.4.1)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
     dependencies:
       cac: 6.7.14
@@ -26805,6 +27011,25 @@ snapshots:
       sass: 1.104.0
       sass-embedded: 1.104.0
       terser: 5.51.2
+
+  vite@7.3.6(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
+    dependencies:
+      esbuild: 0.28.2
+      fdir: 6.5.0(picomatch@4.0.7)
+      picomatch: 4.0.7
+      postcss: 8.5.28
+      rollup: 4.63.1
+      tinyglobby: 0.2.17
+    optionalDependencies:
+      '@types/node': 22.20.2
+      fsevents: 2.3.3
+      jiti: 2.7.0
+      lightningcss: 1.33.0
+      sass: 1.104.0
+      sass-embedded: 1.104.0
+      terser: 5.51.2
+      tsx: 4.23.13
+      yaml: 2.9.0
 
   vite@7.3.6(@types/node@26.4.1)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
     dependencies:
@@ -26932,6 +27157,50 @@ snapshots:
       - vite
       - vitest
       - webpack
+
+  vitest@3.2.7(@types/debug@4.1.12)(@types/node@22.20.2)(happy-dom@20.14.0)(jiti@2.7.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0):
+    dependencies:
+      '@types/chai': 5.2.3
+      '@vitest/expect': 3.2.7
+      '@vitest/mocker': 3.2.7(vite@7.3.6(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0))
+      '@vitest/pretty-format': 3.2.7
+      '@vitest/runner': 3.2.7
+      '@vitest/snapshot': 3.2.7
+      '@vitest/spy': 3.2.7
+      '@vitest/utils': 3.2.7
+      chai: 5.3.3
+      debug: 4.4.3(supports-color@5.5.0)
+      expect-type: 1.4.0
+      magic-string: 0.30.21
+      pathe: 2.0.3
+      picomatch: 4.0.7
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinyglobby: 0.2.17
+      tinypool: 1.1.1
+      tinyrainbow: 2.0.0
+      vite: 7.3.6(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      vite-node: 3.2.4(@types/node@22.20.2)(jiti@2.7.0)(lightningcss@1.33.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/debug': 4.1.12
+      '@types/node': 22.20.2
+      happy-dom: 20.14.0
+      jsdom: 30.0.1(@noble/hashes@2.4.0)
+    transitivePeerDependencies:
+      - jiti
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+      - tsx
+      - yaml
 
   vitest@4.1.11(@opentelemetry/api@1.9.0)(@types/node@26.4.1)(happy-dom@20.14.0)(jsdom@30.0.1(@noble/hashes@2.4.0))(vite@8.2.2(@types/node@26.4.1)(esbuild@0.25.12)(jiti@2.7.0)(sass-embedded@1.104.0)(sass@1.104.0)(terser@5.51.2)(tsx@4.23.13)(yaml@2.9.0)):
     dependencies:
@@ -27290,7 +27559,7 @@ snapshots:
 
   wkx@0.5.0:
     dependencies:
-      '@types/node': 18.19.110
+      '@types/node': 24.13.3
 
   word-wrap@1.2.5: {}
 


### PR DESCRIPTION
## Summary

Adds a new workspace package, `@lfx-insights/tinybird-client`, providing a fetch-based Tinybird API client with:

- Adaptive concurrency limiting (semaphore-based throttling)
- Per-bucket response caching
- Typed request/response errors

Ported verbatim from the public API preliminary work branch as a standalone unit. The `libs/*` workspace glob already exists in `pnpm-workspace.yaml` (added in #2176), so no workspace config changes are needed here.

This package isn't consumed anywhere yet — a follow-up PR will migrate the frontend's Tinybird integration to use it, and another will introduce the new `api/` package which depends on it too.

## Test plan

- [x] `pnpm build` — builds cleanly
- [x] `pnpm lint` — no errors
- [x] `pnpm test` — 33/33 tests pass

Signed-off-by: Anil Bostanci <abostanci@contractor.linuxfoundation.org>

- `main` <!-- branch-stack -->
  - **feat: add @lfx-insights/tinybird-client shared client package** :point\_left:
    - \#2185
    - \#2186
