### PR TITLE
ci: lint, build, and test api and libs packages

### DIFF
--- a/.github/workflows/lint-test-api-libs.yml
+++ b/.github/workflows/lint-test-api-libs.yml
@@ -1,0 +1,43 @@
+name: Lint & Test API and Libs
+
+on:
+  pull_request:
+    paths:
+      - 'api/**'
+      - 'libs/**'
+
+permissions:
+  contents: read
+
+jobs:
+  lint-test-api-libs:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.18.2
+
+      - name: Install dependencies
+        run: pnpm install --filter @lfx-insights/api... --filter @lfx-insights/tinybird-client --filter @lfx-insights/types
+
+      - name: Build workspace libs
+        run: pnpm --filter @lfx-insights/types --filter @lfx-insights/tinybird-client build
+
+      - name: Format check
+        run: pnpm --filter @lfx-insights/api --filter @lfx-insights/types --filter @lfx-insights/tinybird-client format:check
+
+      - name: Lint
+        run: pnpm --filter @lfx-insights/api --filter @lfx-insights/types --filter @lfx-insights/tinybird-client lint
+
+      - name: Type check
+        run: pnpm --filter @lfx-insights/api --filter @lfx-insights/types --filter @lfx-insights/tinybird-client tsc-check
+
+      - name: Build API
+        run: pnpm --filter @lfx-insights/api build
+
+      - name: Test
+        run: pnpm --filter @lfx-insights/api --filter @lfx-insights/tinybird-client test


### PR DESCRIPTION
## Summary

`@lfx-insights/api`, `@lfx-insights/tinybird-client`, and `@lfx-insights/types` had no CI coverage of their own — `lint-frontend.yml` and `tests.yml` only run for `frontend/` changes, so a PR touching only `api/` or `libs/*` currently gets no automated format/lint/type-check/build/test feedback.

Adds `.github/workflows/lint-test-api-libs.yml`, triggered on `api/**` or `libs/**` changes, running:

- `pnpm install` (scoped to these three packages)
- build workspace libs (`types`, `tinybird-client`)
- `format:check`, `lint`, `tsc-check` across `api`, `types`, `tinybird-client`
- `build` for `api`
- `test` for `api` and `tinybird-client` (`types` has no test script)

## Test plan

- [x] Ran every step of the workflow locally (`pnpm install --filter ...`, `format:check`, `lint`, `tsc-check`, `build`, `test`) — all pass