### PR TITLE
fix: correct pre-commit hook path matching and add api checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ scripts/services
 scripts/scaffold.yaml
 
 node_modules
+libs/*/dist
 .prettierrc
 **/.env*
 !.env.dist

--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,5 +1,9 @@
+set -e
+
+ROOT="$(git rev-parse --show-toplevel)"
+
 #run husky pre-commit hook only if frontend changed
-if git diff --name-only --cached | grep 'frontend/';
+if git diff --name-only --cached | grep '^frontend/';
   then
     echo "FRONTEND FOLDER CHANGED --> starting husky..."
     cd frontend && \
@@ -7,6 +11,16 @@ if git diff --name-only --cached | grep 'frontend/';
     ([ -z "$ESLINT_FILES" ] || (pnpm exec eslint --fix $ESLINT_FILES && git add -u $(git diff --name-only --diff-filter=d --cached --relative | grep -E '\.(js|cjs|mjs|ts|cts|mts|tsx|jsx|vue)$'))) && \
     pnpm tsc-check
 fi
+
+if git diff --diff-filter=d --name-only --cached | grep '^api/';
+  then
+    echo "API FOLDER CHANGED --> running api checks..."
+    cd "$ROOT/api" && \
+    pnpm lint && \
+    pnpm tsc-check
+fi
+
+cd "$ROOT"
 
 #run lint-staged to add copyright license on top of all new files
 #


### PR DESCRIPTION
## Summary

Two issues in `frontend/.husky/pre-commit`:

- The frontend-changed check (`grep 'frontend/'`) matched that substring anywhere in a staged path instead of anchoring it to the start. No false positive exists in the repo today, but it's fragile as soon as any other package gets a nested `frontend/`-named path.
- The hook had no `set -e`. Since the guarded blocks chain their commands with `&&`, a failing `pnpm tsc-check` (or lint) inside a block returns non-zero for that block, but without `set -e` the script keeps running past it — the final `lint-staged` conditional at the end then determines the script's overall exit status, so the failure never actually blocked the commit.

Fixes both, and adds the same lint + tsc-check guard for `api/` (mirroring the existing frontend one) now that `api/` is a real package with its own lint/tsc-check scripts. Also ignores `libs/*/dist`, the build output `pnpm build` leaves behind for `@lfx-insights/tinybird-client` and `@lfx-insights/types` (previously showing up as untracked noise in `git status`; `api/dist` already had its own `.gitignore`).

## Test plan

- [x] Committing this change itself exercised the frontend-changed path (`FRONTEND FOLDER CHANGED --> starting husky...`, `tsc-check` ran)
- [x] Manually staged an `api/` file and ran the hook directly — `API FOLDER CHANGED --> running api checks...`, `lint` and `tsc-check` both ran and passed
- [x] Confirmed `libs/tinybird-client/dist` and `libs/types/dist` are now ignored via `git check-ignore`